### PR TITLE
Extract hint-related code into an extension

### DIFF
--- a/lib/dry/schema/extensions.rb
+++ b/lib/dry/schema/extensions.rb
@@ -1,3 +1,7 @@
 Dry::Schema.register_extension(:monads) do
   require 'dry/schema/extensions/monads'
 end
+
+Dry::Schema.register_extension(:hints) do
+  require 'dry/schema/extensions/hints'
+end

--- a/lib/dry/schema/extensions/hints.rb
+++ b/lib/dry/schema/extensions/hints.rb
@@ -1,3 +1,4 @@
+require 'dry/schema/message'
 require 'dry/schema/message_compiler'
 
 require 'dry/schema/extensions/hints/message_compiler_methods'
@@ -6,6 +7,42 @@ require 'dry/schema/extensions/hints/result_methods'
 
 module Dry
   module Schema
+    # Hint-specific Message extensions
+    #
+    # @see Message
+    #
+    # @api public
+    class Message
+      # @see Message::Or
+      #
+      # @api public
+      class Or
+        # @api private
+        def hint?
+          false
+        end
+      end
+
+      # @api private
+      def hint?
+        false
+      end
+    end
+
+    # A hint message sub-type
+    #
+    # @api private
+    class Hint < Message
+      def self.[](predicate, path, text, options)
+        Hint.new(predicate, path, text, options)
+      end
+
+      # @api private
+      def hint?
+        true
+      end
+    end
+
     module Extensions
       MessageCompiler.prepend(Hints::MessageCompilerMethods)
       MessageSet.prepend(Hints::MessageSetMethods)

--- a/lib/dry/schema/extensions/hints.rb
+++ b/lib/dry/schema/extensions/hints.rb
@@ -1,0 +1,15 @@
+require 'dry/schema/message_compiler'
+
+require 'dry/schema/extensions/hints/message_compiler_methods'
+require 'dry/schema/extensions/hints/message_set_methods'
+require 'dry/schema/extensions/hints/result_methods'
+
+module Dry
+  module Schema
+    module Extensions
+      MessageCompiler.prepend(Hints::MessageCompilerMethods)
+      MessageSet.prepend(Hints::MessageSetMethods)
+      Result.prepend(Hints::ResultMethods)
+    end
+  end
+end

--- a/lib/dry/schema/extensions/hints/message_compiler_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_compiler_methods.rb
@@ -35,6 +35,11 @@ module Dry
           end
 
           # @api private
+          def message_type(options)
+            options[:message_type].equal?(:hint) ? Hint : Message
+          end
+
+          # @api private
           def visit_hint(node, opts = EMPTY_OPTS.dup)
             if hints?
               filter(visit(node, opts.(message_type: :hint)))

--- a/lib/dry/schema/extensions/hints/message_compiler_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_compiler_methods.rb
@@ -1,0 +1,32 @@
+module Dry
+  module Schema
+    module Extensions
+      module Hints
+        module MessageCompilerMethods
+          attr_reader :hints
+
+          def initialize(*args)
+            super
+            @hints = @options.fetch(:hints, true)
+          end
+
+          # @api private
+          def hints?
+            hints.equal?(true)
+          end
+
+          # @api private
+          def visit_hint(node, opts = EMPTY_OPTS.dup)
+            visit(node, opts.(message_type: :hint)) if hints?
+          end
+
+          # @api private
+          def visit_each(node, opts = EMPTY_OPTS.dup)
+            # TODO: we can still generate a hint for elements here!
+            []
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/schema/extensions/hints/message_set_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_set_methods.rb
@@ -3,19 +3,11 @@ module Dry
     module Extensions
       module Hints
         module MessageSetMethods
-          HINT_EXCLUSION = %i(
-            key? filled? nil? bool?
-            str? int? float? decimal?
-            date? date_time? time? hash?
-            array? format?
-          ).freeze
-
           attr_reader :hints, :failures
 
           # @api private
           def initialize(messages, options = EMPTY_HASH)
             @hints = messages.select(&:hint?)
-            @hints.reject! { |hint| HINT_EXCLUSION.include?(hint.predicate) }
             super(messages.reject(&:hint?) + @hints, options)
           end
 

--- a/lib/dry/schema/extensions/hints/message_set_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_set_methods.rb
@@ -7,8 +7,8 @@ module Dry
 
           # @api private
           def initialize(messages, options = EMPTY_HASH)
+            super
             @hints = messages.select(&:hint?)
-            super(messages.reject(&:hint?) + @hints, options)
           end
 
           # @api public

--- a/lib/dry/schema/extensions/hints/message_set_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_set_methods.rb
@@ -15,14 +15,13 @@ module Dry
           # @api private
           def initialize(messages, options = EMPTY_HASH)
             @hints = messages.select(&:hint?)
-            @failures = messages - hints
             @hints.reject! { |hint| HINT_EXCLUSION.include?(hint.predicate) }
