### PR TITLE
Update type spec API

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -131,8 +131,8 @@ module Dry
       # @return [Macros::Required]
       #
       # @api public
-      def required(name, type = Types::Any, &block)
-        key(name, type: type, macro: Macros::Required, &block)
+      def required(name, &block)
+        key(name, macro: Macros::Required, &block)
       end
 
       # Define an optional key
@@ -147,8 +147,8 @@ module Dry
       # @return [Macros::Optional]
       #
       # @api public
-      def optional(name, type = Types::Any, &block)
-        key(name, type: type, macro: Macros::Optional, &block)
+      def optional(name, &block)
+        key(name, macro: Macros::Optional, &block)
       end
 
       # A generic method for defining keys
@@ -159,8 +159,8 @@ module Dry
       # @return [Macros::Key]
       #
       # @api public
-      def key(name, type:, macro:, &block)
-        set_type(name, type)
+      def key(name, macro:, &block)
+        set_type(name, Types::Any)
 
         macro = macro.new(
           name: name,

--- a/spec/integration/params/predicates/array_spec.rb
+++ b/spec/integration/params/predicates/array_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Array' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?)
+        required(:foo).value(array[:integer]).each(:int?)
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe 'Predicates: Array' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?)
+        optional(:foo).value(array[:integer]).each(:int?)
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe 'Predicates: Array' do
     context 'with required' do
       subject(:schema) do
         Dry::Schema.Params do
-          required(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?)
+          required(:foo).value(array[:integer]).each(:int?)
         end
       end
 
@@ -203,7 +203,7 @@ RSpec.describe 'Predicates: Array' do
     context 'with optional' do
       subject(:schema) do
         Dry::Schema.Params do
-          optional(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?)
+          optional(:foo).value(array[:integer]).each(:int?)
         end
       end
 
@@ -252,7 +252,7 @@ RSpec.describe 'Predicates: Array' do
   context 'with maybe macro' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, [:nil, Types::Params::Array.of(Types::Params::Integer)]).maybe(:array?)
+        required(:foo).maybe(array[:integer])
       end
     end
 

--- a/spec/integration/params/predicates/eql_spec.rb
+++ b/spec/integration/params/predicates/eql_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Eql' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :string) { eql?('23') }
+        required(:foo).value(:string) { eql?('23') }
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe 'Predicates: Eql' do
       let(:input) { { 'foo' => nil } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be equal to 23']
+        expect(result).to be_failing ['must be a string', 'must be equal to 23']
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'Predicates: Eql' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :string) { eql?('23') }
+        optional(:foo).value(:string) { eql?('23') }
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'Predicates: Eql' do
       let(:input) { { 'foo' => nil } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be equal to 23']
+        expect(result).to be_failing ['must be a string', 'must be equal to 23']
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe 'Predicates: Eql' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :string).value(eql?: '23')
+            required(:foo).value(:string, eql?: '23')
           end
         end
 
@@ -108,7 +108,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be equal to 23']
+            expect(result).to be_failing ['must be a string', 'must be equal to 23']
           end
         end
 
@@ -124,7 +124,7 @@ RSpec.describe 'Predicates: Eql' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :string).filled(eql?: '23')
+            required(:foo).filled(:string, eql?: '23')
           end
         end
 
@@ -164,7 +164,7 @@ RSpec.describe 'Predicates: Eql' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :string]).maybe(eql?: '23')
+            required(:foo).maybe(:string, eql?: '23')
           end
         end
 
@@ -206,7 +206,7 @@ RSpec.describe 'Predicates: Eql' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :string).value(eql?: '23')
+            optional(:foo).value(:string, eql?: '23')
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be equal to 23']
+            expect(result).to be_failing ['must be a string', 'must be equal to 23']
           end
         end
 
@@ -246,7 +246,7 @@ RSpec.describe 'Predicates: Eql' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :string).filled(eql?: '23')
+            optional(:foo).filled(:string, eql?: '23')
           end
         end
 
@@ -286,7 +286,7 @@ RSpec.describe 'Predicates: Eql' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :string]).maybe(eql?: '23')
+            optional(:foo).maybe(:string, eql?: '23')
           end
         end
 

--- a/spec/integration/params/predicates/even_spec.rb
+++ b/spec/integration/params/predicates/even_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Even' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :integer) { int? & even? }
+        required(:foo).value(:integer) { even? }
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe 'Predicates: Even' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :integer) { int? & even? }
+        optional(:foo).value(:integer) { even? }
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: Even' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).value(:int?, :even?)
+            required(:foo).value(:integer, :even?)
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: Even' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).filled(:int?, :even?)
+            required(:foo).filled(:integer, :even?)
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Even' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(:int?, :even?)
+            required(:foo).maybe(:integer, :even?)
           end
         end
 
@@ -286,7 +286,7 @@ RSpec.describe 'Predicates: Even' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).value(:int?, :even?)
+            optional(:foo).value(:integer, :even?)
           end
         end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: Even' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).filled(:int?, :even?)
+            optional(:foo).filled(:integer, :even?)
           end
         end
 
@@ -398,7 +398,7 @@ RSpec.describe 'Predicates: Even' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(:int?, :even?)
+            optional(:foo).maybe(:integer, :even?)
           end
         end
 

--- a/spec/integration/params/predicates/excluded_from_spec.rb
+++ b/spec/integration/params/predicates/excluded_from_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Excluded From' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :string) { excluded_from?(%w(1 3 5)) }
+        required(:foo).value(:string) { excluded_from?(%w(1 3 5)) }
       end
     end
 
@@ -25,8 +25,8 @@ RSpec.describe 'Predicates: Excluded From' do
     context 'with nil input' do
       let(:input) { { 'foo' => nil } }
 
