### PR TITLE
Improve hints generation

### DIFF
--- a/lib/dry/schema/extensions/hints/message_compiler_methods.rb
+++ b/lib/dry/schema/extensions/hints/message_compiler_methods.rb
@@ -3,12 +3,12 @@ module Dry
     module Extensions
       module Hints
         module MessageCompilerMethods
-          HINT_EXCLUSION = %i(
-            key? filled? nil? bool?
-            str? int? float? decimal?
-            date? date_time? time? hash?
-            array? format?
-          ).freeze
+          HINT_TYPE_EXCLUSION = %i[
+            key? nil? bool? str? int? float? decimal?
+            date? date_time? time? hash? array?
+          ].freeze
+
+          HINT_OTHER_EXCLUSION = %i[format? filled?].freeze
 
           attr_reader :hints
 
@@ -23,14 +23,21 @@ module Dry
           end
 
           # @api private
-          def filter(messages)
-            Array(messages).flatten.reject do |msg|
-              case msg
-              when Message::Or
-                false
-              else
-                HINT_EXCLUSION.include?(msg.predicate)
-              end
+          def filter(messages, opts)
+            Array(messages).flatten.map { |msg| msg unless exclude?(msg, opts) }.compact.uniq
+          end
+
+          # @api private
+          def exclude?(messages, opts)
+            Array(messages).all? do |msg|
+              hints = opts.hints.reject { |hint| msg == hint }.reject { |hint| hint.predicate == :filled? }
+              key_failure = opts.key_failure?(msg.path)
+              predicate = msg.predicate
+
+              (HINT_TYPE_EXCLUSION.include?(predicate) && !key_failure) ||
+                (msg.predicate == :filled? && key_failure) ||
+                  (!key_failure && HINT_TYPE_EXCLUSION.include?(predicate) && !hints.empty? && hints.any? { |hint| hint.path == msg.path }) ||
+                    HINT_OTHER_EXCLUSION.include?(predicate)
             end
           end
 
@@ -40,14 +47,21 @@ module Dry
           end
 
           # @api private
-          def visit_hint(node, opts = EMPTY_OPTS.dup)
+          def visit_hint(node, opts)
             if hints?
-              filter(visit(node, opts.(message_type: :hint)))
+              filter(visit(node, opts.(message_type: :hint)), opts)
             end
           end
 
           # @api private
