### PR TITLE
Improved Messages API

### DIFF
--- a/dry-schema.gemspec
+++ b/dry-schema.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'dry-configurable', '~> 0.1', '>= 0.1.3'
+  spec.add_runtime_dependency 'dry-configurable', '~> 0.8', '>= 0.8.0'
   spec.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.1'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-initializer', '~> 2.4'

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -103,7 +103,7 @@ module Dry
       # @example
       #   Dry::Schema.define do
       #     configure do |config|
-      #       config.messages = :i18n
+      #       config.messages.backend = :i18n
       #     end
       #   end
       #

--- a/lib/dry/schema/messages.rb
+++ b/lib/dry/schema/messages.rb
@@ -9,27 +9,28 @@ module Dry
       module_function
 
       public def setup(config)
-        messages = build(config)
+        messages = build(config.backend)
+        namespace = config.namespace
 
-        if config.messages_file && config.namespace
-          messages.merge(config.messages_file).namespaced(config.namespace)
-        elsif config.messages_file
-          messages.merge(config.messages_file)
-        elsif config.namespace
-          messages.namespaced(config.namespace)
+        if config.load_paths.any? && namespace
+          messages.merge(config.load_paths[0]).namespaced(namespace)
+        elsif config.load_paths.any?
+          messages.merge(config.load_paths[0])
+        elsif namespace
+          messages.namespaced(namespace)
         else
           messages
         end
       end
 
       # @api private
-      def build(config)
+      def build(backend)
         klass =
-          case config.messages
+          case backend
           when :yaml then default
           when :i18n then const_get(:I18n)
           else
-            raise "+#{config.messages}+ is not a valid messages identifier"
+            raise "+#{backend}+ is not a valid messages identifier"
           end
 
         klass.build

--- a/lib/dry/schema/messages.rb
+++ b/lib/dry/schema/messages.rb
@@ -6,7 +6,9 @@ module Dry
     #
     # @api private
     module Messages
-      def self.setup(config)
+      module_function
+
+      public def setup(config)
         messages = build(config)
 
         if config.messages_file && config.namespace
@@ -21,20 +23,21 @@ module Dry
       end
 
       # @api private
-      def self.build(config)
-        klass = case config.messages
-        when :yaml then default
-        when :i18n then Messages::I18n
-        else
-          raise "+#{config.messages}+ is not a valid messages identifier"
-        end
+      def build(config)
+        klass =
+          case config.messages
+          when :yaml then default
+          when :i18n then const_get(:I18n)
+          else
+            raise "+#{config.messages}+ is not a valid messages identifier"
+          end
 
         klass.build
       end
 
       # @api private
-      def self.default
-        Messages::YAML
+      def default
+        const_get(:YAML)
       end
     end
   end

--- a/lib/dry/schema/messages.rb
+++ b/lib/dry/schema/messages.rb
@@ -13,9 +13,9 @@ module Dry
         namespace = config.namespace
 
         if config.load_paths.any? && namespace
-          messages.merge(config.load_paths[0]).namespaced(namespace)
+          messages.merge(config.load_paths).namespaced(namespace)
         elsif config.load_paths.any?
-          messages.merge(config.load_paths[0])
+          messages.merge(config.load_paths)
         elsif namespace
           messages.namespaced(namespace)
         else

--- a/lib/dry/schema/messages.rb
+++ b/lib/dry/schema/messages.rb
@@ -11,10 +11,11 @@ module Dry
       public def setup(config)
         messages = build(config.backend)
         namespace = config.namespace
+        load_paths = config.load_paths
 
-        if config.load_paths.any? && namespace
+        if !load_paths.empty? && namespace
           messages.merge(config.load_paths).namespaced(namespace)
-        elsif config.load_paths.any?
+        elsif !load_paths.empty?
           messages.merge(config.load_paths)
         elsif namespace
           messages.namespaced(namespace)

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -57,13 +57,15 @@ module Dry
 
       # Merge messages from an additional path
       #
-      # @param [String] path
+      # @param [String, Array<String>] paths
       #
       # @return [Messages::I18n]
       #
       # @api public
-      def merge(path)
-        ::I18n.load_path << path
+      def merge(paths)
+        ::I18n.load_path.concat(Array(paths))
+        ::I18n.backend.load_translations
+        ::I18n.reload!
         self
       end
 

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -88,7 +88,9 @@ module Dry
         if overrides.is_a?(Hash)
           self.class.new(data.merge(self.class.flat_hash(overrides)))
         else
-          self.class.new(data.merge(Messages::YAML.load_file(overrides)))
+          self.class.new(
+            Array(overrides).reduce(data) { |a, e| a.merge(Messages::YAML.load_file(e)) }
+          )
         end
       end
     end