-            super
+            super(messages.reject(&:hint?) + @hints, options)
           end
 
           # @api public
           def to_h
-            failures? ? messages_map : hints_map
+            failures? ? messages_map : messages_map(hints)
           end
           alias_method :to_hash, :to_h
           alias_method :dump, :to_h
@@ -35,23 +34,8 @@ module Dry
           private
 
           # @api private
-          def messages_map(messages = failures + hints)
-            super
-          end
-
-          # @api private
-          def hints_map
-            messages_map(hints)
-          end
-
-          # @api private
           def hint_groups
             @hint_groups ||= hints.group_by(&:path)
-          end
-
-          # @api private
-          def paths
-            @paths ||= failures.map(&:path).uniq
           end
         end
       end

--- a/lib/dry/schema/extensions/hints/message_set_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_set_methods.rb
@@ -1,0 +1,60 @@
+module Dry
+  module Schema
+    module Extensions
+      module Hints
+        module MessageSetMethods
+          HINT_EXCLUSION = %i(
+            key? filled? nil? bool?
+            str? int? float? decimal?
+            date? date_time? time? hash?
+            array? format?
+          ).freeze
+
+          attr_reader :hints, :failures
+
+          # @api private
+          def initialize(messages, options = EMPTY_HASH)
+            @hints = messages.select(&:hint?)
+            @failures = messages - hints
+            @hints.reject! { |hint| HINT_EXCLUSION.include?(hint.predicate) }
+            super
+          end
+
+          # @api public
+          def to_h
+            failures? ? messages_map : hints_map
+          end
+          alias_method :to_hash, :to_h
+          alias_method :dump, :to_h
+
+          # @api private
+          def failures?
+            options[:failures].equal?(true)
+          end
+
+          private
+
+          # @api private
+          def messages_map(messages = failures + hints)
+            super
+          end
+
+          # @api private
+          def hints_map
+            messages_map(hints)
+          end
+
+          # @api private
+          def hint_groups
+            @hint_groups ||= hints.group_by(&:path)
+          end
+
+          # @api private
+          def paths
+            @paths ||= failures.map(&:path).uniq
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/schema/extensions/hints/message_set_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_set_methods.rb
@@ -22,13 +22,6 @@ module Dry
           def failures?
             options[:failures].equal?(true)
           end
-
-          private
-
-          # @api private
-          def hint_groups
-            @hint_groups ||= hints.group_by(&:path)
-          end
         end
       end
     end

--- a/lib/dry/schema/extensions/hints/result_methods.rb
+++ b/lib/dry/schema/extensions/hints/result_methods.rb
@@ -1,0 +1,38 @@
+module Dry
+  module Schema
+    module Extensions
+      module Hints
+        module ResultMethods
+          # @see Result#errors
+          #
+          # @api public
+          def errors(options = EMPTY_HASH)
+            message_set(options.merge(hints: false)).dump
+          end
+
+          # Get all messages including hints
+          #
+          # @see #message_set
+          #
+          # @return [Hash<Symbol=>Array>]
+          #
+          # @api public
+          def messages(options = EMPTY_HASH)
+            message_set(options).dump
+          end
+
+          # Get hints exclusively without errors
+          #
+          # @see #message_set
+          #
+          # @return [Hash<Symbol=>Array>]
+          #
+          # @api public
+          def hints(options = EMPTY_HASH)
+            message_set(options.merge(failures: false)).dump
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -34,11 +34,6 @@ module Dry
           @path = left.path
         end
 
-        # @api private
-        def hint?
-          false
-        end
-
         # Return a string representation of the message
         #
         # @api public
@@ -76,27 +71,8 @@ module Dry
       end
 
       # @api private
-      def hint?
-        false
-      end
-
-      # @api private
       def eql?(other)
         other.is_a?(String) ? text == other : super
-      end
-    end
-
-    # A hint message sub-type
-    #
-    # @api private
-    class Hint < Message
-      def self.[](predicate, path, text, options)
-        Hint.new(predicate, path, text, options)
-      end
-
-      # @api private
-      def hint?
-        true
       end
     end
   end

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -113,14 +113,17 @@ module Dry
 
         text = message_text(rule, template, tokens, options)
 