-          def visit_each(node, opts = EMPTY_OPTS.dup)
+          def visit_predicate(node, opts)
+            message = super
+            opts.current_messages << message
+            message
+          end
+
+          # @api private
+          def visit_each(node, opts)
             # TODO: we can still generate a hint for elements here!
             []
           end

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -35,7 +35,7 @@ module Dry
         #
         # @api public
         def value(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates|
+          extract_type_spec(*args) do |*predicates, type_spec:|
             super(*predicates, **opts, &block)
           end
         end
@@ -48,8 +48,8 @@ module Dry
         #
         # @api public
         def filled(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates|
-            super(*predicates, **opts, &block)
+          extract_type_spec(*args) do |*predicates, type_spec:|
+            super(*predicates, type_spec: type_spec, **opts, &block)
           end
         end
 
@@ -61,7 +61,7 @@ module Dry
         #
         # @api public
         def maybe(*args, **opts, &block)
-          extract_type_spec(*args, nullable: true) do |*predicates|
+          extract_type_spec(*args, nullable: true) do |*predicates, type_spec:|
             append_macro(Macros::Maybe) do |macro|
               macro.call(*predicates, **opts, &block)
             end
@@ -129,7 +129,7 @@ module Dry
             end
           end
 
-          yield(*predicates)
+          yield(*predicates, type_spec: !type_spec.nil?)
         end
       end
     end

--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -14,6 +14,8 @@ module Dry
       #
       # @api public
       class Or
+        include Enumerable
+
         # @api private
         attr_reader :left
 
@@ -38,7 +40,17 @@ module Dry
         #
         # @api public
         def to_s
-          [left, right].uniq.join(" #{messages[:or].()} ")
+          uniq.join(" #{messages[:or].()} ")
+        end
+
+        # @api private
+        def each(&block)
+          to_a.each(&block)
+        end
+
+        # @api private
+        def to_a
+          [left, right]
         end
       end
 

--- a/lib/dry/schema/message_compiler/visitor_opts.rb
+++ b/lib/dry/schema/message_compiler/visitor_opts.rb
@@ -1,3 +1,4 @@
+require 'dry/schema/constants'
 require 'dry/schema/message'
 
 module Dry
@@ -14,6 +15,7 @@ module Dry
           opts[:path] = EMPTY_ARRAY
           opts[:rule] = nil
           opts[:message_type] = :failure
+          opts[:current_messages] = EMPTY_ARRAY.dup
           opts
         end
 
@@ -25,6 +27,28 @@ module Dry
         # @api private
         def call(other)
           merge(other.update(path: [*path, *other[:path]]))
+        end
+
+        def dup(current_messages = EMPTY_ARRAY.dup)
+          opts = super()
+          opts[:current_messages] = current_messages
+          opts
+        end
+
+        def key_failure?(path)
+          failures.any? { |f| f.path == path && f.predicate.equal?(:key?) }
+        end
+
+        def failures
+          current_messages.reject(&:hint?)
+        end
+
+        def hints
+          current_messages.select(&:hint?)
+        end
+
+        def current_messages
+          self[:current_messages]
         end
       end
     end

--- a/lib/dry/schema/trace.rb
+++ b/lib/dry/schema/trace.rb
@@ -28,6 +28,9 @@ module Dry
 
       # @api private
       def evaluate(*predicates, **opts, &block)
+        pred_opts = opts.dup
+        pred_opts.delete(:type_spec)
+
         predicates.each do |predicate|
           if predicate.respond_to?(:call)
             append(predicate)
@@ -38,7 +41,7 @@ module Dry
           end
         end
 
-        opts.each do |predicate, *args|
+        pred_opts.each do |predicate, *args|
           append(__send__(predicate, *args))
         end
 

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Validation hints' do
   end
 
   context 'when type expectation is specified' do
-    subject(:schema)  do
+    subject(:schema) do
       Dry::Schema.define do
         required(:email).filled
         required(:name).filled(:str?, size?: 5..25)
@@ -161,6 +161,26 @@ RSpec.describe 'Validation hints' do
     it 'provides a correct hint' do
       expect(schema.(pill: nil).messages).to eql(
         pill: ['must be filled', 'must be equal to blue']
+      )
+    end
+  end
+
+  context 'disjunctions on an optional key' do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:attributes).schema do
+          optional(:text) { int? | nil? }
+        end
+      end
+    end
+
+    it 'skips hints when key is missing' do
+      expect(schema.({}).messages).to eql(attributes: ['is missing', 'must be a hash'])
+    end
+
+    it 'shows hints when key is present' do
+      expect(schema.(attributes: { text: 'invalid' }).messages).to eql(
+        attributes: { text: ['must be an integer or cannot be defined'] }
       )
     end
   end

--- a/spec/integration/messages/i18n/with_locale_spec.rb
+++ b/spec/integration/messages/i18n/with_locale_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'I18n validation messages / using I18n.with_locale' do
     end
   end
 
-  let(:result) { schema.(name: nil) }
+  let(:result) { schema.(name: '') }
   let(:expected) { ['заполните это поле'] }
 
   around do |example|

--- a/spec/integration/params/predicates/array_spec.rb
+++ b/spec/integration/params/predicates/array_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Predicates: Array' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing']
+        expect(result).to be_failing ['is missing', 'must be an array']
       end
     end
 
@@ -163,7 +163,7 @@ RSpec.describe 'Predicates: Array' do
         let(:input) { {} }
 
         it 'is not successful' do
-          expect(result).to be_failing ['is missing']
+          expect(result).to be_failing ['is missing', 'must be an array']
         end
       end
 

--- a/spec/integration/params/predicates/eql_spec.rb
+++ b/spec/integration/params/predicates/eql_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Eql' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be equal to 23']
+        expect(result).to be_failing ['is missing', 'must be a string', 'must be equal to 23']
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be equal to 23']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must be equal to 23']
           end
         end
 
@@ -140,7 +140,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be equal to 23']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must be equal to 23']
           end
         end
 
@@ -148,7 +148,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be equal to 23']
+            expect(result).to be_failing ['must be a string', 'must be equal to 23']
           end
         end
 
@@ -180,7 +180,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be equal to 23']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must be equal to 23']
           end
         end
 
