### PR TITLE
Change interface of Message to allow arbitrary objects

### DIFF
--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -9,9 +9,9 @@ module Dry
     #
     # @api public
     class Message
-      include Dry::Equalizer(:predicate, :path, :text, :options)
+      include Dry::Equalizer(:predicate, :path, :message, :options)
 
-      attr_reader :predicate, :path, :text, :args, :options
+      attr_reader :predicate, :path, :message, :args, :options
 
       # A message sub-type used by OR operations
       #
@@ -42,8 +42,8 @@ module Dry
         # Return a string representation of the message
         #
         # @api public
-        def to_s
-          uniq.join(" #{messages[:or]} ")
+        def dump
+          uniq.map(&:dump).join(" #{messages[:or]} ")
         end
 
         # @api private
@@ -60,29 +60,29 @@ module Dry
       # Build a new message object
       #
       # @api private
-      def self.[](predicate, path, text, options)
-        Message.new(predicate, path, text, options)
+      def self.[](predicate, path, message, options)
+        Message.new(predicate, path, message, options)
       end
 
       # @api private
-      def initialize(predicate, path, text, options)
+      def initialize(predicate, path, message, options)
         @predicate = predicate
         @path = path
-        @text = text
+        @message = message
         @options = options
         @args = options[:args] || EMPTY_ARRAY
       end
 
-      # Return a string representation of the message
+      # Return internal representation of the message
       #
       # @api public
-      def to_s
-        text
+      def dump
+        message
       end
 
       # @api private
       def eql?(other)
-        other.is_a?(String) ? text == other : super
+        other.is_a?(String) ? message == other : super
       end
 
       def <=>(other)

--- a/lib/dry/schema/message_set.rb
+++ b/lib/dry/schema/message_set.rb
@@ -69,7 +69,7 @@ module Dry
             node << msg
           end
 
-          node.map!(&:to_s)
+          node.map!(&:dump)
 
           hash
         end


### PR DESCRIPTION
This is required by https://github.com/dry-rb/dry-validation/pull/499
Now it's possible to pass custom object from validation rules as errors. Strictly speaking, this wasn't necessary but we don't want those custom objects to be accidentally coerced to strings when you call `MessageSet#to_h` hence this change.