### PR TITLE
Refine `schema` macro and introduce `hash` macro

### DIFF
--- a/lib/dry/schema/macros.rb
+++ b/lib/dry/schema/macros.rb
@@ -1,5 +1,6 @@
 require 'dry/schema/macros/each'
 require 'dry/schema/macros/filled'
+require 'dry/schema/macros/schema'
 require 'dry/schema/macros/hash'
 require 'dry/schema/macros/maybe'
 require 'dry/schema/macros/optional'

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -35,10 +35,21 @@ module Dry
           end
         end
 
-        # Specify a nested schema
+        # Specify a nested hash without enforced hash? type-check
         #
         # @api public
         def schema(*args, &block)
+          append_macro(Macros::Schema) do |macro|
+            macro.call(*args, &block)
+          end
+        end
+
+        # Specify a nested hash with enforced hash? type-check
+        #
+        # @see #schema
+        #
+        # @api public
+        def hash(*args, &block)
           append_macro(Macros::Hash) do |macro|
             macro.call(*args, &block)
           end

--- a/lib/dry/schema/macros/hash.rb
+++ b/lib/dry/schema/macros/hash.rb
@@ -1,4 +1,4 @@
-require 'dry/schema/macros/value'
+require 'dry/schema/macros/schema'
 
 module Dry
   module Schema
@@ -6,38 +6,11 @@ module Dry
       # Macro used to specify a nested schema
       #
       # @api public
-      class Hash < Value
+      class Hash < Schema
         # @api private
         def call(*args, &block)
           trace << hash?
-
-          super(*args) unless args.empty?
-
-          if block
-            definition = schema_dsl.new(&block)
-
-            parent_type = schema_dsl.types[name]
-            definition_schema = definition.type_schema
-
-            schema_type =
-              if parent_type.respond_to?(:of)
-                parent_type.of(definition_schema)
-              else
-                definition_schema
-              end
-
-            final_type =
-              if schema_dsl.maybe?(parent_type)
-                schema_type.optional
-              else
-                schema_type
-              end
-
-            schema_dsl.set_type(name, final_type)
-
-            trace << definition.to_rule
-          end
-
+          super(*args, &block)
           self
         end
       end

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -104,7 +104,7 @@ module Dry
         def extract_type_spec(*args, nullable: false)
           type_spec = args[0]
 
-          if type_spec.kind_of?(Schema::Processor) || type_spec.is_a?(Symbol) && type_spec.to_s.end_with?(QUESTION_MARK)
+          if type_spec.kind_of?(Dry::Schema::Processor) || type_spec.is_a?(Symbol) && type_spec.to_s.end_with?(QUESTION_MARK)
             type_spec = nil
           end
 

--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -1,0 +1,44 @@
+require 'dry/schema/macros/value'
+
+module Dry
+  module Schema
+    module Macros
+      # Macro used to specify a nested schema
+      #
+      # @api public
+      class Schema < Value
+        # @api private
+        def call(*args, &block)
+          super(*args) unless args.empty?
+
+          if block
+            definition = schema_dsl.new(&block)
+
+            parent_type = schema_dsl.types[name]
+            definition_schema = definition.type_schema
+
+            schema_type =
+              if parent_type.respond_to?(:of)
+                parent_type.of(definition_schema)
+              else
+                definition_schema
+              end
+
+            final_type =
+              if schema_dsl.maybe?(parent_type)
+                schema_type.optional
+              else
+                schema_type
+              end
+
+            schema_dsl.set_type(name, final_type)
+
+            trace << definition.to_rule
+          end
+
+          self
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Validation hints' do
       Dry::Schema.define do
         required(:code).filled(:str?, eql?: 'foo')
 
-        required(:nested).schema do
+        required(:nested).hash do
           required(:code).filled(:str?, eql?: 'bar')
         end
       end
@@ -168,7 +168,7 @@ RSpec.describe 'Validation hints' do
   context 'disjunctions on an optional key' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:attributes).schema do
+        required(:attributes).hash do
           optional(:text) { int? | nil? }
         end
       end

--- a/spec/integration/messages/namespaced_spec.rb
+++ b/spec/integration/messages/namespaced_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Namespaced messages' do
         config.namespace = :post
 
         required(:post_body).filled
-        required(:comment).schema(::Test::CommentSchema)
+        required(:comment).hash(::Test::CommentSchema)
       end
     end
 

--- a/spec/integration/optional_keys_spec.rb
+++ b/spec/integration/optional_keys_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Dry::Schema do
       Dry::Schema.define do
         optional(:email).value(:filled?)
 
-        required(:address).schema do
+        required(:address).hash do
           required(:city).value(:filled?)
           required(:street).value(:filled?)
 

--- a/spec/integration/result/error_predicate_spec.rb
+++ b/spec/integration/result/error_predicate_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Dry::Schema::Result, '#error?' do
   context 'with a nested hash' do
     let(:schema) do
       Dry::Schema.Params do
-        required(:user).schema do
-          required(:address).schema do
+        required(:user).hash do
+          required(:address).hash do
             required(:street).filled
           end
         end

--- a/spec/integration/schema/json_spec.rb
+++ b/spec/integration/schema/json_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Dry::Schema, 'defining a schema with json coercion' do
 
       required(:age).maybe(:integer).maybe(:int?, gt?: 18)
 
-      required(:address).value(:hash).schema do
+      required(:address).value(:hash).hash do
         required(:city).value(:string).filled
         required(:street).value(:string).filled
 
-        required(:loc).value(:hash).schema do
+        required(:loc).value(:hash).hash do
           required(:lat).filled(:float)
           required(:lng).filled(:float)
         end

