### PR TITLE
Make top level locale namespace configurable

### DIFF
--- a/lib/dry/schema.rb
+++ b/lib/dry/schema.rb
@@ -38,15 +38,6 @@ module Dry
     def self.JSON(**options, &block)
       define(**options, processor_type: JSON, &block)
     end
-
-    # Return configured paths to message files
-    #
-    # @return [Array<String>]
-    #
-    # @api public
-    def self.messages_paths
-      Messages::Abstract.config.paths
-    end
   end
 end
 

--- a/lib/dry/schema/config.rb
+++ b/lib/dry/schema/config.rb
@@ -2,6 +2,8 @@
 
 require 'dry/equalizer'
 require 'dry/configurable'
+
+require 'dry/schema/constants'
 require 'dry/schema/predicate_registry'
 
 module Dry
@@ -20,7 +22,8 @@ module Dry
       setting(:messages) do
         setting(:backend, :yaml)
         setting(:namespace)
-        setting(:load_paths, EMPTY_ARRAY, &:dup)
+        setting(:load_paths, Set[DEFAULT_MESSAGES_PATH], &:dup)
+        setting(:top_namespace, DEFAULT_MESSAGES_ROOT)
       end
 
       # Return configured predicate registry

--- a/lib/dry/schema/constants.rb
+++ b/lib/dry/schema/constants.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'pathname'
 require 'dry/core/constants'
 
 module Dry
@@ -9,6 +10,9 @@ module Dry
     LIST_SEPARATOR = ', '
     QUESTION_MARK = '?'
     DOT = '.'
+
+    DEFAULT_MESSAGES_PATH = Pathname(__dir__).join('../../../config/errors.yml').realpath.freeze
+    DEFAULT_MESSAGES_ROOT = 'dry_schema'
 
     InvalidSchemaError = Class.new(StandardError)
 

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -15,12 +15,14 @@ module Dry
       #
       # @api public
       class Abstract
-        extend Dry::Configurable
+        include Dry::Configurable
         include Dry::Equalizer(:config)
 
         DEFAULT_PATH = Pathname(__dir__).join('../../../../config/errors.yml').realpath.freeze
+        DEFAULT_TOP_NAMESPACE = 'dry_schema'
 
         setting :paths, [DEFAULT_PATH]
+        setting :top_namespace, DEFAULT_TOP_NAMESPACE
         setting :root, 'errors'
         setting :lookup_options, [:root, :predicate, :path, :val_type, :arg_type].freeze
 
@@ -40,14 +42,11 @@ module Dry
           rules.%{name}
         ).freeze
 
