### PR TITLE
Refactor Messages to use dynamic template objects

### DIFF
--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -43,7 +43,7 @@ module Dry
         #
         # @api public
         def to_s
-          [left, right].uniq.join(" #{messages[:or]} ")
+          [left, right].uniq.join(" #{messages[:or].()} ")
         end
       end
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -164,9 +164,7 @@ module Dry
 
       # @api private
       def message_text(rule, template, tokens, opts)
-        original_verbosity = $VERBOSE
-        $VERBOSE = nil
-        text = template % tokens
+        text = template[template.data(tokens)]
 
         if full?
           rule_name = rule ? (messages.rule(rule, opts) || rule) : (opts[:name] || opts[:path].last)
@@ -174,8 +172,6 @@ module Dry
         else
           text
         end
-      ensure
-        $VERBOSE = original_verbosity
       end
 
       # @api private

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -4,6 +4,7 @@ require 'dry/equalizer'
 require 'dry/configurable'
 
 require 'dry/schema/constants'
+require 'dry/schema/messages/template'
 
 module Dry
   module Schema
@@ -69,15 +70,15 @@ module Dry
           get(path, options) if key?(path, options)
         end
 
-        # Retrieve a message
+        # Retrieve a message template
         #
-        # @return [String]
+        # @return [Template]
         #
         # @api public
         def call(*args)
           cache.fetch_or_store(args.hash) do
             path, opts = lookup(*args)
-            get(path, opts) if path
+            Template[get(path, opts)] if path
           end
         end
         alias_method :[], :call