-      it 'is successful' do
-        expect(result).to be_successful
+      it 'is failing' do
+        expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
       end
     end
 
@@ -41,8 +41,8 @@ RSpec.describe 'Predicates: Excluded From' do
     context 'with invalid type' do
       let(:input) { { 'foo' => { 'a' => '1' } } }
 
-      it 'is successful' do
-        expect(result).to be_successful
+      it 'is failing' do
+        expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe 'Predicates: Excluded From' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :string) { excluded_from?(%w(1 3 5)) }
+        optional(:foo).value(:string) { excluded_from?(%w(1 3 5)) }
       end
     end
 
@@ -81,8 +81,8 @@ RSpec.describe 'Predicates: Excluded From' do
     context 'with nil input' do
       let(:input) { { 'foo' => nil } }
 
-      it 'is successful' do
-        expect(result).to be_successful
+      it 'is failing' do
+        expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe 'Predicates: Excluded From' do
       let(:input) { { 'foo' => { 'a' => '1' } } }
 
       it 'is successful' do
-        expect(result).to be_successful
+        expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: Excluded From' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :string).value(excluded_from?: %w(1 3 5))
+            required(:foo).value(:string, excluded_from?: %w(1 3 5))
           end
         end
 
@@ -139,8 +139,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with nil input' do
           let(:input) { { 'foo' => nil } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -155,8 +155,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with invalid type' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: Excluded From' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :string).filled(excluded_from?: %w(1 3 5))
+            required(:foo).filled(:string, excluded_from?: %w(1 3 5))
           end
         end
 
@@ -211,8 +211,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with invalid type' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Excluded From' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :string]).maybe(excluded_from?: %w(1 3 5))
+            required(:foo).maybe(:string, excluded_from?: %w(1 3 5))
           end
         end
 
@@ -267,8 +267,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with invalid type' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -286,7 +286,7 @@ RSpec.describe 'Predicates: Excluded From' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :string).value(excluded_from?: %w(1 3 5))
+            optional(:foo).value(:string, excluded_from?: %w(1 3 5))
           end
         end
 
@@ -309,8 +309,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with nil input' do
           let(:input) { { 'foo' => nil } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -325,8 +325,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with invalid type' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: Excluded From' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :string).filled(excluded_from?: %w(1 3 5))
+            optional(:foo).value(:string).filled(excluded_from?: %w(1 3 5))
           end
         end
 
@@ -366,7 +366,7 @@ RSpec.describe 'Predicates: Excluded From' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must not be one of: 1, 3, 5']
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -381,8 +381,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with invalid type' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -398,7 +398,7 @@ RSpec.describe 'Predicates: Excluded From' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :string]).maybe(excluded_from?: %w(1 3 5))
+            optional(:foo).maybe(:string).maybe(excluded_from?: %w(1 3 5))
           end
         end
 
@@ -437,8 +437,8 @@ RSpec.describe 'Predicates: Excluded From' do
         context 'with invalid type' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
-          it 'is successful' do
-            expect(result).to be_successful
+          it 'is failing' do
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 

--- a/spec/integration/params/predicates/excludes_spec.rb
+++ b/spec/integration/params/predicates/excludes_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Excludes' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?).value(excludes?: 1)
+        required(:foo).value(array[:integer]).each(:int?).value(excludes?: 1)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe 'Predicates: Excludes' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?).value(excludes?: 1)
+        optional(:foo).value(array[:integer]).each(:int?).value(excludes?: 1)
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe 'Predicates: Excludes' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, Types::Params::Array.of(Types::Params::Integer)).value(excludes?: "foo")
+            required(:foo).value(:string, excludes?: "foo")
           end
         end
 
@@ -124,7 +124,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => nil } }
 
           it 'is successful' do
-            expect(result).to be_successful
+            expect(result).to be_failing ['must be a string', 'must not include foo']
           end
         end
 
@@ -148,7 +148,7 @@ RSpec.describe 'Predicates: Excludes' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, Types::Params::Array.of(Types::Params::Integer)).filled(excludes?: 'foo')
+            required(:foo).filled(:string, excludes?: 'foo')
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Excludes' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, Types::Params::Array.of(Types::Params::Integer)]).maybe(excludes?: 'foo')
+            required(:foo).maybe(:string, excludes?: 'foo')
           end
         end
 
@@ -246,7 +246,7 @@ RSpec.describe 'Predicates: Excludes' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, Types::Params::Array.of(Types::Params::Integer)).value(excludes?: 1)
+            optional(:foo).value(array[:integer], excludes?: 1)
           end
         end
 
@@ -270,7 +270,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => nil } }
 
           it 'is successful' do
-            expect(result).to be_successful
+            expect(result).to be_failing ['must be an array', 'must not include 1']
           end
         end
 
@@ -294,7 +294,7 @@ RSpec.describe 'Predicates: Excludes' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, Types::Params::Array.of(Types::Params::Integer)).filled(excludes?: 'foo')
+            optional(:foo).filled(:string, excludes?: 'foo')
           end
         end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: Excludes' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, Types::Params::Array.of(Types::Params::Integer)]).maybe(excludes?: 'foo')
+            optional(:foo).maybe(:string, excludes?: 'foo')
           end
         end
 

--- a/spec/integration/params/predicates/false_spec.rb
+++ b/spec/integration/params/predicates/false_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: False' do
   context 'with key' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :false) { false? }
+        required(:foo).value(:false)
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe 'Predicates: False' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :false) { false? }
+        optional(:foo).value(:false)
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: False' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :false).value(:false?)
+            required(:foo).value(:false)
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: False' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :false).filled(:false?)
+            required(:foo).filled(:false)
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: False' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :false]).maybe(:false?)
+            required(:foo).maybe(:false)
           end
         end
 