-        setting :arg_type_default, 'default'
-        setting :val_type_default, 'default'
-
-        setting :arg_types, Hash.new { |*| config.arg_type_default }.update(
+        setting :arg_types, Hash.new { |*| 'default' }.update(
           Range => 'range'
         )
 
-        setting :val_types, Hash.new { |*| config.val_type_default }.update(
+        setting :val_types, Hash.new { |*| 'default' }.update(
           Range => 'range',
           String => 'string'
         )
@@ -58,21 +57,13 @@ module Dry
         end
 
         # @api private
-        attr_reader :config
-
-        # @api private
-        def initialize
-          @config = self.class.config
-        end
-
-        # @api private
         def hash
           @hash ||= config.hash
         end
 
         # @api private
         def translate(key, locale: default_locale)
-          t["dry_schema.#{key}", locale: locale]
+          t["#{config.top_namespace}.#{key}", locale: locale]
         end
 
         # @api private
@@ -133,7 +124,7 @@ module Dry
         #
         # @api public
         def namespaced(namespace)
-         Dry::Schema::Messages::Namespaced.new(namespace, self)
+          Dry::Schema::Messages::Namespaced.new(namespace, self)
         end
 
         # Return root path to messages file

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -158,6 +158,13 @@ module Dry
         def default_locale
           :en
         end
+
+        private
+
+        # @api private
+        def custom_top_namespace?(path)
+          path.to_s == DEFAULT_PATH.to_s && config.top_namespace != DEFAULT_TOP_NAMESPACE
+        end
       end
     end
   end

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pathname'
+require 'set'
 require 'concurrent/map'
 require 'dry/equalizer'
 require 'dry/configurable'
@@ -18,11 +18,8 @@ module Dry
         include Dry::Configurable
         include Dry::Equalizer(:config)
 
-        DEFAULT_PATH = Pathname(__dir__).join('../../../../config/errors.yml').realpath.freeze
-        DEFAULT_TOP_NAMESPACE = 'dry_schema'
-
-        setting :paths, [DEFAULT_PATH]
-        setting :top_namespace, DEFAULT_TOP_NAMESPACE
+        setting :load_paths, Set[DEFAULT_MESSAGES_PATH]
+        setting :top_namespace, DEFAULT_MESSAGES_ROOT
         setting :root, 'errors'
         setting :lookup_options, %i[root predicate path val_type arg_type].freeze
 
@@ -169,7 +166,7 @@ module Dry
 
         # @api private
         def custom_top_namespace?(path)
-          path.to_s == DEFAULT_PATH.to_s && config.top_namespace != DEFAULT_TOP_NAMESPACE
+          path.to_s == DEFAULT_MESSAGES_PATH.to_s && config.top_namespace != DEFAULT_MESSAGES_ROOT
         end
       end
     end

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -55,6 +55,23 @@ module Dry
         end
 
         # @api private
+        def self.build(options = EMPTY_HASH)
+          messages = new
+
+          messages.configure do |config|
+            options.each do |key, value|
+              config.public_send(:"#{key}=", value)
+            end
+
+            yield(config)
+          end
+
+          messages.prepare
+
+          messages
+        end
+
+        # @api private
         def hash
           @hash ||= config.hash
         end

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -67,8 +67,6 @@ module Dry
           end
 
           messages.prepare
-
-          messages
         end
 
         # @api private

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -24,23 +24,21 @@ module Dry
         setting :paths, [DEFAULT_PATH]
         setting :top_namespace, DEFAULT_TOP_NAMESPACE
         setting :root, 'errors'
-        setting :lookup_options, [:root, :predicate, :path, :val_type, :arg_type].freeze
+        setting :lookup_options, %i[root predicate path val_type arg_type].freeze
 
-        setting :lookup_paths, %w(
-          %{root}.rules.%{path}.%{predicate}.arg.%{arg_type}
-          %{root}.rules.%{path}.%{predicate}
-          %{root}.%{predicate}.%{message_type}
-          %{root}.%{predicate}.value.%{path}.arg.%{arg_type}
-          %{root}.%{predicate}.value.%{path}
-          %{root}.%{predicate}.value.%{val_type}.arg.%{arg_type}
-          %{root}.%{predicate}.value.%{val_type}
-          %{root}.%{predicate}.arg.%{arg_type}
-          %{root}.%{predicate}
-        ).freeze
+        setting :lookup_paths, [
+          '%<root>s.rules.%<path>s.%<predicate>s.arg.%<arg_type>s',
+          '%<root>s.rules.%<path>s.%<predicate>s',
+          '%<root>s.%<predicate>s.%<message_type>s',
+          '%<root>s.%<predicate>s.value.%<path>s.arg.%<arg_type>s',
+          '%<root>s.%<predicate>s.value.%<path>s',
+          '%<root>s.%<predicate>s.value.%<val_type>s.arg.%<arg_type>s',
+          '%<root>s.%<predicate>s.value.%<val_type>s',
+          '%<root>s.%<predicate>s.arg.%<arg_type>s',
+          '%<root>s.%<predicate>s'
+        ].freeze
 
-        setting :rule_lookup_paths, %w(
-          rules.%{name}
-        ).freeze
+        setting :rule_lookup_paths, ['rules.%<name>s'].freeze
 
         setting :arg_types, Hash.new { |*| 'default' }.update(
           Range => 'range'
@@ -99,7 +97,7 @@ module Dry
             message_type: options[:message_type] || :failure
           )
 
-          opts = options.select { |k, _| !config.lookup_options.include?(k) }
+          opts = options.reject { |k, _| config.lookup_options.include?(k) }
 
           path = lookup_paths(tokens).detect do |key|
             key?(key, opts) && get(key, opts).is_a?(String)

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -63,7 +63,13 @@ module Dry
               config.public_send(:"#{key}=", value)
             end
 
-            yield(config)
+            config.root = "#{config.top_namespace}.#{config.root}"
+
+            config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
+              "#{config.top_namespace}.#{path}"
+            }
+
+            yield(config) if block_given?
           end
 
           messages.prepare

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -36,7 +36,7 @@ module Dry
       # @return [String]
       #
       # @api public
-      def get(key, options = {})
+      def get(key, options = EMPTY_HASH)
         t.(key, options) if key
       end
 

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -73,7 +73,7 @@ module Dry
         paths.each do |path|
           data = YAML.load_file(path)
 
-          if path.equal?(DEFAULT_PATH) && top_namespace != DEFAULT_TOP_NAMESPACE
+          if custom_top_namespace?(path)
             mapped_data = data
               .map { |k, v| [k, { top_namespace => v[DEFAULT_TOP_NAMESPACE] }] }
               .to_h

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -46,8 +46,8 @@ module Dry
       #
       # @api public
       def key?(key, options)
-        ::I18n.exists?(key, options.fetch(:locale, default_locale)) ||
-          ::I18n.exists?(key, I18n.default_locale)
+        I18n.exists?(key, options.fetch(:locale, default_locale)) ||
+          I18n.exists?(key, I18n.default_locale)
       end
 
       # Merge messages from an additional path
@@ -93,10 +93,10 @@ module Dry
       def store_translations(data)
         locales = data.keys.map(&:to_sym)
 
-        ::I18n.available_locales += locales
+        I18n.available_locales += locales
 
         locales.each do |locale|
-          ::I18n.backend.store_translations(locale, data[locale.to_s])
+          I18n.backend.store_translations(locale, data[locale.to_s])
         end
       end
     end

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -56,7 +56,7 @@ module Dry
       end
 
       # @api private
-      def prepare(paths = config.paths)
+      def prepare(paths = config.load_paths)
         paths.each do |path|
           data = YAML.load_file(path)
 
@@ -64,7 +64,7 @@ module Dry
             top_namespace = config.top_namespace
 
             mapped_data = data
-              .map { |k, v| [k, { top_namespace => v[DEFAULT_TOP_NAMESPACE] }] }
+              .map { |k, v| [k, { top_namespace => v[DEFAULT_MESSAGES_ROOT] }] }
               .to_h
 
             store_translations(mapped_data)

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -12,17 +12,6 @@ module Dry
       attr_reader :t
 
       # @api private
-      def self.build(options = EMPTY_HASH)
-        super do |config|
-          config.root = "#{config.top_namespace}.#{config.root}"
-
-          config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
-            "#{config.top_namespace}.#{path}"
-          }
-        end
-      end
-
-      # @api private
       def initialize
         super
         @t = I18n.method(:t)

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -11,26 +11,61 @@ module Dry
     class Messages::I18n < Messages::Abstract
       attr_reader :t
 
