### PR TITLE
Fix issues with rule name translations

### DIFF
--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -71,10 +71,7 @@ module Dry
         # @api private
         def rule(name, options = {})
           tokens = { name: name, locale: options.fetch(:locale, default_locale) }
-
-          path = rule_lookup_paths.
-            map { |key| key % tokens }.
-            detect { |key| key?(key, options) }
+          path = rule_lookup_paths(tokens).detect { |key| key?(key, options) }
 
           get(path, options) if path
         end
@@ -121,8 +118,8 @@ module Dry
         end
 
         # @api private
-        def rule_lookup_paths
-          config.rule_lookup_paths
+        def rule_lookup_paths(tokens)
+          config.rule_lookup_paths.map { |key| key % tokens }
         end
 
         # Return a new message backend that will look for messages under provided namespace

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -34,6 +34,10 @@ module Dry
           %{root}.%{predicate}
         ).freeze
 
+        setting :rule_lookup_paths, %w(
+          rules.%{name}
+        ).freeze
+
         setting :arg_type_default, 'default'.freeze
         setting :val_type_default, 'default'.freeze
 
@@ -66,8 +70,13 @@ module Dry
 
         # @api private
         def rule(name, options = {})
-          path = "%{locale}.rules.#{name}"
-          get(path, options) if key?(path, options)
+          tokens = { name: name, locale: options.fetch(:locale, default_locale) }
+
+          path = rule_lookup_paths.
+            map { |key| key % tokens }.
+            detect { |key| key?(key, options) }
+
+          get(path, options) if path
         end
 
         # Retrieve a message template
@@ -109,6 +118,11 @@ module Dry
         # @api private
         def lookup_paths(tokens)
           config.lookup_paths.map { |path| path % tokens }
+        end
+
+        # @api private
+        def rule_lookup_paths
+          config.rule_lookup_paths
         end
 
         # Return a new message backend that will look for messages under provided namespace

--- a/lib/dry/schema/messages/namespaced.rb
+++ b/lib/dry/schema/messages/namespaced.rb
@@ -47,6 +47,10 @@ module Dry
         def lookup_paths(tokens)
           super(tokens.merge(root: "#{root}.rules.#{namespace}")) + super
         end
+
+        def rule_lookup_paths(tokens)
+          super(tokens).map { |key| "#{namespace}.#{key}" } + super
+        end
       end
     end
   end

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -17,6 +17,7 @@ module Dry
       # @api private
       configure do |config|
         config.root = '%{locale}.errors'.freeze
+        config.rule_lookup_paths = config.rule_lookup_paths.map { |path| "%{locale}.#{path}" }
       end
 
       # @api private
@@ -51,7 +52,11 @@ module Dry
       #
       # @api public
       def get(key, options = {})
-        data[key % { locale: options.fetch(:locale, default_locale) }]
+        evaluated_key = key.include?('%{locale}') ?
+          key % { locale: options.fetch(:locale, default_locale) } :
+          key
+
+        data[evaluated_key]
       end
 
       # Check if given key is defined
@@ -60,7 +65,11 @@ module Dry
       #
       # @api public
       def key?(key, options = {})
-        data.key?(key % { locale: options.fetch(:locale, default_locale) })
+        evaluated_key = key.include?('%{locale}') ?
+          key % { locale: options.fetch(:locale, default_locale) } :
+          key
+
+        data.key?(evaluated_key)
       end
 
       # Merge messages from an additional path

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -1,6 +1,9 @@
 en:
   rules:
     email: "E-mail address"
+  company:
+    rules:
+      email: "Company email"
   errors:
     rules:
       email:

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  rules:
+    email: "E-mail address"
   errors:
     rules:
       email:

--- a/spec/fixtures/locales/pl.yml
+++ b/spec/fixtures/locales/pl.yml
@@ -1,6 +1,9 @@
 pl:
   rules:
     email: "Adres mailowy"
+  company:
+    rules:
+      email: "Email firmowy"
   errors:
     filled?: "nie może być pusty"
     size?:

--- a/spec/fixtures/locales/pl.yml
+++ b/spec/fixtures/locales/pl.yml
@@ -1,4 +1,6 @@
 pl:
+  rules:
+    email: "Adres mailowy"
   errors:
     filled?: "nie może być pusty"
     size?:

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe Dry::Schema::Messages::I18n do
     it 'returns rule name using provided locale' do
       expect(messages.rule(:email, locale: :en)).to eql('E-mail address')
     end
+
+    it 'returns rule name using default locale within a namespace' do
+      expect(messages.namespaced(:company).rule(:email)).to eql('Email firmowy')
+    end
+
+    it 'returns rule name using provided locale within a namespace' do
+      expect(messages.namespaced(:company).rule(:email, locale: :en)).to eql('Company email')
+    end
   end
 
   after(:all) do

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe Dry::Schema::Messages::I18n do
     end
   end
 
+  describe '#rule' do
+    it 'returns rule name using default locale' do
+      expect(messages.rule(:email)).to eql('Adres mailowy')
+    end
+
+    it 'returns rule name using provided locale' do
+      expect(messages.rule(:email, locale: :en)).to eql('E-mail address')
+    end
+  end
+
   after(:all) do
     I18n.locale = I18n.default_locale
   end


### PR DESCRIPTION
This fixes issues with rule name translations. Previously translations were under `%{locale}.errors.rules`, now they are under root, so `%{locale}.rules`.

Closes #52 
Closes #57 