@@ -286,7 +286,7 @@ RSpec.describe 'Predicates: False' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :false).value(:false?)
+            optional(:foo).value(:false)
           end
         end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: False' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :false).filled(:false?)
+            optional(:foo).filled(:false)
           end
         end
 
@@ -398,7 +398,7 @@ RSpec.describe 'Predicates: False' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :false]).maybe(:false?)
+            optional(:foo).maybe(:false)
           end
         end
 

--- a/spec/integration/params/predicates/filled_spec.rb
+++ b/spec/integration/params/predicates/filled_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe 'Predicates: Filled' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :string]).maybe(:filled?)
+            required(:foo).maybe([:array, :hash], :filled?)
           end
         end
 
@@ -258,7 +258,7 @@ RSpec.describe 'Predicates: Filled' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'must be an array or must be a hash']
           end
         end
 
@@ -274,7 +274,7 @@ RSpec.describe 'Predicates: Filled' do
           let(:input) { { 'foo' => '' } }
 
           it 'is successful' do
-            expect(result).to be_successful
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -410,7 +410,7 @@ RSpec.describe 'Predicates: Filled' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :string]).maybe(:filled?)
+            optional(:foo).maybe([:array, :hash], :filled?)
           end
         end
 
@@ -450,7 +450,7 @@ RSpec.describe 'Predicates: Filled' do
           let(:input) { { 'foo' => '' } }
 
           it 'is successful' do
-            expect(result).to be_successful
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/format_spec.rb
+++ b/spec/integration/params/predicates/format_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Format' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :string]).maybe(:str?, format?: /bar/)
+            required(:foo).maybe(:string).maybe(:str?, format?: /bar/)
           end
         end
 
@@ -398,7 +398,7 @@ RSpec.describe 'Predicates: Format' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :string]).maybe(:str?, format?: /bar/)
+            optional(:foo).maybe(:string).maybe(:str?, format?: /bar/)
           end
         end
 

--- a/spec/integration/params/predicates/gt_spec.rb
+++ b/spec/integration/params/predicates/gt_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Gt' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :integer) { int? & gt?(23) }
+        required(:foo).value(:integer) { gt?(23) }
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'Predicates: Gt' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :integer) { int? & gt?(23) }
+        optional(:foo).value(:integer) { gt?(23) }
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Gt' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).value(:int?, gt?: 23)
+            required(:foo).value(:integer, gt?: 23)
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Gt' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).filled(:int?, gt?: 23)
+            required(:foo).filled(:integer, gt?: 23)
           end
         end
 
@@ -260,7 +260,7 @@ RSpec.describe 'Predicates: Gt' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(:int?, gt?: 23)
+            required(:foo).maybe(:integer).maybe(:int?, gt?: 23)
           end
         end
 
@@ -326,7 +326,7 @@ RSpec.describe 'Predicates: Gt' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).value(:int?, gt?: 23)
+            optional(:foo).value(:integer, gt?: 23)
           end
         end
 
@@ -390,7 +390,7 @@ RSpec.describe 'Predicates: Gt' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).filled(:int?, gt?: 23)
+            optional(:foo).filled(:integer, gt?: 23)
           end
         end
 
@@ -454,7 +454,7 @@ RSpec.describe 'Predicates: Gt' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(:int?, gt?: 23)
+            optional(:foo).maybe(:integer).maybe(:int?, gt?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/gteq_spec.rb
+++ b/spec/integration/params/predicates/gteq_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Gteq' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :integer) { int? & gteq?(23) }
+        required(:foo).value(:integer) { gteq?(23) }
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'Predicates: Gteq' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :integer) { int? & gteq?(23) }
+        optional(:foo).value(:integer) { gteq?(23) }
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Gteq' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).value(:int?, gteq?: 23)
+            required(:foo).value(:integer, gteq?: 23)
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Gteq' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).filled(:int?, gteq?: 23)
+            required(:foo).filled(:integer, gteq?: 23)
           end
         end
 
@@ -260,7 +260,7 @@ RSpec.describe 'Predicates: Gteq' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(:int?, gteq?: 23)
+            required(:foo).maybe(:integer).maybe(:int?, gteq?: 23)
           end
         end
 
@@ -326,7 +326,7 @@ RSpec.describe 'Predicates: Gteq' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).value(:int?, gteq?: 23)
+            optional(:foo).value(:integer, gteq?: 23)
           end
         end
 
@@ -390,7 +390,7 @@ RSpec.describe 'Predicates: Gteq' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).filled(:int?, gteq?: 23)
+            optional(:foo).filled(:integer, gteq?: 23)
           end
         end
 
@@ -454,7 +454,7 @@ RSpec.describe 'Predicates: Gteq' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(:int?, gteq?: 23)
+            optional(:foo).maybe(:integer).maybe(:int?, gteq?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/included_in_spec.rb
+++ b/spec/integration/params/predicates/included_in_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Included In' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :string]).maybe(included_in?: %w(1 3 5))
+            required(:foo).maybe(:string, included_in?: %w(1 3 5))
           end
         end
 
@@ -268,7 +268,7 @@ RSpec.describe 'Predicates: Included In' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be one of: 1, 3, 5']
+            expect(result).to be_failing ['must be a string', 'must be one of: 1, 3, 5']
           end
         end
 
@@ -398,7 +398,7 @@ RSpec.describe 'Predicates: Included In' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :string]).maybe(included_in?: %w(1 3 5))
+            optional(:foo).maybe(:string).maybe(included_in?: %w(1 3 5))
           end
         end
 