-      configure do |config|
-        config.root = 'dry_schema.errors'
-        config.rule_lookup_paths = config.rule_lookup_paths.map { |path| "dry_schema.#{path}" }
-      end
-
       # @api private
-      def self.build(paths = config.paths)
-        set_load_paths(paths)
-        new
-      end
+      def self.build(options = EMPTY_HASH)
+        messages = new
 
-      # @api private
-      def self.set_load_paths(paths)
-        ::I18n.load_path.concat(paths)
+        messages.configure do |config|
+          options.each do |key, value|
+            config.public_send(:"#{key}=", value)
+          end
+
+          config.root = "#{config.top_namespace}.#{config.root}"
+
+          config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
+            "#{config.top_namespace}.#{path}"
+          }
+        end
+
+        messages.prepare
+
+        messages
       end
 
       # @api private
       def initialize
         super
         @t = I18n.method(:t)
+      end
+
+      # @api private
+      def prepare
+        top_namespace = config.top_namespace
+
+        config.paths.each do |path|
+          data = YAML.load_file(path)
+
+          if path.equal?(DEFAULT_PATH) && top_namespace != DEFAULT_TOP_NAMESPACE
+            mapped_data = data
+              .map { |k, v| [k, { top_namespace => v[DEFAULT_TOP_NAMESPACE] }] }
+              .to_h
+
+            store_translations(mapped_data)
+          else
+            store_translations(data)
+          end
+        end
+      end
+
+      # @api private
+      def store_translations(data)
+        locales = data.keys.map(&:to_sym)
+
+        ::I18n.available_locales += locales
+
+        locales.each do |locale|
+          ::I18n.backend.store_translations(locale, data[locale.to_s])
+        end
       end
 
       # Get a message for the given key and its options
