### PR TITLE
Improve message compiler

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
 --require spec_helper
 --order random
+--warning

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -1,7 +1,7 @@
 en:
   dry_schema:
+    or: "or"
     errors:
-      or: "or"
       array?: "must be an array"
 
       empty?: "must be empty"

--- a/lib/dry/schema/constants.rb
+++ b/lib/dry/schema/constants.rb
@@ -6,11 +6,20 @@ module Dry
   module Schema
     include Core::Constants
 
-    InvalidSchemaError = Class.new(StandardError)
-    MissingMessageError = Class.new(StandardError)
-
     LIST_SEPARATOR = ', '
     QUESTION_MARK = '?'
     DOT = '.'
+
+    InvalidSchemaError = Class.new(StandardError)
+
+    MissingMessageError = Class.new(StandardError) do
+      # @api private
+      def initialize(path)
+        *rest, rule = path
+        super(<<~STR)
+          Message template for #{rule.inspect} under #{rest.join(DOT).inspect} was not found
+        STR
+      end
+    end
   end
 end

--- a/lib/dry/schema/constants.rb
+++ b/lib/dry/schema/constants.rb
@@ -9,6 +9,7 @@ module Dry
     InvalidSchemaError = Class.new(StandardError)
     MissingMessageError = Class.new(StandardError)
 
+    LIST_SEPARATOR = ', '
     QUESTION_MARK = '?'
     DOT = '.'
   end

--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -11,7 +11,7 @@ module Dry
     class Message
       include Dry::Equalizer(:predicate, :path, :text, :options)
 
-      attr_reader :predicate, :path, :text, :rule, :args, :options
+      attr_reader :predicate, :path, :text, :args, :options
 
       # A message sub-type used by OR operations
       #
@@ -67,15 +67,10 @@ module Dry
       # @api private
       def initialize(predicate, path, text, options)
         @predicate = predicate
-        @path = path.dup
+        @path = path
         @text = text
         @options = options
-        @rule = options[:rule] || path.last
         @args = options[:args] || EMPTY_ARRAY
-
-        if predicate == :key?
-          @path << rule
-        end
       end
 
       # Return a string representation of the message

--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -43,7 +43,7 @@ module Dry
         #
         # @api public
         def to_s
-          uniq.join(" #{messages[:or].()} ")
+          uniq.join(" #{messages[:or]} ")
         end
 
         # @api private

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -47,11 +47,6 @@ module Dry
       end
 
       # @api private
-      def full?
-        @full
-      end
-
-      # @api private
       def with(new_options)
         return self if new_options.empty?
 
@@ -184,7 +179,7 @@ module Dry
       def message_text(template, tokens, options)
         text = template[template.data(tokens)]
 
-        return text unless full?
+        return text unless full
 
         rule = options[:path].last
         "#{messages.rule(rule, options) || rule} #{text}"

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dry/initializer'
+
 require 'dry/schema/constants'
 require 'dry/schema/message'
 require 'dry/schema/message_set'
@@ -11,18 +13,25 @@ module Dry
     #
     # @api private
     class MessageCompiler
-      attr_reader :messages, :options, :locale, :default_lookup_options
+      extend Dry::Initializer
 
       EMPTY_OPTS = VisitorOpts.new
       LIST_SEPARATOR = ', '
 
+      param :messages
+
+      option :full, default: -> { false }
+      option :locale, default: -> { :en }
+
+      attr_reader :options
+
+      attr_reader :default_lookup_options
+
       # @api private
-      def initialize(messages, options = {})
-        @messages = messages
+      def initialize(messages, options = EMPTY_HASH)
+        super
         @options = options
-        @full = @options.fetch(:full, false)
-        @locale = @options[:locale]
-        @default_lookup_options = @locale ? { locale: locale } : EMPTY_HASH
+        @default_lookup_options = options[:locale] ? { locale: locale } : EMPTY_HASH
       end
 
       # @api private

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -21,7 +21,7 @@ module Dry
       }
 
       resolve_predicate = proc { |node, opts|
-        [opts.path, *node.map(&:last)]
+        [Array(opts.path), *node.map(&:last)]
       }
 
       DEFAULT_PREDICATE_RESOLVERS = Hash
@@ -120,7 +120,7 @@ module Dry
         path, *arg_vals, input = predicate_resolvers[predicate].(args, opts)
 
         options = opts.dup.update(
-          path: path, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
+          path: path.last, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
         )
 
         template = messages[predicate, options] || raise(MissingMessageError, path)
@@ -176,7 +176,7 @@ module Dry
 
         return text unless full
 
