### PR TITLE
Travis: update to 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 bundler_args: --without benchmarks tools
 before_install: gem update --system
 before_script:
@@ -9,10 +8,8 @@ before_script:
   - ./cc-test-reporter before-build
 after_script:
   - "[ -d coverage ] && ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
-script:
-  - bundle exec rake
 rvm:
-  - 2.6.0
+  - 2.6.1
   - 2.5.3
   - 2.4.5
   - 2.3.8


### PR DESCRIPTION
This PR polishes the Travis configuration file:

  - use Ruby 2.6.1
  - drop unused sudo: false directive
  - use Travis default script directive (bundle exec rake)