@@ -65,7 +100,6 @@ module Dry
       def merge(paths)
         ::I18n.load_path.concat(Array(paths))
         ::I18n.backend.load_translations
-        ::I18n.reload!
         self
       end
 

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -28,38 +28,6 @@ module Dry
         @t = I18n.method(:t)
       end
 
-      # @api private
-      def prepare(paths = config.paths)
-        top_namespace = config.top_namespace
-
-        paths.each do |path|
-          data = YAML.load_file(path)
-
-          if path.equal?(DEFAULT_PATH) && top_namespace != DEFAULT_TOP_NAMESPACE
-            mapped_data = data
-              .map { |k, v| [k, { top_namespace => v[DEFAULT_TOP_NAMESPACE] }] }
-              .to_h
-
-            store_translations(mapped_data)
-          else
-            store_translations(data)
-          end
-        end
-
-        self
-      end
-
-      # @api private
-      def store_translations(data)
-        locales = data.keys.map(&:to_sym)
-
-        ::I18n.available_locales += locales
-
-        locales.each do |locale|
-          ::I18n.backend.store_translations(locale, data[locale.to_s])
-        end
-      end
-
       # Get a message for the given key and its options
       #
       # @param [Symbol] key
@@ -96,6 +64,40 @@ module Dry
       # @api private
       def default_locale
         I18n.locale || I18n.default_locale || super
+      end
+
+      # @api private
+      def prepare(paths = config.paths)
+        top_namespace = config.top_namespace
+
+        paths.each do |path|
+          data = YAML.load_file(path)
+
+          if path.equal?(DEFAULT_PATH) && top_namespace != DEFAULT_TOP_NAMESPACE
+            mapped_data = data
+              .map { |k, v| [k, { top_namespace => v[DEFAULT_TOP_NAMESPACE] }] }
+              .to_h
+
+            store_translations(mapped_data)
+          else
+            store_translations(data)
+          end
+        end
+
+        self
+      end
+
+      private
+
+      # @api private
+      def store_translations(data)
+        locales = data.keys.map(&:to_sym)
+
+        ::I18n.available_locales += locales
+
+        locales.each do |locale|
+          ::I18n.backend.store_translations(locale, data[locale.to_s])
+        end
       end
     end
   end

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -13,23 +13,13 @@ module Dry
 
       # @api private
       def self.build(options = EMPTY_HASH)
-        messages = new
-
-        messages.configure do |config|
-          options.each do |key, value|
-            config.public_send(:"#{key}=", value)
-          end
-
+        super do |config|
           config.root = "#{config.top_namespace}.#{config.root}"
 
           config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
             "#{config.top_namespace}.#{path}"
           }
         end
-
-        messages.prepare
-
-        messages
       end
 
       # @api private

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -29,10 +29,10 @@ module Dry
       end
 
       # @api private
-      def prepare
+      def prepare(paths = config.paths)
         top_namespace = config.top_namespace
 