@@ -438,7 +438,7 @@ RSpec.describe 'Predicates: Included In' do
           let(:input) { { 'foo' => { 'a' => '1' } } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be one of: 1, 3, 5']
+            expect(result).to be_failing ['must be a string', 'must be one of: 1, 3, 5']
           end
         end
 

--- a/spec/integration/params/predicates/includes_spec.rb
+++ b/spec/integration/params/predicates/includes_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Includes' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?).value(includes?: 1)
+        required(:foo).value(array[:integer]).each(:int?).value(includes?: 1)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe 'Predicates: Includes' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, Types::Params::Array.of(Types::Params::Integer)).value(:array?).each(:int?).value(includes?: 1)
+        optional(:foo).value(array[:integer]).each(:int?).value(includes?: 1)
       end
     end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Includes' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :string]).maybe(:str?, includes?: 'Hello')
+            required(:foo).maybe(:string).maybe(:str?, includes?: 'Hello')
           end
         end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: Includes' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :string]).maybe(includes?: 'Hello')
+            optional(:foo).maybe(:string).maybe(includes?: 'Hello')
           end
         end
 

--- a/spec/integration/params/predicates/lt_spec.rb
+++ b/spec/integration/params/predicates/lt_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Lt' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :integer) { int? & lt?(23) }
+        required(:foo).value(:integer) { lt?(23) }
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'Predicates: Lt' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :integer) { int? & lt?(23) }
+        optional(:foo).value(:integer) { lt?(23) }
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Lt' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).value(:int?, lt?: 23)
+            required(:foo).value(:integer, lt?: 23)
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Lt' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).filled(:int?, lt?: 23)
+            required(:foo).filled(:integer, lt?: 23)
           end
         end
 
@@ -260,7 +260,7 @@ RSpec.describe 'Predicates: Lt' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(:int?, lt?: 23)
+            required(:foo).maybe(:integer).maybe(:int?, lt?: 23)
           end
         end
 
@@ -326,7 +326,7 @@ RSpec.describe 'Predicates: Lt' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).value(:int?, lt?: 23)
+            optional(:foo).value(:integer, lt?: 23)
           end
         end
 
@@ -390,7 +390,7 @@ RSpec.describe 'Predicates: Lt' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).filled(:int?, lt?: 23)
+            optional(:foo).filled(:integer, lt?: 23)
           end
         end
 
@@ -454,7 +454,7 @@ RSpec.describe 'Predicates: Lt' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(:int?, lt?: 23)
+            optional(:foo).maybe(:integer).maybe(:int?, lt?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/lteq_spec.rb
+++ b/spec/integration/params/predicates/lteq_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Lteq' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :integer) { int? & lteq?(23) }
+        required(:foo).value(:integer) { lteq?(23) }
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'Predicates: Lteq' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :integer) { int? & lteq?(23) }
+        optional(:foo).value(:integer) { lteq?(23) }
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Lteq' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).value(:int?, lteq?: 23)
+            required(:foo).value(:integer, lteq?: 23)
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Lteq' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).filled(:int?, lteq?: 23)
+            required(:foo).filled(:integer, lteq?: 23)
           end
         end
 
@@ -260,7 +260,7 @@ RSpec.describe 'Predicates: Lteq' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(:int?, lteq?: 23)
+            required(:foo).maybe(:integer, lteq?: 23)
           end
         end
 
@@ -326,7 +326,7 @@ RSpec.describe 'Predicates: Lteq' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).value(:int?, lteq?: 23)
+            optional(:foo).value(:integer, lteq?: 23)
           end
         end
 
@@ -390,7 +390,7 @@ RSpec.describe 'Predicates: Lteq' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).filled(:int?, lteq?: 23)
+            optional(:foo).filled(:integer, lteq?: 23)
           end
         end
 
@@ -454,7 +454,7 @@ RSpec.describe 'Predicates: Lteq' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(:int?, lteq?: 23)
+            optional(:foo).maybe(:integer).maybe(:int?, lteq?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/min_size_spec.rb
+++ b/spec/integration/params/predicates/min_size_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Min Size' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(min_size?: 3)
+            required(:foo).maybe(:array, min_size?: 3)
           end
         end
 
@@ -236,7 +236,7 @@ RSpec.describe 'Predicates: Min Size' do
           let(:input) { { 'foo' => { 'a' => '1', 'b' => '2' } } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['size cannot be less than 3']
+            expect(result).to be_failing ['must be an array', 'size cannot be less than 3']
           end
         end
       end
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: Min Size' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(min_size?: 3)
+            optional(:foo).maybe(:array, min_size?: 3)
           end
         end
 
@@ -382,7 +382,7 @@ RSpec.describe 'Predicates: Min Size' do
           let(:input) { { 'foo' => { 'a' => '1', 'b' => '2' } } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['size cannot be less than 3']
+            expect(result).to be_failing ['must be an array', 'size cannot be less than 3']
           end
         end
       end

--- a/spec/integration/params/predicates/none_spec.rb
+++ b/spec/integration/params/predicates/none_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: None' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :nil) { none? }
+        required(:foo).value(:nil)
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'Predicates: None' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :nil) { none? }
+        optional(:foo).value(:nil)
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe 'Predicates: None' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :nil).value(:none?)
+            required(:foo).value(:nil)
           end
         end
 
@@ -175,7 +175,7 @@ RSpec.describe 'Predicates: None' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :nil).value(:none?)
+            optional(:foo).value(:nil)
           end
         end
 
@@ -215,7 +215,7 @@ RSpec.describe 'Predicates: None' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).filled(:none?)
+            optional(:foo).filled(:nil)
           end
         end
 