--- a/lib/dry/schema/messages/template.rb
+++ b/lib/dry/schema/messages/template.rb
@@ -1,0 +1,66 @@
+require 'dry/equalizer'
+
+require 'dry/schema/constants'
+
+module Dry
+  module Schema
+    module Messages
+      # Template wraps a string with interpolation tokens and defines evaluator function
+      # dynamically
+      #
+      # @api private
+      class Template
+        include Dry::Equalizer(:text)
+
+        TOKEN_REGEXP = /%{([\w\d]*)}/
+
+        # !@attribute [r] text
+        #   @return [String]
+        attr_reader :text
+
+        # !@attribute [r] tokens
+        #   @return [Hash]
+        attr_reader :tokens
+
+        # !@attribute [r] evaluator
+        #   @return [Proc]
+        attr_reader :evaluator
+
+        # @api private
+        def self.[](input)
+          new(*parse(input))
+        end
+
+        # @api private
+        def self.parse(input)
+          tokens = input.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym)
+          text = input.gsub('%', '#')
+
+          evaluator = <<-RUBY.strip
+            -> (#{tokens.map { |token| "#{token}:" }.join(", ")}) { "#{text}" }
+          RUBY
+
+          [text, tokens, eval(evaluator, binding, __FILE__, __LINE__ - 3)]
+        end
+
+        # @api private
+        def initialize(text, tokens, evaluator)
+          @text = text
+          @tokens = tokens
+          @evaluator = evaluator
+        end
+
+        # @api private
+        def data(input)
+          tokens.each_with_object({}) { |k, h| h[k] = input[k] }
+        end
+
+        # @api private
+        def call(data = EMPTY_HASH)
+          data.empty? ? evaluator.() : evaluator.(data)
+        end
+        alias_method :[], :call
+      end
+    end
+  end
+end

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -17,59 +17,59 @@ RSpec.describe Dry::Schema::Messages::I18n do
       end
 
       it 'returns a message for a predicate' do
-        message = messages[:filled?, path: :name]
+        template = messages[:filled?, path: :name]
 
-        expect(message).to eql("nie może być pusty")
+        expect(template.()).to eql("nie może być pusty")
       end
 
       it 'returns a message for a specific rule' do
-        message = messages[:filled?, path: :email]
+        template = messages[:filled?, path: :email]
 
-        expect(message).to eql("Proszę podać adres email")
+        expect(template.()).to eql("Proszę podać adres email")
       end
 
       it 'returns a message for a specific val type' do
-        message = messages[:size?, path: :pages, val_type: String]
+        template = messages[:size?, path: :pages, val_type: String]
 
-        expect(message).to eql("wielkość musi być równa %{size}")
+        expect(template.(size: 2)).to eql("wielkość musi być równa 2")
       end
 
       it 'returns a message for a specific rule and its default arg type' do
-        message = messages[:size?, path: :pages]
+        template = messages[:size?, path: :pages]
 
-        expect(message).to eql("wielkość musi być równa %{size}")
+        expect(template.(size: 2)).to eql("wielkość musi być równa 2")
       end
 
       it 'returns a message for a specific rule and its arg type' do
-        message = messages[:size?, path: :pages, arg_type: Range]
+        template = messages[:size?, path: :pages, arg_type: Range]
 
-        expect(message).to eql("wielkość musi być między %{size_left} a %{size_right}")
+        expect(template.(size_left: 1, size_right: 2)).to eql("wielkość musi być między 1 a 2")
       end
     end
 
     context 'with a different locale' do
       it 'returns a message for a predicate' do
-        message = messages[:filled?, path: :name, locale: :en]
+        template = messages[:filled?, path: :name, locale: :en]
 
-        expect(message).to eql("must be filled")
+        expect(template.()).to eql("must be filled")
       end
 
       it 'returns a message for a specific rule' do
-        message = messages[:filled?, path: :email, locale: :en]
+        template = messages[:filled?, path: :email, locale: :en]
 
-        expect(message).to eql("Please provide your email")
+        expect(template.()).to eql("Please provide your email")
       end
 
       it 'returns a message for a specific rule and its default arg type' do
-        message = messages[:size?, path: :pages, locale: :en]
+        template = messages[:size?, path: :pages, locale: :en]
 
-        expect(message).to eql("size must be %{size}")
+        expect(template.(size: 2)).to eql("size must be 2")
       end
 
       it 'returns a message for a specific rule and its arg type' do
-        message = messages[:size?, path: :pages, arg_type: Range, locale: :en]
+        template = messages[:size?, path: :pages, arg_type: Range, locale: :en]
 
-        expect(message).to eql("size must be within %{size_left} - %{size_right}")
+        expect(template.(size_left: 1, size_right: 2)).to eql("size must be within 1 - 2")
       end
     end
 
@@ -84,10 +84,10 @@ RSpec.describe Dry::Schema::Messages::I18n do
       end
 
       it 'returns a message for a predicate in the default_locale' do
-        message = messages[:even?, path: :some_number]
+        template = messages[:even?, path: :some_number]
 
         expect(I18n.locale).to eql(:pl)
-        expect(message).to eql("must be even")
+        expect(template.()).to eql("must be even")
       end
     end
   end

--- a/spec/unit/dry/schema/messages/template_spec.rb
+++ b/spec/unit/dry/schema/messages/template_spec.rb
@@ -1,0 +1,20 @@
+require 'dry/schema/messages/template'
+
+RSpec.describe Dry::Schema::Messages::Template do
+  describe '.[]' do
+    it 'builds a template from a text with tokens' do
+      text = '%{value} looks %{how} and %{this31} and %{tha_t_21} too'
+      template = Dry::Schema::Messages::Template[text]
+
+      data = { value: 'this', how: 'good', this31: 'this', tha_t_21: 'that' }
+
+      expect(template.(data).to_s).to eql('this looks good and this and that too')
+    end
+
+    it 'builds a template from a text without tokens' do
+      template = Dry::Schema::Messages::Template['this is good']
+
+      expect(template.().to_s).to eql('this is good')
+    end
+  end
+end


### PR DESCRIPTION
This introduces callable templates for messages that are used instead of `String#%`. This way we get faster template evaluation[1] and useful information like which tokens are needed for a template, which are then extracted from message options, so we don't need the nasty workaround for #27 

[1] 👇🏻

```
Warming up --------------------------------------
            String#%   112.000  i/100ms
Dry::Schema::Messages::Template#call
                       171.000  i/100ms
Calculating -------------------------------------
            String#%      1.142k (± 0.9%) i/s -      5.712k in   5.002857s
Dry::Schema::Messages::Template#call
                          1.708k (± 1.9%) i/s -      8.550k in   5.007776s

Comparison:
Dry::Schema::Messages::Template#call:     1708.0 i/s
            String#%:     1141.8 i/s - 1.50x  slower
```

Closes #27