@@ -270,7 +270,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be equal to 23']
+            expect(result).to be_failing ['must be a string', 'must be equal to 23']
           end
         end
 

--- a/spec/integration/params/predicates/even_spec.rb
+++ b/spec/integration/params/predicates/even_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Even' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be even']
+        expect(result).to be_failing ['is missing', 'must be an integer', 'must be even']
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be even']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be even']
           end
         end
 
@@ -188,7 +188,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be even']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be even']
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be even']
+            expect(result).to be_failing ['must be an integer', 'must be even']
           end
         end
 
@@ -204,7 +204,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be even']
+            expect(result).to be_failing ['must be an integer', 'must be even']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be even']
+            expect(result).to be_failing ['must be an integer', 'must be even']
           end
         end
 
@@ -244,7 +244,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be even']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be even']
           end
         end
 
@@ -366,7 +366,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be even']
+            expect(result).to be_failing ['must be an integer', 'must be even']
           end
         end
 
@@ -374,7 +374,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be even']
+            expect(result).to be_failing ['must be an integer', 'must be even']
           end
         end
 
@@ -382,7 +382,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be even']
+            expect(result).to be_failing ['must be an integer', 'must be even']
           end
         end
 

--- a/spec/integration/params/predicates/excluded_from_spec.rb
+++ b/spec/integration/params/predicates/excluded_from_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Excluded From' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must not be one of: 1, 3, 5']
+        expect(result).to be_failing ['is missing', 'must be a string', 'must not be one of: 1, 3, 5']
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Excluded From' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must not be one of: 1, 3, 5']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -188,7 +188,7 @@ RSpec.describe 'Predicates: Excluded From' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must not be one of: 1, 3, 5']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Excluded From' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must not be one of: 1, 3, 5']
+            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 
@@ -244,7 +244,7 @@ RSpec.describe 'Predicates: Excluded From' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must not be one of: 1, 3, 5']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must not be one of: 1, 3, 5']
           end
         end
 

--- a/spec/integration/params/predicates/excludes_spec.rb
+++ b/spec/integration/params/predicates/excludes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Excludes' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must not include 1']
+        expect(result).to be_failing ['is missing', 'must be an array', 'must not include 1']
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must not include foo']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must not include foo']
           end
         end
 
@@ -164,7 +164,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must not include foo']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must not include foo']
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must not include foo']
+            expect(result).to be_failing ['must be a string', 'must not include foo']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must not include foo']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must not include foo']
           end
         end
 
@@ -318,7 +318,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must not include foo']
+            expect(result).to be_failing ['must be a string', 'must not include foo']
           end
         end
 

--- a/spec/integration/params/predicates/false_spec.rb
+++ b/spec/integration/params/predicates/false_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be false']
+            expect(result).to be_failing ['must be false']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be false']
+            expect(result).to be_failing ['must be false']
           end
         end
 
@@ -220,7 +220,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be false']
+            expect(result).to be_failing ['must be false']
           end
         end
       end
@@ -374,7 +374,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be false']
+            expect(result).to be_failing ['must be false']
           end
         end
 
@@ -382,7 +382,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be false']
+            expect(result).to be_failing ['must be false']
           end
         end
 
@@ -390,7 +390,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be false']
+            expect(result).to be_failing ['must be false']
           end
         end
       end

--- a/spec/integration/params/predicates/format_spec.rb
+++ b/spec/integration/params/predicates/format_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Format' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing']
+        expect(result).to be_failing ['is missing', 'must be a string']
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Format' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'must be a string']
           end
         end
 
@@ -188,7 +188,7 @@ RSpec.describe 'Predicates: Format' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'must be a string']
           end
         end
 
@@ -244,7 +244,7 @@ RSpec.describe 'Predicates: Format' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'must be a string']
           end
         end
 

--- a/spec/integration/params/predicates/gt_spec.rb
+++ b/spec/integration/params/predicates/gt_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Gt' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be greater than 23']
+        expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than 23']
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be greater than 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than 23']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be greater than 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than 23']
           end
         end
 
@@ -220,7 +220,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
           end
         end
 
@@ -236,7 +236,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
           end
         end
 
@@ -276,7 +276,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be greater than 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than 23']
           end
         end
 
@@ -414,7 +414,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
           end
         end
 
@@ -422,7 +422,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
           end
         end
 