@@ -252,11 +252,11 @@ RSpec.describe 'Predicates: None' do
         end
       end
 
-      #makes no sense see: #134
+      # makes no sense see: #134
       context 'with maybe' do
         it "should raise error" do
           expect { Dry::Schema.Params do
-            optional(:foo).maybe(:none?)
+            optional(:foo).maybe(:nil)
           end }.to raise_error Dry::Schema::InvalidSchemaError
         end
       end

--- a/spec/integration/params/predicates/odd_spec.rb
+++ b/spec/integration/params/predicates/odd_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Odd' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :integer) { int? & odd? }
+        required(:foo).value(:integer) { odd? }
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe 'Predicates: Odd' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :integer) { int? & odd? }
+        optional(:foo).value(:integer) { odd? }
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: Odd' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).value(:int?, :odd?)
+            required(:foo).value(:integer, :odd?)
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: Odd' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).filled(:int?, :odd?)
+            required(:foo).filled(:integer, :odd?)
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Odd' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(:int?, :odd?)
+            required(:foo).maybe(:integer).maybe(:int?, :odd?)
           end
         end
 
@@ -286,7 +286,7 @@ RSpec.describe 'Predicates: Odd' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).value(:int?, :odd?)
+            optional(:foo).value(:integer, :odd?)
           end
         end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: Odd' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).filled(:int?, :odd?)
+            optional(:foo).filled(:integer, :odd?)
           end
         end
 
@@ -398,7 +398,7 @@ RSpec.describe 'Predicates: Odd' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(:int?, :odd?)
+            optional(:foo).maybe(:integer, :odd?)
           end
         end
 

--- a/spec/integration/params/predicates/size/fixed_spec.rb
+++ b/spec/integration/params/predicates/size/fixed_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe 'Predicates: Size' do
     context 'with required' do
       subject(:schema) do
         Dry::Schema.Params do
-          required(:foo, [:integer, :string]) { size?(3) }
+          required(:foo).value(:string) { size?(3) }
         end
       end
 
       context 'with valid input' do
-        let(:input) { { 'foo' => %w(1 2 3) } }
+        let(:input) { { 'foo' => 'bar' } }
 
         it 'is successful' do
           expect(result).to be_successful
@@ -26,8 +26,8 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { 'foo' => nil } }
 
-        it 'is raises error' do
-          expect { result }.to raise_error(NoMethodError)
+        it 'is not successful' do
+          expect(result).to be_failing ['must be a string', 'size must be 3']
         end
       end
 
@@ -43,7 +43,7 @@ RSpec.describe 'Predicates: Size' do
         let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
         it 'is not successful' do
-          expect(result).to be_failing ['size must be 3']
+          expect(result).to be_failing ['must be a string', 'size must be 3']
         end
       end
     end
@@ -51,12 +51,12 @@ RSpec.describe 'Predicates: Size' do
     context 'with optional' do
       subject(:schema) do
         Dry::Schema.Params do
-          optional(:foo, [:integer, :string]) { size?(3) }
+          optional(:foo).value([:integer, :string]) { size?(3) }
         end
       end
 
       context 'with valid input' do
-        let(:input) { { 'foo' => %w(1 2 3) } }
+        let(:input) { { 'foo' => 'bar' } }
 
         it 'is successful' do
           expect(result).to be_successful
@@ -74,8 +74,8 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { 'foo' => nil } }
 
-        it 'is raises error' do
-          expect { result }.to raise_error(NoMethodError)
+        it 'is not successful' do
+          expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
         end
       end
 
@@ -91,7 +91,7 @@ RSpec.describe 'Predicates: Size' do
         let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
         it 'is not successful' do
-          expect(result).to be_failing ['size must be 3']
+          expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
         end
       end
     end
@@ -101,12 +101,12 @@ RSpec.describe 'Predicates: Size' do
         context 'with value' do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo, [:integer, :string]).value(size?: 3)
+              required(:foo).value([:integer, :string], size?: 3)
             end
           end
 
           context 'with valid input' do
-            let(:input) { { 'foo' => %w(1 2 3) } }
+            let(:input) { { 'foo' => 'bar' } }
 
             it 'is successful' do
               expect(result).to be_successful
@@ -117,15 +117,15 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { {} }
 
             it 'is not successful' do
-              expect(result).to be_failing ['is missing', 'size must be 3']
+              expect(result).to be_failing ['is missing', 'must be an integer or must be a string', 'size must be 3']
             end
           end
 
           context 'with nil input' do
             let(:input) { { 'foo' => nil } }
 
-            it 'is raises error' do
-              expect { result }.to raise_error(NoMethodError)
+            it 'is not successful' do
+              expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
             end
           end
 
@@ -141,7 +141,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be 3']
+              expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
             end
           end
         end
@@ -149,7 +149,7 @@ RSpec.describe 'Predicates: Size' do
         context 'with filled' do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo, [:integer, :string]).filled(size?: 3)
+              required(:foo).filled([:array, :string], size?: 3)
             end
           end
 
@@ -165,7 +165,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { {} }
 
             it 'is not successful' do
-              expect(result).to be_failing ['is missing', 'size must be 3']
+              expect(result).to be_failing ['is missing', 'must be an array or must be a string', 'size must be 3']
             end
           end
 
@@ -173,7 +173,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'size must be 3']
+              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
             end
           end
 
@@ -181,7 +181,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'length must be 3']
+              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
             end
           end
 
@@ -189,7 +189,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be 3']
+              expect(result).to be_failing ['must be an array or must be a string', 'size must be 3']
             end
           end
         end