--- a/lib/dry/schema/rule_applier.rb
+++ b/lib/dry/schema/rule_applier.rb
@@ -20,10 +20,10 @@ module Dry
       param :rules
 
       # @api private
-      option :config, default: proc { Config.new }
+      option :config, default: -> { Config.new }
 
       # @api private
-      option :message_compiler, default: proc { MessageCompiler.new(Messages.setup(config.messages)) }
+      option :message_compiler, default: -> { MessageCompiler.new(Messages.setup(config.messages)) }
 
       # @api private
       def call(input)
@@ -31,6 +31,7 @@ module Dry
 
         rules.each do |name, rule|
           next if input.error?(name)
+
           result = rule.(input)
           results << result if result.failure?
         end

--- a/lib/dry/schema/rule_applier.rb
+++ b/lib/dry/schema/rule_applier.rb
@@ -23,7 +23,7 @@ module Dry
       option :config, default: proc { Config.new }
 
       # @api private
-      option :message_compiler, default: proc { MessageCompiler.new(Messages.setup(config)) }
+      option :message_compiler, default: proc { MessageCompiler.new(Messages.setup(config.messages)) }
 
       # @api private
       def call(input)
@@ -40,8 +40,8 @@ module Dry
 
       # @api private
       def to_ast
-        if config.namespace
-          [:namespace, [config.namespace, [:set, rules.values.map(&:to_ast)]]]
+        if config.messages.namespace
+          [:namespace, [config.messages.namespace, [:set, rules.values.map(&:to_ast)]]]
         else
           [:set, rules.values.map(&:to_ast)]
         end

--- a/spec/integration/custom_error_messages_spec.rb
+++ b/spec/integration/custom_error_messages_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dry::Schema do
     subject(:schema) do
       Dry::Schema.define do
         configure do
-          config.messages_file = SPEC_ROOT.join('fixtures/locales/en.yml')
+          config.messages.load_paths << SPEC_ROOT.join('fixtures/locales/en.yml')
         end
 
         required(:email).value(:filled?)
@@ -37,7 +37,7 @@ RSpec.describe Dry::Schema do
       subject(:schema) do
         Dry::Schema.define do
           configure do
-            config.messages = :i18n
+            config.messages.backend = :i18n
           end
 
           required(:email).value(:filled?)

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Validation hints' do
   context 'with i18n messages' do
     subject(:schema) do
       Dry::Schema.define do
-        configure { |c| c.messages = :i18n }
+        config.messages.backend = :i18n
 
         required(:age).maybe(:int?, gt?: 18)
       end
@@ -148,7 +148,7 @@ RSpec.describe 'Validation hints' do
   context 'when the message uses input value' do
     subject(:schema) do
       Dry::Schema.define do
-        configure { |c| c.messages_file = SPEC_ROOT.join('fixtures/messages.yml') }
+        configure { |c| c.messages.load_paths << SPEC_ROOT.join('fixtures/messages.yml') }
 
         required(:pill).filled(eql?: 'blue')
       end

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -4,10 +4,7 @@ require 'dry/schema/messages/i18n'
 
 RSpec.describe Dry::Schema, 'with localized messages' do
   before do