@@ -430,7 +430,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
           end
         end
 

--- a/spec/integration/params/predicates/gteq_spec.rb
+++ b/spec/integration/params/predicates/gteq_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Gteq' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be greater than or equal to 23']
+        expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than or equal to 23']
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -220,7 +220,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -236,7 +236,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -276,7 +276,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -414,7 +414,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -422,7 +422,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
           end
         end
 
@@ -430,7 +430,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
           end
         end
 

--- a/spec/integration/params/predicates/included_in_spec.rb
+++ b/spec/integration/params/predicates/included_in_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe 'Predicates: Included In' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be one of: 1, 3, 5']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must be one of: 1, 3, 5']
           end
         end
 

--- a/spec/integration/params/predicates/includes_spec.rb
+++ b/spec/integration/params/predicates/includes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Includes' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must include 1']
+        expect(result).to be_failing ['is missing', 'must be an array', 'must include 1']
       end
     end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Includes' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must include Hello']
+            expect(result).to be_failing ['is missing', 'must be a string', 'must include Hello']
           end
         end
 

--- a/spec/integration/params/predicates/lt_spec.rb
+++ b/spec/integration/params/predicates/lt_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Lt' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be less than 23']
+        expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than 23']
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be less than 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than 23']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be less than 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than 23']
           end
         end
 
@@ -220,7 +220,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than 23']
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than 23']
           end
         end
 
@@ -236,7 +236,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than 23']
           end
         end
 
@@ -276,7 +276,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be less than 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than 23']
           end
         end
 
@@ -414,7 +414,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than 23']
           end
         end
 
@@ -422,7 +422,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than 23']
           end
         end
 
@@ -430,7 +430,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than 23']
           end
         end
 

--- a/spec/integration/params/predicates/lteq_spec.rb
+++ b/spec/integration/params/predicates/lteq_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Lteq' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be less than or equal to 23']
+        expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than or equal to 23']
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be less than or equal to 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be less than or equal to 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -220,7 +220,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -228,7 +228,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -236,7 +236,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -276,7 +276,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be less than or equal to 23']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -414,7 +414,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -422,7 +422,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
           end
         end
 
@@ -430,7 +430,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
           end
         end
 

--- a/spec/integration/params/predicates/min_size_spec.rb
+++ b/spec/integration/params/predicates/min_size_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Min Size' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'size cannot be less than 3']
+            expect(result).to be_failing ['is missing', 'must be an array', 'size cannot be less than 3']
           end
         end
 

--- a/spec/integration/params/predicates/nil_spec.rb
+++ b/spec/integration/params/predicates/nil_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Predicates: None' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing']
+        expect(result).to be_failing ['is missing', 'cannot be defined']
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe 'Predicates: None' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'cannot be defined']
           end
         end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: None' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'cannot be defined']
           end
         end
 

--- a/spec/integration/params/predicates/odd_spec.rb
+++ b/spec/integration/params/predicates/odd_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Odd' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing', 'must be odd']
+        expect(result).to be_failing ['is missing', 'must be an integer', 'must be odd']
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be odd']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be odd']
           end
         end
 
@@ -188,7 +188,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be odd']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be odd']
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be odd']
+            expect(result).to be_failing ['must be an integer', 'must be odd']
           end
         end
 
@@ -204,7 +204,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be odd']
+            expect(result).to be_failing ['must be an integer', 'must be odd']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be odd']
+            expect(result).to be_failing ['must be an integer', 'must be odd']
           end
         end
 
@@ -244,7 +244,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing', 'must be odd']
+            expect(result).to be_failing ['is missing', 'must be an integer', 'must be odd']
           end
         end
 
@@ -366,7 +366,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be odd']
+            expect(result).to be_failing ['must be an integer', 'must be odd']
           end
         end
 
@@ -374,7 +374,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be odd']
+            expect(result).to be_failing ['must be an integer', 'must be odd']
           end
         end
 
@@ -382,7 +382,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be odd']
+            expect(result).to be_failing ['must be an integer', 'must be odd']
           end
         end
 

--- a/spec/integration/params/predicates/size/fixed_spec.rb
+++ b/spec/integration/params/predicates/size/fixed_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Predicates: Size' do
         let(:input) { {} }
 
         it 'is not successful' do