-        config.paths.each do |path|
+        paths.each do |path|
           data = YAML.load_file(path)
 
           if path.equal?(DEFAULT_PATH) && top_namespace != DEFAULT_TOP_NAMESPACE
@@ -45,6 +45,8 @@ module Dry
             store_translations(data)
           end
         end
+
+        self
       end
 
       # @api private
@@ -88,9 +90,7 @@ module Dry
       #
       # @api public
       def merge(paths)
-        ::I18n.load_path.concat(Array(paths))
-        ::I18n.backend.load_translations
-        self
+        prepare(paths)
       end
 
       # @api private

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -68,12 +68,12 @@ module Dry
 
       # @api private
       def prepare(paths = config.paths)
-        top_namespace = config.top_namespace
-
         paths.each do |path|
           data = YAML.load_file(path)
 
           if custom_top_namespace?(path)
+            top_namespace = config.top_namespace
+
             mapped_data = data
               .map { |k, v| [k, { top_namespace => v[DEFAULT_TOP_NAMESPACE] }] }
               .to_h

--- a/lib/dry/schema/messages/namespaced.rb
+++ b/lib/dry/schema/messages/namespaced.rb
@@ -6,7 +6,7 @@ module Dry
       # Namespaced messages backend
       #
       # @api public
-      class Namespaced <Dry::Schema::Messages::Abstract
+      class Namespaced < Dry::Schema::Messages::Abstract
         # @api private
         attr_reader :namespace
 
@@ -14,17 +14,16 @@ module Dry
         attr_reader :messages
 
         # @api private
-        attr_reader :root
+        attr_reader :config
 
         # @api private
         attr_reader :call_opts
 
         # @api private
         def initialize(namespace, messages)
-          super()
+          @config = messages.config
           @namespace = namespace
           @messages = messages
-          @root = messages.root
           @call_opts = { namespace: namespace }.freeze
         end
 

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -90,7 +90,7 @@ module Dry
 
       # @api private
       def prepare
-        @data = config.paths.map { |path| load_translations(path) }.reduce(:merge)
+        @data = config.load_paths.map { |path| load_translations(path) }.reduce(:merge)
         self
       end
 
@@ -102,7 +102,7 @@ module Dry
 
         return data unless custom_top_namespace?(path)
 
-        data.map { |k, v| [k.gsub(DEFAULT_TOP_NAMESPACE, config.top_namespace), v] }.to_h
+        data.map { |k, v| [k.gsub(DEFAULT_MESSAGES_ROOT, config.top_namespace), v] }.to_h
       end
 
       # @api private

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -21,23 +21,13 @@ module Dry
 
       # @api private
       def self.build(options = EMPTY_HASH)
-        messages = new
-
-        messages.configure do |config|
-          options.each do |key, value|
-            config.public_send(:"#{key}=", value)
-          end
-
+        super do |config|
           config.root = "%<locale>s.#{config.top_namespace}.#{config.root}"
 
           config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
             "%<locale>s.#{config.top_namespace}.#{path}"
           }
         end
-
-        messages.prepare
-
-        messages
       end
 
       # @api private

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -13,6 +13,8 @@ module Dry
     #
     # @api public
     class Messages::YAML < Messages::Abstract
+      LOCALE_TOKEN = '%<locale>s'
+
       include Dry::Equalizer(:data)
 
       attr_reader :data, :t
@@ -78,12 +80,8 @@ module Dry
       # @return [String]
       #
       # @api public
-      def get(key, options = {})
-        evaluated_key = key.include?('%<locale>s') ?
-          key % { locale: options.fetch(:locale, default_locale) } :
-          key
-
-        data[evaluated_key]
+      def get(key, options = EMPTY_HASH)
+        data[evaluated_key(key, options)]
       end
 
       # Check if given key is defined
@@ -91,12 +89,8 @@ module Dry
       # @return [Boolean]
       #
       # @api public