@@ -197,12 +197,12 @@ RSpec.describe 'Predicates: Size' do
         context 'with maybe' do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo, [:nil, [:integer, :string]]).maybe(size?: 3)
+              required(:foo).maybe([:integer, :string], size?: 3)
             end
           end
 
           context 'with valid input' do
-            let(:input) { { 'foo' => %w(1 2 3) } }
+            let(:input) { { 'foo' => 'bar' } }
 
             it 'is successful' do
               expect(result).to be_successful
@@ -213,7 +213,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { {} }
 
             it 'is not successful' do
-              expect(result).to be_failing ['is missing', 'size must be 3']
+              expect(result).to be_failing ['is missing', 'must be an integer or must be a string', 'size must be 3']
             end
           end
 
@@ -229,7 +229,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is successful' do
-              expect(result).to be_successful
+              expect(result).to be_failing ['length must be 3']
             end
           end
 
@@ -237,7 +237,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be 3']
+              expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
             end
           end
         end
@@ -247,12 +247,12 @@ RSpec.describe 'Predicates: Size' do
         context 'with value' do
           subject(:schema) do
             Dry::Schema.Params do
-              optional(:foo, [:integer, :string]).value(size?: 3)
+              optional(:foo).value([:integer, :string], size?: 3)
             end
           end
 
           context 'with valid input' do
-            let(:input) { { 'foo' => %w(1 2 3) } }
+            let(:input) { { 'foo' => 'bar' } }
 
             it 'is successful' do
               expect(result).to be_successful
@@ -270,8 +270,8 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { 'foo' => nil } }
 
-            it 'is raises error' do
-              expect { result }.to raise_error(NoMethodError)
+            it 'is not successful' do
+              expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
             end
           end
 
@@ -287,7 +287,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be 3']
+              expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
             end
           end
         end
@@ -295,7 +295,7 @@ RSpec.describe 'Predicates: Size' do
         context 'with filled' do
           subject(:schema) do
             Dry::Schema.Params do
-              optional(:foo, [:integer, :string]).filled(size?: 3)
+              optional(:foo).filled([:array, :string], size?: 3)
             end
           end
 
@@ -319,7 +319,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'size must be 3']
+              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
             end
           end
 
@@ -327,7 +327,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'length must be 3']
+              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
             end
           end
 
@@ -335,7 +335,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be 3']
+              expect(result).to be_failing ['must be an array or must be a string', 'size must be 3']
             end
           end
         end
@@ -343,12 +343,12 @@ RSpec.describe 'Predicates: Size' do
         context 'with maybe' do
           subject(:schema) do
             Dry::Schema.Params do
-              optional(:foo, [:nil, [:integer, :string]]).maybe(size?: 3)
+              optional(:foo).maybe([:integer, :string], size?: 3)
             end
           end
 
           context 'with valid input' do
-            let(:input) { { 'foo' => %w(1 2 3) } }
+            let(:input) { { 'foo' => 'bar' } }
 
             it 'is successful' do
               expect(result).to be_successful
@@ -375,7 +375,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is successful' do
-              expect(result).to be_successful
+              expect(result).to be_failing ['length must be 3']
             end
           end
 
@@ -383,7 +383,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be 3']
+              expect(result).to be_failing ['must be an integer or must be a string', 'size must be 3']
             end
           end
         end

--- a/spec/integration/params/predicates/size/range_spec.rb
+++ b/spec/integration/params/predicates/size/range_spec.rb
@@ -199,12 +199,12 @@ RSpec.describe 'Predicates: Size' do
         context 'with maybe' do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo, [:nil, :string]).maybe(size?: 2..3)
+              required(:foo).maybe(:string, size?: 2..3)
             end
           end
 
           context 'with valid input' do
-            let(:input) { { 'foo' => %w(1 2 3) } }
+            let(:input) { { 'foo' => 'bar' } }
 
             it 'is successful' do
               expect(result).to be_successful
@@ -239,7 +239,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be within 2 - 3']
+              expect(result).to be_failing ['must be a string', 'size must be within 2 - 3']
             end
           end
         end
@@ -298,12 +298,12 @@ RSpec.describe 'Predicates: Size' do
         context 'with filled' do
           subject(:schema) do
             Dry::Schema.Params do
-              optional(:foo).filled(size?: 2..3)
+              optional(:foo).filled(:string, size?: 2..3)
             end
           end
 
           context 'with valid input' do
-            let(:input) { { 'foo' => %w(1 2 3) } }
+            let(:input) { { 'foo' => 'bar' } }
 
             it 'is successful' do
               expect(result).to be_successful
@@ -338,7 +338,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be within 2 - 3']
+              expect(result).to be_failing ['must be a string', 'size must be within 2 - 3']
             end
           end
         end
@@ -346,12 +346,12 @@ RSpec.describe 'Predicates: Size' do
         context 'with maybe' do
           subject(:schema) do
             Dry::Schema.Params do
-              optional(:foo, [:nil, :string]).maybe(size?: 2..3)
+              optional(:foo).maybe(:string, size?: 2..3)
             end
           end
 
           context 'with valid input' do
-            let(:input) { { 'foo' => %w(1 2 3) } }
+            let(:input) { { 'foo' => 'bar' } }
 
             it 'is successful' do
               expect(result).to be_successful
@@ -383,10 +383,10 @@ RSpec.describe 'Predicates: Size' do
           end
 
           context 'with invalid input' do