-          expect(result).to be_failing ['is missing', 'size must be 3']
+          expect(result).to be_failing ['is missing', 'must be a string', 'size must be 3']
         end
       end
 
@@ -173,7 +173,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
+              expect(result).to be_failing ['must be an array or must be a string', 'size must be 3']
             end
           end
 
@@ -181,7 +181,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
+              expect(result).to be_failing ['must be filled', 'size must be 3']
             end
           end
 
@@ -319,7 +319,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
+              expect(result).to be_failing ['must be an array or must be a string', 'size must be 3']
             end
           end
 
@@ -327,7 +327,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'must be an array or must be a string', 'size must be 3']
+              expect(result).to be_failing ['must be filled', 'size must be 3']
             end
           end
 

--- a/spec/integration/params/predicates/size/range_spec.rb
+++ b/spec/integration/params/predicates/size/range_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { {} }
 
             it 'is not successful' do
-              expect(result).to be_failing ['is missing', 'size must be within 2 - 3']
+              expect(result).to be_failing ['is missing', 'must be a string', 'size must be within 2 - 3']
             end
           end
 
@@ -322,7 +322,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'size must be within 2 - 3']
+              expect(result).to be_failing ['must be a string', 'size must be within 2 - 3']
             end
           end
 

--- a/spec/integration/params/predicates/true_spec.rb
+++ b/spec/integration/params/predicates/true_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be true']
+            expect(result).to be_failing ['must be true']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be true']
+            expect(result).to be_failing ['must be true']
           end
         end
 
@@ -220,7 +220,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be true']
+            expect(result).to be_failing ['must be true']
           end
         end
       end
@@ -374,7 +374,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be true']
+            expect(result).to be_failing ['must be true']
           end
         end
 
@@ -382,7 +382,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be true']
+            expect(result).to be_failing ['must be true']
           end
         end
 
@@ -390,7 +390,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be true']
+            expect(result).to be_failing ['must be true']
           end
         end
       end

--- a/spec/integration/params/predicates/type_spec.rb
+++ b/spec/integration/params/predicates/type_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Type' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing']
+        expect(result).to be_failing ['is missing', 'must be an integer']
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'must be an integer']
           end
         end
 
@@ -164,7 +164,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'must be an integer']
           end
         end
 
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 
@@ -180,7 +180,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 
@@ -212,7 +212,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'must be an integer']
           end
         end
 
@@ -318,7 +318,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 
@@ -326,7 +326,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled']
+            expect(result).to be_failing ['must be an integer']
           end
         end
 

--- a/spec/integration/schema/each_with_set_spec.rb
+++ b/spec/integration/schema/each_with_set_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Schema with each and set rules' do
     it 'validates using all rules' do
       expect(schema.(payments: [{}]).messages).to eql(
         { payments: {
-          0 => { method: ['is missing'], amount: ['is missing'] }
+          0 => { method: ['is missing', 'must be a string'], amount: ['is missing', 'must be a float'] }
         }}
       )
     end
@@ -39,7 +39,7 @@ RSpec.describe 'Schema with each and set rules' do
       }
 
       expect(schema.(input).messages).to eql(
-        payments: { 1 => { method: ['is missing'] } }
+        payments: { 1 => { method: ['is missing', 'must be a string'] } }
       )
     end
 

--- a/spec/integration/schema/json_spec.rb
+++ b/spec/integration/schema/json_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Dry::Schema, 'defining a schema with json coercion' do
 
       expect(result.messages).to eql(
         email: ['must be filled'],
-        address: ['is missing'],
+        address: ['is missing', 'must be a hash']
       )
 
       expect(result.output).to eql(email: '', age: 19)
@@ -44,7 +44,7 @@ RSpec.describe Dry::Schema, 'defining a schema with json coercion' do
 
       expect(result.messages).to eql(
         address: {
-          loc: { lat: ['must be a float'], lng: ['must be filled'] },
+          loc: { lat: ['must be a float'], lng: ['must be a float'] },
           city: ['must be filled']
         }
       )
@@ -78,7 +78,7 @@ RSpec.describe Dry::Schema, 'defining a schema with json coercion' do
       result = schema.('email' => '', 'age' => 18)
 
       expect(result.messages).to eql(
-        address: ['is missing'],
+        address: ['is missing', 'must be a hash'],
         age: ['must be greater than 18'],
         email: ['must be filled']
       )