-        rule = options[:path].last
+        rule = options[:path]
         "#{messages.rule(rule, options) || rule} #{text}"
       end
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -98,7 +98,7 @@ module Dry
         left, right = node.map { |n| visit(n, opts) }
 
         if [left, right].flatten.map(&:path).uniq.size == 1
-          Message::Or.new(left, right, proc { |k| messages[k, default_lookup_options] })
+          Message::Or.new(left, right, proc { |k| messages.translate(k, default_lookup_options) })
         elsif right.is_a?(Array)
           right
         else

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -33,6 +33,7 @@ module Dry
       # @api private
       def with(new_options)
         return self if new_options.empty?
+
         self.class.new(messages, options.merge(new_options))
       end
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -116,13 +116,12 @@ module Dry
       def visit_predicate(node, opts)
         predicate, args = node
 
+        tokens = message_tokens(args)
         path, *arg_vals, input = predicate_resolvers[predicate].(args, opts)
 
-        base_opts = opts.dup
-        tokens = message_tokens(args)
-
-        options = base_opts.update(path: path, **lookup_options(arg_vals: arg_vals, input: input))
-        options.update(tokens)
+        options = opts.dup.update(
+          path: path, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
+        )
 
         template = messages[predicate, options]
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -116,12 +116,10 @@ module Dry
       def visit_predicate(node, opts)
         predicate, args = node
 
-        path, *arg_vals, val = predicate_resolvers[predicate].(args, opts)
+        path, *arg_vals, input = predicate_resolvers[predicate].(args, opts)
 
         base_opts = opts.dup
         tokens = message_tokens(args)
-
-        input = val != Undefined ? val : nil
 
         options = base_opts.update(path: path, **lookup_options(arg_vals: arg_vals, input: input))
         options.update(tokens)
@@ -168,10 +166,10 @@ module Dry
       end
 
       # @api private
-      def lookup_options(arg_vals: [], input: nil)
+      def lookup_options(arg_vals:, input:)
         default_lookup_options.merge(
           arg_type: arg_vals.size == 1 && arg_vals[0].class,
-          val_type: input.class
+          val_type: input.equal?(Undefined) ? NilClass : input.class
         )
       end
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -16,7 +16,6 @@ module Dry
       extend Dry::Initializer
 
       EMPTY_OPTS = VisitorOpts.new
-      LIST_SEPARATOR = ', '
 
       param :messages
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -123,9 +123,7 @@ module Dry
           path: path, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
         )
 
-        template = messages[predicate, options]
-
-        template || raise(MissingMessageError, "message for #{predicate} was not found")
+        template = messages[predicate, options] || raise(MissingMessageError, path)
 
         text = message_text(template, tokens, options)
 

--- a/lib/dry/schema/message_compiler/visitor_opts.rb
+++ b/lib/dry/schema/message_compiler/visitor_opts.rb
@@ -15,7 +15,6 @@ module Dry
         def self.new
           opts = super
           opts[:path] = EMPTY_ARRAY
-          opts[:rule] = nil
           opts[:message_type] = :failure
           opts[:current_messages] = EMPTY_ARRAY.dup
           opts

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -108,8 +108,6 @@ module Dry
             message_type: options[:message_type] || :failure
           )
 
-          tokens[:path] = Array(options[:path]).last
-
           opts = options.select { |k, _| !config.lookup_options.include?(k) }
 
           path = lookup_paths(tokens).detect do |key|

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -71,6 +71,11 @@ module Dry
         end
 
         # @api private
+        def translate(key, locale: default_locale)
+          t["dry_schema.#{key}", locale: locale]
+        end
+
+        # @api private
         def rule(name, options = {})
           tokens = { name: name, locale: options.fetch(:locale, default_locale) }
           path = rule_lookup_paths(tokens).detect { |key| key?(key, options) }

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -103,7 +103,7 @@ module Dry
             message_type: options[:message_type] || :failure
           )
 
-          tokens[:path] = options[:rule] || Array(options[:path]).last
+          tokens[:path] = Array(options[:path]).last
 
           opts = options.select { |k, _| !config.lookup_options.include?(k) }
 

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -14,7 +14,7 @@ module Dry
     class Messages::YAML < Messages::Abstract
       include Dry::Equalizer(:data)
 
-      attr_reader :data
+      attr_reader :data, :t
 
       # @api private
       configure do |config|
@@ -45,6 +45,7 @@ module Dry
       def initialize(data)
         super()
         @data = data
+        @t = proc { |key, locale: default_locale| get("%{locale}.#{key}", locale: locale) }
       end
 
       # Get a message for the given key and its options

--- a/spec/fixtures/locales/pl.yml
+++ b/spec/fixtures/locales/pl.yml
@@ -1,5 +1,6 @@
 pl:
   dry_schema:
