### PR TITLE
move unit specs

### DIFF
--- a/spec/shared/message_compiler.rb
+++ b/spec/shared/message_compiler.rb
@@ -1,0 +1,11 @@
+RSpec.shared_context :message_compiler do
+  subject(:compiler) { Dry::Schema::MessageCompiler.new(messages) }
+
+  let(:messages) do
+    Dry::Schema::Messages.default
+  end
+
+  let(:result) do
+    compiler.public_send(visitor, node)
+  end
+end

--- a/spec/unit/dry/schema/message_compiler/visit_failure_spec.rb
+++ b/spec/unit/dry/schema/message_compiler/visit_failure_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Dry::Schema::MessageCompiler, '#visit_failure' do
+  include_context :message_compiler
+
+  let(:visitor) { :visit_failure }
+
+  context 'with :int? predicate' do
+    let(:node) do
+      [:age, [:key, [:age, [:predicate, [:int?, [[:input, '17']]]]]]]
+    end
+
+    it 'returns a message for :int? failure with :rule name inferred from key-rule' do
+      expect(result.rule).to be(:age)
+      expect(result.path).to eql([:age])
+      expect(result).to eql('must be an integer')
+    end
+  end
+
+  context 'with set failure and :int? predicate' do
+    let(:node) do
+      [:items, [:key, [:items, [:set, [
+        [:key, [0, [:predicate, [:int?, [[:input, 'foo']]]]]],
+        [:key, [2, [:predicate, [:int?, [[:input, 'bar']]]]]]
+      ]]]]]
+    end
+
+    it 'returns a message for the first element that failed' do
+      expect(result[0].rule).to be(:items)
+      expect(result[0].path).to eql([:items, 0])
+      expect(result[0]).to eql('must be an integer')
+    end
+
+    it 'returns a message for the third element that failed' do
+      expect(result[1].rule).to be(:items)
+      expect(result[1].path).to eql([:items, 2])
+      expect(result[1]).to eql('must be an integer')
+    end
+  end
+end

--- a/spec/unit/dry/schema/message_compiler/visit_spec.rb
+++ b/spec/unit/dry/schema/message_compiler/visit_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Dry::Schema::MessageCompiler, '#visit' do
+  include_context :message_compiler
+
+  let(:visitor) { :visit }
+
+  context 'with an anonymous :failure' do
+    let(:node) do
+      [:failure, [:age, [:key, [:age, [:predicate, [:int?, [[:input, '17']]]]]]]]
+    end
+
+    it 'returns a message for :int? failure with :rule name inferred from key-rule' do
+      expect(result.rule).to be(:age)
+      expect(result).to eql('must be an integer')
+    end
+  end
+end

--- a/spec/unit/dry/schema/message_compiler_spec.rb
+++ b/spec/unit/dry/schema/message_compiler_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Dry::Schema::MessageCompiler, '#call' do
+  subject(:message_compiler) { Dry::Schema::MessageCompiler.new( Dry::Schema::Messages.default ) }
+
+  it 'returns an empty hash when there are no errors' do
+    expect(message_compiler.([])).to be_empty
+  end
+end


### PR DESCRIPTION
I started working on restoring the `unit` folder.

@solnic @flash-gordon is this what we want? Just moving specs? I did not have to modify any code to make them pass. If this looks good to you I will continue moving specs.