-      def key?(key, options = {})
-        evaluated_key = key.include?('%<locale>s') ?
-          key % { locale: options.fetch(:locale, default_locale) } :
-          key
-
-        data.key?(evaluated_key)
+      def key?(key, options = EMPTY_HASH)
+        data.key?(evaluated_key(key, options))
       end
 
       # Merge messages from an additional path
@@ -118,6 +112,15 @@ module Dry
             config: config
           )
         end
+      end
+
+      private
+
+      # @api private
+      def evaluated_key(key, options)
+        return key unless key.include?(LOCALE_TOKEN)
+
+        key % { locale: options[:locale] || default_locale }
       end
     end
   end

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -100,9 +100,7 @@ module Dry
       def load_translations(path)
         data = self.class.flat_hash(YAML.load_file(path))
 
-        unless path.equal?(DEFAULT_PATH) && config.top_namespace != DEFAULT_TOP_NAMESPACE
-          return data
-        end
+        return data unless custom_top_namespace?(path)
 
         data.map { |k, v| [k.gsub(DEFAULT_TOP_NAMESPACE, config.top_namespace), v] }.to_h
       end

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -26,10 +26,10 @@ module Dry
             config.public_send(:"#{key}=", value)
           end
 
-          config.root = "%{locale}.#{config.top_namespace}.#{config.root}"
+          config.root = "%<locale>s.#{config.top_namespace}.#{config.root}"
 
           config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
-            "%{locale}.#{config.top_namespace}.#{path}"
+            "%<locale>s.#{config.top_namespace}.#{path}"
           }
         end
 
@@ -51,7 +51,7 @@ module Dry
         super()
         @data = data
         @config = config if config
-        @t = proc { |key, locale: default_locale| get("%{locale}.#{key}", locale: locale) }
+        @t = proc { |key, locale: default_locale| get("%<locale>s.#{key}", locale: locale) }
       end
 
       # @api private
@@ -79,7 +79,7 @@ module Dry
       #
       # @api public
       def get(key, options = {})
-        evaluated_key = key.include?('%{locale}') ?
+        evaluated_key = key.include?('%<locale>s') ?
           key % { locale: options.fetch(:locale, default_locale) } :
           key
 
@@ -92,7 +92,7 @@ module Dry
       #
       # @api public
       def key?(key, options = {})
-        evaluated_key = key.include?('%{locale}') ?
+        evaluated_key = key.include?('%<locale>s') ?
           key % { locale: options.fetch(:locale, default_locale) } :
           key
 

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -46,22 +46,6 @@ module Dry
         @t = proc { |key, locale: default_locale| get("%<locale>s.#{key}", locale: locale) }
       end
 
-      # @api private
-      def prepare
-        @data = config.paths.map { |path| load_translations(path) }.reduce(:merge)
-      end
-
-      # @api private
-      def load_translations(path)
-        data = self.class.flat_hash(YAML.load_file(path))
-
-        unless path.equal?(DEFAULT_PATH) && config.top_namespace != DEFAULT_TOP_NAMESPACE
-          return data
-        end
-
-        data.map { |k, v| [k.gsub(DEFAULT_TOP_NAMESPACE, config.top_namespace), v] }.to_h
-      end
-
       # Get a message for the given key and its options
       #
       # @param [Symbol] key
@@ -104,7 +88,24 @@ module Dry
         end
       end
 
+      # @api private
+      def prepare
+        @data = config.paths.map { |path| load_translations(path) }.reduce(:merge)
+        self
+      end
+
       private
+
+      # @api private
+      def load_translations(path)
+        data = self.class.flat_hash(YAML.load_file(path))
+
+        unless path.equal?(DEFAULT_PATH) && config.top_namespace != DEFAULT_TOP_NAMESPACE
+          return data
+        end
+
+        data.map { |k, v| [k.gsub(DEFAULT_TOP_NAMESPACE, config.top_namespace), v] }.to_h
+      end
 
       # @api private
       def evaluated_key(key, options)

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -22,10 +22,10 @@ module Dry
       # @api private
       def self.build(options = EMPTY_HASH)
         super do |config|