--- a/spec/integration/schema/macros/filled_spec.rb
+++ b/spec/integration/schema/macros/filled_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Macros #filled' do
 
     it 'generates str? && filled? rule' do
       expect(schema.(age: nil).messages).to eql(
-        age: ['must be filled']
+        age: ['must be a string']
       )
     end
   end

--- a/spec/integration/schema/nested_schemas_spec.rb
+++ b/spec/integration/schema/nested_schemas_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe Dry::Schema, 'nested schemas' do
 
     it 'fails when one sub-key is missing' do
       input = {content: {data: {city: "Canberra"}}}
-      expect(schema.(input).messages).to eql(content: {meta: ['is missing']})
+      expect(schema.(input).messages).to eql(content: {meta: ['is missing', 'must be a hash']})
     end
 
     it 'fails when both sub-keys are missing' do
       input = {content: {}}
-      expect(schema.(input).messages).to eql(content: {meta: ['is missing'], data: ['is missing']})
+      expect(schema.(input).messages).to eql(content: {meta: ['is missing', 'must be a hash'], data: ['is missing', 'must be a hash']})
     end
 
     it 'fails when the deeply nested keys are invalid' do
@@ -55,18 +55,18 @@ RSpec.describe Dry::Schema, 'nested schemas' do
     end
 
     it 'fails when root key is missing' do
-      expect(schema.({}).messages).to eql(meta: ['is missing'])
+      expect(schema.({}).messages).to eql(meta: ['is missing', 'must be a hash'])
     end
 
     it 'fails when 1-level key is missing' do
       expect(schema.(meta: {}).messages).to eql(
-        meta: { info: ['is missing'] }
+        meta: { info: ['is missing', 'must be a hash'] }
       )
     end
 
     it 'fails when 2-level key is missing' do
       expect(schema.(meta: { info: {} }).messages).to eql(
-        meta: { info: { details: ['is missing'], meta: ['is missing'] } }
+        meta: { info: { details: ['is missing', 'must be a string'], meta: ['is missing', 'must be a string'] } }
       )
     end
 
@@ -78,7 +78,7 @@ RSpec.describe Dry::Schema, 'nested schemas' do
 
     it 'fails when 2-level key has invalid value' do
       expect(schema.(meta: { info: { details: nil, meta: 'foo' } }).messages).to eql(
-        meta: { info: { details: ['must be filled'] } }
+        meta: { info: { details: ['must be a string'] } }
       )
     end
   end
@@ -97,11 +97,11 @@ RSpec.describe Dry::Schema, 'nested schemas' do
     end
 
     it 'fails when root key is missing' do
-      expect(schema.({}).messages).to eql(meta: ['is missing'])
+      expect(schema.({}).messages).to eql(meta: ['is missing', 'must be a hash'])
     end
 
     it 'fails when 1-level key is missing' do
-      expect(schema.(meta: {}).messages).to eql(meta: { meta: ['is missing'] })
+      expect(schema.(meta: {}).messages).to eql(meta: { meta: ['is missing', 'must be a string'] })
     end
 
     it 'fails when 1-level key value is invalid' do
@@ -127,11 +127,11 @@ RSpec.describe Dry::Schema, 'nested schemas' do
     end
 
     it 'fails when root key is missing' do
-      expect(schema.({}).messages).to eql(meta: ['is missing'])
+      expect(schema.({}).messages).to eql(meta: ['is missing', 'must be a hash'])
     end
 
     it 'fails when 1-level key is missing' do
-      expect(schema.(meta: {}).messages).to eql(meta: { meta: ['is missing'] })
+      expect(schema.(meta: {}).messages).to eql(meta: { meta: ['is missing', 'must be a hash'] })
     end
 
     it 'fails when 1-level key value is invalid' do
@@ -142,7 +142,7 @@ RSpec.describe Dry::Schema, 'nested schemas' do
 
     it 'fails when 2-level key is missing' do
       expect(schema.(meta: { meta: {} }).messages).to eql(
-        meta: { meta: { data: ['is missing'] } }
+        meta: { meta: { data: ['is missing', 'must be a string'] } }
       )
     end
 
@@ -173,7 +173,7 @@ RSpec.describe Dry::Schema, 'nested schemas' do
     end
 
     it 'fails when root key is missing' do
