### PR TITLE
Fixed I18n fallback issue

### DIFF
--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -76,12 +76,14 @@ RSpec.describe Dry::Schema::Messages::I18n do
     context 'fallbacking to I18n.default_locale with fallback backend config' do
       before do
         require "i18n/backend/fallbacks"
+
+        # https://github.com/svenfuchs/i18n/pull/415
+        # Since I18n does not provide default fallbacks anymore, we have to do this explicitly
         I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+        I18n.fallbacks = I18n::Locale::Fallbacks.new(:en)
       end
 
       it 'returns a message for a predicate in the default_locale' do
-        pending "i18n fallback API changed, so this spec started failing"
-
         message = messages[:even?, path: :some_number]
 
         expect(I18n.locale).to eql(:pl)


### PR DESCRIPTION
Fixed I18n issue with fallbacks.

https://github.com/svenfuchs/i18n/pull/415
I18n does not provide default fallbacks anymore, we have to do this explicitly.