-          config.root = "%<locale>s.#{config.top_namespace}.#{config.root}"
+          config.root = "%<locale>s.#{config.root}"
 
           config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
-            "%<locale>s.#{config.top_namespace}.#{path}"
+            "%<locale>s.#{path}"
           }
         end
       end

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -3,10 +3,6 @@
 require 'dry/schema/messages/i18n'
 
 RSpec.describe Dry::Schema, 'with localized messages' do
-  before do
-    I18n.config.available_locales = %i[en pl]
-  end
-
   describe 'defining schema' do
     context 'without a namespace' do
       subject(:schema) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
   config.before do
     module Test
       def self.remove_constants
-        constants.each { |const| remove_const(const)  }
+        constants.each { |const| remove_const(const) }
         self
       end
     end
@@ -68,7 +68,7 @@ RSpec.configure do |config|
   config.after do
     Object.send(:remove_const, Test.remove_constants.name)
 
-    I18n.load_path = Dry::Schema.messages_paths.dup
+    I18n.load_path = [Dry::Schema::Messages::Abstract::DEFAULT_PATH]
     I18n.locale = :en
     I18n.reload!
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ RSpec.configure do |config|
   config.after do
     Object.send(:remove_const, Test.remove_constants.name)
 
-    I18n.load_path = [Dry::Schema::Messages::Abstract::DEFAULT_PATH]
+    I18n.load_path = [Dry::Schema::DEFAULT_MESSAGES_PATH]
     I18n.locale = :en
     I18n.reload!
   end

--- a/spec/unit/dry/schema/message_compiler_spec.rb
+++ b/spec/unit/dry/schema/message_compiler_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Schema::MessageCompiler, '#call' do
-  subject(:message_compiler) { Dry::Schema::MessageCompiler.new( Dry::Schema::Messages.default ) }
+  subject(:message_compiler) do
+    Dry::Schema::MessageCompiler.new(Dry::Schema::Messages::YAML.build)
+  end
 
   it 'returns an empty hash when there are no errors' do
     expect(message_compiler.([])).to be_empty

--- a/spec/unit/dry/schema/messages/i18n_spec.rb
+++ b/spec/unit/dry/schema/messages/i18n_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'dry/schema/messages/i18n'
+
+RSpec.describe Dry::Schema::Messages::I18n do
+  context 'with default config' do
+    subject(:messages) do
+      Dry::Schema::Messages::I18n.build
+    end
+
+    describe '#[]' do
+      it 'returns message template' do
+        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+      end
+    end
+
+    describe '#translate' do
+      it 'returns translated string' do
+        expect(messages.translate(:or)).to eql('or')
+      end
+    end
+  end
+
+  context 'with custom top-level namespace config' do
+    subject(:messages) do
+      Dry::Schema::Messages::I18n.build(top_namespace: 'my_app')
+    end
+
+    describe '#[]' do
+      it 'returns message template' do
+        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+      end
+    end
+
+    describe '#translate' do
+      it 'returns translated string' do
+        expect(messages.translate(:or)).to eql('or')
+      end
+    end
+  end
+end

--- a/spec/unit/dry/schema/messages/yaml_spec.rb
+++ b/spec/unit/dry/schema/messages/yaml_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'dry/schema/messages/yaml'
+
+RSpec.describe Dry::Schema::Messages::YAML do
+  describe '#[]' do
+    context 'with default config' do
+      subject(:messages) do
+        Dry::Schema::Messages::YAML.build
+      end
+
+      it 'returns message template' do
+        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+      end
+    end
+
+    context 'with custom top-level namespace config' do
+      subject(:messages) do
+        Dry::Schema::Messages::YAML.build(top_namespace: 'my_app')
+      end
+
+      it 'returns message template' do
+        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+      end
+    end
+  end
+end


### PR DESCRIPTION
To make top-level locale namespace configurable, I had to refactor `Messages::I18n` and `Messages::YAML` to use instance-level configuration. This is actually a really, really good thing because there's even less global state now. I will make some more improvements in a follow-up PR.

Closes #95 