+    or: "lub"
     rules:
       email: "Adres mailowy"
     company:

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -95,6 +95,13 @@ RSpec.describe Dry::Schema::Messages::I18n do
     end
   end
 
+  describe '#translate' do
+    it 'translates raw paths to stored translation texts' do
+      expect(messages.translate(:or)).to eql('lub')
+      expect(messages.translate(:or, locale: :en)).to eql('or')
+    end
+  end
+
   describe '#rule' do
     it 'returns rule name using default locale' do
       expect(messages.rule(:email)).to eql('Adres mailowy')

--- a/spec/integration/optional_keys_spec.rb
+++ b/spec/integration/optional_keys_spec.rb
@@ -43,4 +43,26 @@ RSpec.describe Dry::Schema do
       expect(result).to be_success
     end
   end
+
+  describe 'defining schema with optional key that can be an array with hashes' do
+    subject(:schema) do
+      Dry::Schema.define do
+        optional(:contacts).array do
+          hash do
+            required(:name).filled
+          end
+        end
+      end
+    end
+
+    it 'produces correct errors when array has an empty element' do
+      expect(schema.(contacts: [{}]).errors)
+        .to eql(contacts: { 0 => { name: ['is missing'] } })
+    end
+
+    it 'produces correct errors when array has an invalid element' do
+      expect(schema.(contacts: [{ name: nil }]).errors)
+        .to eql(contacts: { 0 => { name: ['must be filled'] } })
+    end
+  end
 end

--- a/spec/unit/dry/schema/message_compiler/visit_failure_spec.rb
+++ b/spec/unit/dry/schema/message_compiler/visit_failure_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Dry::Schema::MessageCompiler, '#visit_failure' do
     end
 
     it 'returns a message for :int? failure with :rule name inferred from key-rule' do
-      expect(result.rule).to be(:age)
       expect(result.path).to eql([:age])
       expect(result).to eql('must be an integer')
     end
@@ -26,13 +25,11 @@ RSpec.describe Dry::Schema::MessageCompiler, '#visit_failure' do
     end
 
     it 'returns a message for the first element that failed' do
-      expect(result[0].rule).to be(:items)
       expect(result[0].path).to eql([:items, 0])
       expect(result[0]).to eql('must be an integer')
     end
 
     it 'returns a message for the third element that failed' do
-      expect(result[1].rule).to be(:items)
       expect(result[1].path).to eql([:items, 2])
       expect(result[1]).to eql('must be an integer')
     end

--- a/spec/unit/dry/schema/message_compiler/visit_spec.rb
+++ b/spec/unit/dry/schema/message_compiler/visit_spec.rb
@@ -15,4 +15,16 @@ RSpec.describe Dry::Schema::MessageCompiler, '#visit' do
       expect(result).to eql('must be an integer')
     end
   end
+
+  context 'with an unsupported predicate' do
+    let(:node) do
+      [:key, [%i[user address street], [:predicate, [:oops?, [[:input, '17']]]]]]
+    end
+
+    it 'raises MissingMessageError' do
+      expect { result }.to raise_error(Dry::Schema::MissingMessageError, <<~STR)
+        Message template for :street under "user.address" was not found
+      STR
+    end
+  end
 end

--- a/spec/unit/dry/schema/message_compiler/visit_spec.rb
+++ b/spec/unit/dry/schema/message_compiler/visit_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dry::Schema::MessageCompiler, '#visit' do
     end
 
     it 'returns a message for :int? failure with :rule name inferred from key-rule' do
-      expect(result.rule).to be(:age)
+      expect(result.path).to eql([:age])
       expect(result).to eql('must be an integer')
     end
   end


### PR DESCRIPTION
I realized there were left-overs after porting code from dry-validation, so I decided to clean it up because it made the code more complex. This also helped me fix a tricky #89 issue, which is nice.

### Changes

* `:rule` concept **was removed from the message compiler** - dry-schema no longer has arbitrary rules, every failure is identified **by the path**, where the last element is treated as the key in resulting error hash representation under which we store a list of messages. This allowed me to simplify the code **a lot**
* `MessageCompiler` was simplified in general and uses `Dry::Initializer` now
* `MessageCompiler#visit_predicate` uses `predicate_resolvers` to identify:
  * Final `path`, because `key?` predicates fail one level higher, so we need to append their `name` to the path built from failures
  * `arg_vals` - which are values of the arguments that were passed to the predicate, needed by some message templates
  * `input` - the actual original input vale that caused a failure, also needed by some message templates
* `MessageMissingError` includes a much nicer message that mentions both error key and its path ie `Message template for :street under "user.address" was not found` (this is now identical as in dry-validation, consistency ftw after all)
* `Message#lookup` has been simplified too

Fixes #89