-            let(:input) { { 'foo' => { 'a' => '1', 'b' => '2', 'c' => '3', 'd' => '4' } } }
+            let(:input) { { 'foo' => 'barbar' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['size must be within 2 - 3']
+              expect(result).to be_failing ['length must be within 2 - 3']
             end
           end
         end

--- a/spec/integration/params/predicates/true_spec.rb
+++ b/spec/integration/params/predicates/true_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: True' do
   context 'with key' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :true) { true? }
+        required(:foo).value(:true)
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe 'Predicates: True' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :true) { true? }
+        optional(:foo).value(:true)
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: True' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :true).value(:true?)
+            required(:foo).value(:true)
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: True' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :true).filled(:true?)
+            required(:foo).filled(:true)
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: True' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :true]).maybe(:true?)
+            required(:foo).maybe(:true)
           end
         end
 
@@ -286,7 +286,7 @@ RSpec.describe 'Predicates: True' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :true).value(:true?)
+            optional(:foo).value(:true)
           end
         end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: True' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :true).filled(:true?)
+            optional(:foo).filled(:true)
           end
         end
 
@@ -398,7 +398,7 @@ RSpec.describe 'Predicates: True' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :true]).maybe(:true?)
+            optional(:foo).maybe(:true)
           end
         end
 

--- a/spec/integration/params/predicates/type_spec.rb
+++ b/spec/integration/params/predicates/type_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Predicates: Type' do
   context 'with required' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo, :integer) { type?(Integer) }
+        required(:foo).value(:integer)
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be Integer']
+        expect(result).to be_failing ['is missing']
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { { 'foo' => nil } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be Integer']
+        expect(result).to be_failing ['must be an integer']
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { { 'foo' => '' } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be Integer']
+        expect(result).to be_failing ['must be an integer']
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { { 'foo' => ['x'] } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be Integer']
+        expect(result).to be_failing ['must be an integer']
       end
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe 'Predicates: Type' do
   context 'with optional' do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo, :integer) { type?(Integer) }
+        optional(:foo).value(:integer)
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { { 'foo' => nil } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be Integer']
+        expect(result).to be_failing ['must be an integer']
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { { 'foo' => '' } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be Integer']
+        expect(result).to be_failing ['must be an integer']
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { { 'foo' => ['x'] } }
 
       it 'is not successful' do
-        expect(result).to be_failing ['must be Integer']
+        expect(result).to be_failing ['must be an integer']
       end
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe 'Predicates: Type' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).value(type?: Integer)
+            required(:foo).value(:integer)
           end
         end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be Integer']
+            expect(result).to be_failing ['is missing']
           end
         end
 
@@ -124,7 +124,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 
@@ -140,7 +140,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => ['x'] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
       end
@@ -148,7 +148,7 @@ RSpec.describe 'Predicates: Type' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, :integer).filled(type?: Integer)
+            required(:foo).filled(:integer)
           end
         end
 
@@ -164,7 +164,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be Integer']
+            expect(result).to be_failing ['is missing']
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be Integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -180,7 +180,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be Integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -188,7 +188,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => ['x'] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
       end
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Type' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo, [:nil, :integer]).maybe(type?: Integer)
+            required(:foo).maybe(:integer)
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be Integer']
+            expect(result).to be_failing ['is missing']
           end
         end
 
@@ -236,7 +236,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => ['x'] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
       end
@@ -246,7 +246,7 @@ RSpec.describe 'Predicates: Type' do
       context 'with value' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).value(type?: Integer)
+            optional(:foo).value(:integer)
           end
         end
 
@@ -270,7 +270,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 
@@ -278,7 +278,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 
@@ -286,7 +286,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => ['x'] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
       end
@@ -294,7 +294,7 @@ RSpec.describe 'Predicates: Type' do
       context 'with filled' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, :integer).filled(type?: Integer)
+            optional(:foo).filled(:integer)
           end
         end
 
@@ -318,7 +318,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be Integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -326,7 +326,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be Integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -334,7 +334,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => ['x'] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
       end
@@ -342,7 +342,7 @@ RSpec.describe 'Predicates: Type' do
       context 'with maybe' do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo, [:nil, :integer]).maybe(type?: Integer)
+            optional(:foo).maybe(:integer)
           end
         end
 
@@ -382,7 +382,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => ['x'] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be Integer']
+            expect(result).to be_failing ['must be an integer']
           end
         end
       end

--- a/spec/integration/schema/each_with_set_spec.rb
+++ b/spec/integration/schema/each_with_set_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Schema with each and set rules' do
   subject(:schema) do
     Dry::Schema.define do
-      required(:payments, :array).value(:array?).each do
+      required(:payments).value(:array).each do
         schema do
           required(:method).filled(:str?)
           required(:amount).filled(:float?)

--- a/spec/integration/schema/json_spec.rb
+++ b/spec/integration/schema/json_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe Dry::Schema, 'defining a schema with json coercion' do
   subject(:schema) do
     Dry::Schema.JSON do
-      required(:email, :string).filled
+      required(:email).value(:string).filled
 
-      required(:age, [:nil, :integer]).maybe(:int?, gt?: 18)
+      required(:age).maybe(:integer).maybe(:int?, gt?: 18)
 
-      required(:address, :hash).schema do
-        required(:city, :string).filled
-        required(:street, :string).filled
+      required(:address).value(:hash).schema do
+        required(:city).value(:string).filled
+        required(:street).value(:string).filled
 
-        required(:loc, :hash).schema do
-          required(:lat, :float).filled(:float?)
-          required(:lng, :float).filled(:float?)
+        required(:loc).value(:hash).schema do
+          required(:lat).filled(:float)
+          required(:lng).filled(:float)
         end
       end
 

--- a/spec/integration/schema/macros/each_spec.rb
+++ b/spec/integration/schema/macros/each_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Macros #each' do
   context "predicate without options" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo, :array).value(:array?).each(:filled?, :str?)