-      expect(schema.({}).messages).to eql(meta: ['is missing'])
+      expect(schema.({}).messages).to eql(meta: ['is missing', 'must be a hash'])
     end
 
     it 'fails when root key value is invalid' do
@@ -181,7 +181,7 @@ RSpec.describe Dry::Schema, 'nested schemas' do
     end
 
     it 'fails when 1-level key is missing' do
-      expect(schema.(meta: {}).messages).to eql(meta: { data: ['is missing'] })
+      expect(schema.(meta: {}).messages).to eql(meta: { data: ['is missing', 'must be an array'] })
     end
 
     it 'fails when 1-level key has invalid value' do
@@ -190,7 +190,7 @@ RSpec.describe Dry::Schema, 'nested schemas' do
 
     it 'fails when 1-level key has value with a missing key' do
       expect(schema.(meta: { data: [{}] }).messages).to eql(
-        meta: { data: { 0 => { info: ['is missing'] } } }
+        meta: { data: { 0 => { info: ['is missing', 'must be a hash'] } } }
       )
     end
 
@@ -228,7 +228,7 @@ RSpec.describe Dry::Schema, 'nested schemas' do
 
     it 'fails when 1-level element is not valid' do
       expect(schema.(data: [{}]).messages).to eql(
-        data: { 0 => { tags: ['is missing'] } }
+        data: { 0 => { tags: ['is missing', 'must be an array'] } }
       )
     end
 

--- a/spec/integration/schema/predicates/array_spec.rb
+++ b/spec/integration/schema/predicates/array_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Predicates: Array' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing']
+        expect(result).to be_failing ['is missing', 'must be an array']
       end
     end
 

--- a/spec/integration/schema/predicates/hash_spec.rb
+++ b/spec/integration/schema/predicates/hash_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Predicates: hash?' do
         let(:input) { {} }
 
         it 'is not successful' do
-          expect(result).to be_failing ['is missing']
+          expect(result).to be_failing ['is missing', 'must be a hash']
         end
       end
     end

--- a/spec/integration/schema/predicates/key_spec.rb
+++ b/spec/integration/schema/predicates/key_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Predicates: Key' do
     end
 
     it 'uses key? predicate for required' do
-      expect(schema.({}).messages(full: true)).to eql(foo: ['foo is missing'])
-      expect(schema.({}).messages).to eql(foo: ['is missing'])
+      expect(schema.({}).messages(full: true)).to eql(foo: ['foo is missing', 'foo must be a string'])
+      expect(schema.({}).messages).to eql(foo: ['is missing', 'must be a string'])
     end
   end
 

--- a/spec/integration/schema/predicates/nil_spec.rb
+++ b/spec/integration/schema/predicates/nil_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Predicates: None' do
       let(:input) { {} }
 
       it 'is not successful' do
-        expect(result).to be_failing ['is missing']
+        expect(result).to be_failing ['is missing', 'cannot be defined']
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe 'Predicates: None' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'cannot be defined']
           end
         end
 
@@ -132,7 +132,7 @@ RSpec.describe 'Predicates: None' do
           let(:input) { {} }
 
           it 'is not successful' do
-            expect(result).to be_failing ['is missing']
+            expect(result).to be_failing ['is missing', 'cannot be defined']
           end
         end
 

--- a/spec/shared/message_compiler.rb
+++ b/spec/shared/message_compiler.rb
@@ -6,6 +6,6 @@ RSpec.shared_context :message_compiler do
   end
 
   let(:result) do
-    compiler.public_send(visitor, node)
+    compiler.public_send(visitor, node, Dry::Schema::MessageCompiler::EMPTY_OPTS.dup)
   end
 end

--- a/spec/unit/dry/schema/params_spec.rb
+++ b/spec/unit/dry/schema/params_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dry::Schema::Params do
     it 'returns a params schema instance' do
       schema = klass.new
 
-      expect(schema.('name' => 'Jane', 'age' => '').errors).to eql(age: ['must be filled'])
+      expect(schema.('name' => 'Jane', 'age' => '').errors).to eql(age: ['must be an integer'])
     end
 
     it 'raises exception when definition is missing' do


### PR DESCRIPTION
Filter out hints in a smarter way by looking at other generated hints and failures.

Fixes #24 
Fixes #26 