-        message_class = options[:message_type] == :hint ? Hint : Message
-
-        message_class[
+        message_type(options)[
           predicate, path, text,
           args: arg_vals,
           input: input,
           rule: rule || msg_opts[:name]
         ]
+      end
+
+      # @api private
+      def message_type(*)
+        Message
       end
 
       # @api private

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -19,7 +19,6 @@ module Dry
         @messages = messages
         @options = options
         @full = @options.fetch(:full, false)
-        @hints = @options.fetch(:hints, true)
         @locale = @options[:locale]
         @default_lookup_options = @locale ? { locale: locale } : EMPTY_HASH
       end
@@ -27,11 +26,6 @@ module Dry
       # @api private
       def full?
         @full
-      end
-
-      # @api private
-      def hints?
-        @hints
       end
 
       # @api private
@@ -58,15 +52,7 @@ module Dry
 
       # @api private
       def visit_hint(node, opts = EMPTY_OPTS.dup)
-        if hints?
-          visit(node, opts.(message_type: :hint))
-        end
-      end
-
-      # @api private
-      def visit_each(node, opts = EMPTY_OPTS.dup)
-        # TODO: we can still generate a hint for elements here!
-        []
+        nil
       end
 
       # @api private

--- a/lib/dry/schema/message_compiler/visitor_opts.rb
+++ b/lib/dry/schema/message_compiler/visitor_opts.rb
@@ -1,3 +1,5 @@
+require 'dry/schema/message'
+
 module Dry
   module Schema
     # @api private

--- a/lib/dry/schema/message_set.rb
+++ b/lib/dry/schema/message_set.rb
@@ -8,14 +8,7 @@ module Dry
     class MessageSet
       include Enumerable
 
-      HINT_EXCLUSION = %i(
-        key? filled? nil? bool?
-        str? int? float? decimal?
-        date? date_time? time? hash?
-        array? format?
-      ).freeze
-
-      attr_reader :messages, :failures, :hints, :paths, :placeholders, :options
+      attr_reader :messages, :placeholders, :options
 
       # @api private
       def self.[](messages, options = EMPTY_HASH)
@@ -25,12 +18,7 @@ module Dry
       # @api private
       def initialize(messages, options = EMPTY_HASH)
         @messages = messages
-        @hints = messages.select(&:hint?)
-        @failures = messages - hints
-        @paths = failures.map(&:path).uniq
         @options = options
-
-        initialize_hints!
         initialize_placeholders!
       end
 
@@ -42,15 +30,10 @@ module Dry
 
       # @api public
       def to_h
-        failures? ? messages_map : hints_map
+        messages_map
       end
       alias_method :to_hash, :to_h
       alias_method :dump, :to_h
-
-      # @api private
-      def failures?
-        options[:failures].equal?(true)
-      end
 
       # @api private
       def empty?
@@ -60,26 +43,8 @@ module Dry
       private
 
       # @api private
-      def messages_map
-        failures.group_by(&:path).reduce(placeholders) do |hash, (path, msgs)|
-          node = path.reduce(hash) { |a, e| a[e] }
-
-          msgs.each do |msg|
-            node << msg
-          end
-
-          msg_hints = hint_groups[path]
-          node.concat(msg_hints) if msg_hints
-
-          node.map!(&:to_s)
-
-          hash
-        end
-      end
-
-      # @api private
-      def hints_map
-        hints.group_by(&:path).reduce(placeholders) do |hash, (path, msgs)|
+      def messages_map(messages = self.messages)
+        messages.group_by(&:path).reduce(placeholders) do |hash, (path, msgs)|
           node = path.reduce(hash) { |a, e| a[e] }
 
           msgs.each do |msg|
@@ -93,13 +58,8 @@ module Dry
       end
 
       # @api private
-      def hint_groups
-        @hint_groups ||= hints.group_by(&:path)
-      end
-
-      # @api private
-      def initialize_hints!
-        hints.reject! { |hint| HINT_EXCLUSION.include?(hint.predicate) }
+      def paths
+        @paths ||= messages.map(&:path).uniq
       end
 
       # @api private

--- a/lib/dry/schema/message_set.rb
+++ b/lib/dry/schema/message_set.rb
@@ -64,7 +64,7 @@ module Dry
 
       # @api private
       def initialize_placeholders!
-        @placeholders = paths.reduce({}) do |hash, path|
+        @placeholders = messages.map(&:path).uniq.reduce({}) do |hash, path|
           curr_idx = 0
           last_idx = path.size - 1
           node = hash

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -105,29 +105,7 @@ module Dry
       #
       # @api public
       def errors(options = EMPTY_HASH)
-        message_set(options.merge(hints: false)).dump
-      end
-
-      # Get all messages including hints
-      #
-      # @see #message_set
-      #
-      # @return [Hash<Symbol=>Array>]
-      #
-      # @api public
-      def messages(options = EMPTY_HASH)
-        message_set(options.merge(hints: true)).dump
-      end
-
-      # Get hints exclusively without errors
-      #
-      # @see #message_set
-      #
-      # @return [Hash<Symbol=>Array>]
-      #
-      # @api public
-      def hints(options = EMPTY_HASH)
-        message_set(options.merge(failures: false)).dump
+        message_set(options).dump
       end
 
       # Return the message set

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,8 @@ end
 
 Undefined = Dry::Core::Constants::Undefined
 
+Dry::Schema.load_extensions(:hints)
+
 require 'i18n'
 require 'dry/schema/messages/i18n'
 


### PR DESCRIPTION
This moves code that handles hints to `:hints` extension, with some bonus clean-ups/refactorings. Hint behavior is not really crucial and I bet some (possibly many) people will not want to use this feature.