--- a/spec/integration/schema/macros/hash_spec.rb
+++ b/spec/integration/schema/macros/hash_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe 'Macros #hash' do
+  subject(:schema) do
+    Dry::Schema.define do
+      required(:foo).hash do
+        required(:bar).value(:string)
+      end
+    end
+  end
+
+  context 'with valid input' do
+    let(:input) do
+      { foo: { bar: 'valid' } }
+    end
+
+    it 'is successful' do
+      expect(result).to be_successful
+    end
+  end
+
+  context 'with invalid input' do
+    let(:input) do
+      { foo: { bar: 312 } }
+    end
+
+    it 'is not successful' do
+      expect(result).to be_failing(bar: ['must be a string'])
+    end
+  end
+
+  context 'with invalid input type' do
+    let(:input) do
+      { foo: nil }
+    end
+
+    it 'is not successful' do
+      expect(result).to be_failing(['must be a hash'])
+    end
+  end
+end

--- a/spec/integration/schema/macros/schema_spec.rb
+++ b/spec/integration/schema/macros/schema_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe 'Macros #schema' do
+  subject(:schema) do
+    Dry::Schema.define do
+      required(:foo).schema do
+        required(:bar).value(:string)
+      end
+    end
+  end
+
+  context 'with valid input' do
+    let(:input) do
+      { foo: { bar: 'valid' } }
+    end
+
+    it 'is successful' do
+      expect(result).to be_successful
+    end
+  end
+
+  context 'with invalid input' do
+    let(:input) do
+      { foo: { bar: 312 } }
+    end
+
+    it 'is not successful' do
+      expect(result).to be_failing(bar: ['must be a string'])
+    end
+  end
+
+  context 'with invalid input type' do
+    let(:input) do
+      { foo: nil }
+    end
+
+    it 'crashes due to missing hash? check' do
+      expect { result }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/integration/schema/nested_schemas_spec.rb
+++ b/spec/integration/schema/nested_schemas_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'with multiple nested schemas' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:content).value(:hash).schema do
-          required(:meta).value(:hash).schema do
+        required(:content).value(:hash).hash do
+          required(:meta).value(:hash).hash do
             required(:version).value(:string).filled
           end
 
-          required(:data).value(:hash).schema do
+          required(:data).value(:hash).hash do
             required(:city).value(:string).filled
           end
         end
@@ -41,8 +41,8 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'with a 2-level deep schema' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta).schema do
-          required(:info).schema do
+        required(:meta).hash do
+          required(:info).hash do
             required(:details).filled(:string)
             required(:meta).filled(:string)
           end
@@ -86,7 +86,7 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'when duplicated key names are used in 2 subsequent levels' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta).value(:hash).schema do
+        required(:meta).value(:hash).hash do
           required(:meta).value(:string).filled
         end
       end
@@ -114,8 +114,8 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'when duplicated key names are used in 2 subsequent levels as schemas' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta).value(:hash).schema do
-          required(:meta).value(:hash).schema do
+        required(:meta).value(:hash).hash do
+          required(:meta).value(:hash).hash do
             required(:data).value(:string).filled
           end
         end
@@ -156,10 +156,10 @@ RSpec.describe Dry::Schema, 'nested schemas' do
   context 'with `each` + schema inside another schema' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:meta).value(:hash).schema do
+        required(:meta).value(:hash).hash do
           required(:data).value(:array).each do
             schema do
-              required(:info).value(:hash).schema do
+              required(:info).value(:hash).hash do
                 required(:name).value(:string).filled
               end
             end

--- a/spec/integration/schema/or_spec.rb
+++ b/spec/integration/schema/or_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dry::Schema, 'OR messages' do
   context 'with a predicate and a schema' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo) { str? | schema { required(:bar).filled } }
+        required(:foo) { str? | hash { required(:bar).filled } }
       end
     end
 

--- a/spec/integration/schema/type_spec.rb
+++ b/spec/integration/schema/type_spec.rb
@@ -79,16 +79,16 @@ RSpec.describe Dry::Schema, 'types specs' do
   context 'nested schema' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:user).type(:hash).schema do
+        required(:user).type(:hash).hash do
           required(:email).type(:string)
           required(:age).type(:integer)
 
-          required(:address).type(:hash).schema do
+          required(:address).type(:hash).hash do
             required(:street).type(:string)
             required(:city).type(:string)
             required(:zipcode).type(:string)
 
-            required(:location).type(:hash).schema do
+            required(:location).type(:hash).hash do
               required(:lat).type(:float)
               required(:lng).type(:float)
             end
@@ -129,7 +129,7 @@ RSpec.describe Dry::Schema, 'types specs' do
   context 'nested schema with arrays' do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:song).type(:hash).value(:hash?).schema do
+        required(:song).type(:hash).value(:hash?).hash do
           required(:title).type(:string)
 
           required(:tags).type(:array).value(:array?).each do

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Dry::Schema, '.define' do
   context 'nested schema' do
     subject(:schema) do
       Dry::Schema.define do
-        required(:user).schema do
+        required(:user).hash do
           required(:name).filled
           required(:age).filled(:int?)
         end

--- a/spec/unit/dry/schema/dsl_spec.rb
+++ b/spec/unit/dry/schema/dsl_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dry::Schema::DSL do
 
   describe '#schema' do
     it 'defines a rule from a nested schema' do
-      dsl.required(:user).schema do
+      dsl.required(:user).hash do
         required(:name).filled
       end
 


### PR DESCRIPTION
Previously, `schema` would implicitly add `hash?` check, this was
problematic in *some* cases. Because of this, it no longer adds this
type-check, and if you want this behavior, you can now use the new
`hash` macro.

Refs #31