-    I18n.config.available_locales = [:en, :pl]
-    I18n.load_path.concat(%w(en pl).map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") })
-    I18n.backend.load_translations
-    I18n.reload!
+    I18n.config.available_locales = %i[en pl]
   end
 
   describe 'defining schema' do
@@ -15,6 +12,8 @@ RSpec.describe Dry::Schema, 'with localized messages' do
       subject(:schema) do
         Dry::Schema.define do
           config.messages.backend = :i18n
+          config.messages.load_paths = %w[en pl]
+            .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
           required(:email).value(:filled?)
         end
@@ -34,6 +33,8 @@ RSpec.describe Dry::Schema, 'with localized messages' do
         Dry::Schema.define do
           config.messages.backend = :i18n
           config.messages.namespace = :user
+          config.messages.load_paths = %w[en pl]
+            .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
           required(:email).value(:filled?)
         end

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe Dry::Schema, 'with localized messages' do
     context 'without a namespace' do
       subject(:schema) do
         Dry::Schema.define do
-          configure do
-            config.messages = :i18n
-          end
+          config.messages.backend = :i18n
 
           required(:email).value(:filled?)
         end
@@ -34,12 +32,8 @@ RSpec.describe Dry::Schema, 'with localized messages' do
     context 'with a namespace' do
       subject(:schema) do
         Dry::Schema.define do
-          configure do
-            configure do |config|
-              config.messages = :i18n
-              config.namespace = :user
-            end
-          end
+          config.messages.backend = :i18n
+          config.messages.namespace = :user
 
           required(:email).value(:filled?)
         end

--- a/spec/integration/messages/i18n/with_locale_spec.rb
+++ b/spec/integration/messages/i18n/with_locale_spec.rb
@@ -6,8 +6,8 @@ require 'dry/schema/messages/i18n'
 RSpec.describe 'I18n validation messages / using I18n.with_locale' do
   subject(:schema) do
     Dry::Schema.Params do
-      config.messages = :i18n
-      config.namespace = :user
+      config.messages.backend = :i18n
+      config.messages.namespace = :user
 
       required(:name).filled(:string)
     end

--- a/spec/integration/messages/namespaced_spec.rb
+++ b/spec/integration/messages/namespaced_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'Namespaced messages' do
   context 'in nested schemas' do
     let!(:comment_schema) do
       Test::CommentSchema = Dry::Schema.Params do
-        config.messages_file = "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
-        config.namespace = :comment
+        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
+        config.messages.namespace = :comment
 
         required(:comment_body).filled
       end
@@ -15,8 +15,8 @@ RSpec.describe 'Namespaced messages' do
 
     let(:post_schema) do
       Test::PostSchema = Dry::Schema.Params do
-        config.messages_file = "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
-        config.namespace = :post
+        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
+        config.messages.namespace = :post
 
         required(:post_body).filled
         required(:comment).hash(::Test::CommentSchema)

--- a/spec/integration/schema/defining_base_schema_spec.rb
+++ b/spec/integration/schema/defining_base_schema_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Defining base schema class' do
   let(:parent) do
     Dry::Schema.define do
       configure do |config|
-        config.messages = :i18n
+        config.messages.backend = :i18n
       end
 
       optional(:email).filled
@@ -28,20 +28,20 @@ RSpec.describe 'Defining base schema class' do
   end
 
   it 'inherits config' do
-    expect(schema.config.messages).to eql(:i18n)
+    expect(schema.config.messages.backend).to eql(:i18n)
   end
 
   context 'when child schema defines config' do
     subject(:schema) do
       Dry::Schema.define(parent: parent) do
         configure do |config|
-          config.messages = :yaml
+          config.messages.backend = :yaml
         end
       end
     end
 
     it 'overrides parent config' do
-      expect(schema.config.messages).to eql(:yaml)
+      expect(schema.config.messages.backend).to eql(:yaml)
     end
   end
 end

--- a/spec/unit/dry/schema/config_spec.rb
+++ b/spec/unit/dry/schema/config_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe Dry::Schema::Config do
 
   describe '#messages' do
     it 'returns default value' do
-      expect(config.messages).to be(:yaml)
+      expect(config.messages.backend).to be(:yaml)
     end
 
     it 'returns overridden value' do
       config.configure do |config|
-        config.messages = :i18n
+        config.messages.backend = :i18n
       end
 
-      expect(config.messages).to be(:i18n)
+      expect(config.messages.backend).to be(:i18n)
     end
   end
 end

--- a/spec/unit/dry/schema/params_spec.rb
+++ b/spec/unit/dry/schema/params_spec.rb
@@ -50,9 +50,7 @@ RSpec.describe Dry::Schema::Params do
     let(:parent_class) do
       class Test::UserSchema < Dry::Schema::Params
         define do
-          configure do |config|
-            config.messages = :i18n
-          end
+          config.messages.backend = :i18n
 
           required(:name).filled(:string)
         end
@@ -72,7 +70,7 @@ RSpec.describe Dry::Schema::Params do
 
       expect(schema.('name' => '', 'age' => '18').errors).to eql(name: ['must be filled'])
       expect(schema.('name' => 'Jane', 'age' => 'foo').errors).to eql(age: ['must be an integer'])
-      expect(schema.config.messages).to eql(:i18n)
+      expect(schema.config.messages.backend).to eql(:i18n)
     end
   end
 

--- a/spec/unit/dry/schema/schema_spec.rb
+++ b/spec/unit/dry/schema/schema_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dry::Schema do
 
     context 'with i18n setting' do
       let(:schema) do
-        Dry::Schema.define { configure { config.messages = :i18n } }
+        Dry::Schema.define { configure { config.messages.backend = :i18n } }
       end
 
       it 'returns default i18n messages' do
@@ -28,7 +28,7 @@ RSpec.describe Dry::Schema do
 
     context 'with an invalid setting' do
       let(:schema) do
-        Dry::Schema.define { configure { config.messages = :oops } }
+        Dry::Schema.define { configure { config.messages.backend = :oops } }
       end
 
       it 'returns default i18n messages' do


### PR DESCRIPTION
This cleans up `Messages` configuration and makes it reusable, new config looks like this:

``` ruby
Dry::Schema.Params do
  config.messages.backend = :i18n
  config.messages.load_paths << path_to_my_locales
  config.messages.namespace = :user
end
```

Notice that `load_paths` is an array and we now support more than one load path.