+        required(:foo).value(:array).each(:filled?, :str?)
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe 'Macros #each' do
   context "predicate with options" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo, :array).value(:array?).each(size?: 3)
+        required(:foo).value(:array).each(size?: 3)
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'Macros #each' do
   context 'with filled macro' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo, :array).value(:array?).filled(size?: 2) { each(:str?) }
+        required(:foo).value(:array).filled(size?: 2) { each(:str?) }
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe 'Macros #each' do
   context 'with maybe macro' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo, [:nil, :array]).maybe(:array?) { each(:str?) }
+        required(:foo).maybe(:array).maybe(:array?) { each(:str?) }
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe 'Macros #each' do
   context 'with external schema macro' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo, :array).value(:array?).each(FooSchema)
+        required(:foo).value(:array).each(FooSchema)
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe 'Macros #each' do
     context 'with a nested schema' do
       subject(:schema) do
         Dry::Schema.define do
-          required(:songs, :array).value(:array?).each(:hash?) do
+          required(:songs).value(:array).each(:hash?) do
             schema do
               required(:title).filled
               required(:author).filled

--- a/spec/integration/schema/macros/maybe_spec.rb
+++ b/spec/integration/schema/macros/maybe_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe 'Macros #maybe' do
   describe 'with an optional key and a block with schema' do
     subject(:schema) do
       Dry::Schema.define do
-        optional(:employee, [:nil, :hash]).maybe(:hash?) do
+        optional(:employee).maybe(:hash).maybe(:hash?) do
           schema do
-            required(:id, :string).filled(:str?)
+            required(:id).filled(:string)
           end
         end
       end

--- a/spec/integration/schema/nested_schemas_spec.rb
+++ b/spec/integration/schema/nested_schemas_spec.rb
@@ -2,13 +2,13 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'with multiple nested schemas' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:content, :hash).schema do
-          required(:meta, :hash).schema do
-            required(:version, :string).filled
+        required(:content).value(:hash).schema do
+          required(:meta).value(:hash).schema do
+            required(:version).value(:string).filled
           end
 
-          required(:data, :hash).schema do
-            required(:city, :string).filled
+          required(:data).value(:hash).schema do
+            required(:city).value(:string).filled
           end
         end
       end
@@ -41,10 +41,10 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'with a 2-level deep schema' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta, :hash).schema do
-          required(:info, :hash).schema do
-            required(:details, :string).filled
-            required(:meta, :string).filled
+        required(:meta).schema do
+          required(:info).schema do
+            required(:details).filled(:string)
+            required(:meta).filled(:string)
           end
         end
       end
@@ -86,8 +86,8 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'when duplicated key names are used in 2 subsequent levels' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta, :hash).schema do
-          required(:meta, :string).filled
+        required(:meta).value(:hash).schema do
+          required(:meta).value(:string).filled
         end
       end
     end
@@ -114,9 +114,9 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'when duplicated key names are used in 2 subsequent levels as schemas' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta, :hash).schema do
-          required(:meta, :hash).schema do
-            required(:data, :string).filled
+        required(:meta).value(:hash).schema do
+          required(:meta).value(:hash).schema do
+            required(:data).value(:string).filled
           end
         end
       end
@@ -156,11 +156,11 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'with `each` + schema inside another schema' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta, :hash).schema do
-          required(:data, :array).value(:array?).each do
+        required(:meta).value(:hash).schema do
+          required(:data).value(:array).each do
             schema do
-              required(:info, :hash).schema do
-                required(:name, :string).filled
+              required(:info).value(:hash).schema do
+                required(:name).value(:string).filled
               end
             end
           end
@@ -210,11 +210,11 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'with 2-level `each` + schema' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:data, :array).value(:array?).each do
+        required(:data).value(:array).each do
           schema do
-            required(:tags, :array).value(:array?).each do
+            required(:tags).value(:array).each do
               schema do
-                required(:name, :string).filled
+                required(:name).value(:string).filled
               end
             end
           end

--- a/spec/integration/schema/type_spec.rb
+++ b/spec/integration/schema/type_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Dry::Schema, 'types specs' do
   context 'single type spec with an array' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:nums, array[:integer])
+        required(:nums).value(array[:integer])
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe Dry::Schema, 'types specs' do
   context 'using a type object' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:age, Types::Params::Nil | Types::Params::Integer)
+        required(:age).value(Types::Params::Nil | Types::Params::Integer)
       end
     end
 

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Dry::Schema, '.define' do
     context 'with simple predicates' do
       subject(:schema) do
         Dry::Schema.define do
-          required(:tags, :array).value(:array?).each(:str?) { size?(2..4) }
+          required(:tags).value(:array).each(:str?) { size?(2..4) }
         end
       end
 
@@ -78,9 +78,9 @@ RSpec.describe Dry::Schema, '.define' do
     context 'with a nested schema' do
       subject(:schema) do
         Dry::Schema.define do
-          required(:tags, :array).value(:array?).each do
+          required(:tags).value(:array).each do
             schema do
-              required(:name, :string).filled
+              required(:name).filled(:string)
             end
           end
         end
@@ -126,8 +126,8 @@ RSpec.describe Dry::Schema, '.define' do
   context 'with coercible type specs' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:birthday, Types::Params::Date).value(:date?)
-        optional(:age, Types::Params::Integer).value(:int?)
+        required(:birthday).value(Types::Params::Date).value(:date?)
+        optional(:age).value(Types::Params::Integer).value(:int?)
       end
     end
 


### PR DESCRIPTION
  * Remove type spec arg from `required`, `optional` and `key` in DSL
  * Set default type to `Types::Any` in `DSL#key`