### PR TITLE
Add support for meta data in Message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem 'dry-monads', require: false
   gem 'i18n', require: false
   gem 'simplecov', require: false, platform: :mri
+  gem 'transproc'
 end
 
 group :tools do

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -1,6 +1,7 @@
 en:
   dry_schema:
     or: "or"
+
     errors:
       array?: "must be an array"
 
@@ -12,6 +13,7 @@ en:
         arg:
           default: "must not be one of: %{list}"
           range: "must not be one of: %{list_left} - %{list_right}"
+
       exclusion?: "must not be one of: %{list}"
 
       eql?: "must be equal to %{left}"
@@ -38,6 +40,7 @@ en:
         arg:
           default: "must be one of: %{list}"
           range: "must be one of: %{list_left} - %{list_right}"
+
       inclusion?: "must be one of: %{list}"
 
       includes?: "must include %{value}"
@@ -88,5 +91,6 @@ en:
             arg:
               default: "length must be %{size}"
               range: "length must be within %{size_left} - %{size_right}"
+
       not:
         empty?: "cannot be empty"

--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -26,6 +26,8 @@ module Dry
 
       option :input
 
+      option :meta, optional: true
+
       # Return a string representation of the message
       #
       # @api public

--- a/lib/dry/schema/message/or.rb
+++ b/lib/dry/schema/message/or.rb
@@ -36,7 +36,7 @@ module Dry
         #
         # @api public
         def to_s
-          to_a.join(" #{messages[:or]} ")
+          to_a.join(" #{messages[:or][:text]} ")
         end
 
         # @api private

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -130,12 +130,12 @@ module Dry
           path: path.last, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
         ).to_h
 
-        template = messages[predicate, options] || raise(MissingMessageError, path)
+        template, meta = messages[predicate, options] || raise(MissingMessageError, path)
 
         text = message_text(template, tokens, options)
 
         message_type(options).new(
-          text: text, path: path, predicate: predicate, args: arg_vals, input: input
+          text: text, path: path, predicate: predicate, args: arg_vals, input: input, meta: meta
         )
       end
 

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -20,31 +20,31 @@ RSpec.describe Dry::Schema::Messages::I18n do
       end
 
       it 'returns a message for a predicate' do
-        template = messages[:filled?, path: :name]
+        template, = messages[:filled?, path: :name]
 
         expect(template.()).to eql('nie może być pusty')
       end
 
       it 'returns a message for a specific rule' do
-        template = messages[:filled?, path: :email]
+        template, = messages[:filled?, path: :email]
 
         expect(template.()).to eql('Proszę podać adres email')
       end
 
       it 'returns a message for a specific val type' do
-        template = messages[:size?, path: :pages, val_type: String]
+        template, = messages[:size?, path: :pages, val_type: String]
 
         expect(template.(size: 2)).to eql('wielkość musi być równa 2')
       end
 
       it 'returns a message for a specific rule and its default arg type' do
-        template = messages[:size?, path: :pages]
+        template, = messages[:size?, path: :pages]
 
         expect(template.(size: 2)).to eql('wielkość musi być równa 2')
       end
 
       it 'returns a message for a specific rule and its arg type' do
-        template = messages[:size?, path: :pages, arg_type: Range]
+        template, = messages[:size?, path: :pages, arg_type: Range]
 
         expect(template.(size_left: 1, size_right: 2)).to eql('wielkość musi być między 1 a 2')
       end
@@ -52,25 +52,25 @@ RSpec.describe Dry::Schema::Messages::I18n do
 
     context 'with a different locale' do
       it 'returns a message for a predicate' do
-        template = messages[:filled?, path: :name, locale: :en]
+        template, = messages[:filled?, path: :name, locale: :en]
 
         expect(template.()).to eql('must be filled')
       end
 
       it 'returns a message for a specific rule' do
-        template = messages[:filled?, path: :email, locale: :en]
+        template, = messages[:filled?, path: :email, locale: :en]
 
         expect(template.()).to eql('Please provide your email')
       end
 
       it 'returns a message for a specific rule and its default arg type' do
-        template = messages[:size?, path: :pages, locale: :en]
+        template, = messages[:size?, path: :pages, locale: :en]
 
         expect(template.(size: 2)).to eql('size must be 2')
       end
 
       it 'returns a message for a specific rule and its arg type' do
-        template = messages[:size?, path: :pages, arg_type: Range, locale: :en]
+        template, = messages[:size?, path: :pages, arg_type: Range, locale: :en]
 
         expect(template.(size_left: 1, size_right: 2)).to eql('size must be within 1 - 2')
       end
@@ -87,7 +87,7 @@ RSpec.describe Dry::Schema::Messages::I18n do
       end
 
       it 'returns a message for a predicate in the default_locale' do
-        template = messages[:even?, path: :some_number]
+        template, = messages[:even?, path: :some_number]
 
         expect(I18n.locale).to eql(:pl)
         expect(template.()).to eql('must be even')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,12 +34,27 @@ Undefined = Dry::Core::Constants::Undefined
 Dry::Schema.load_extensions(:hints)
 
 require 'i18n'
+require 'transproc/all'
+
 require 'dry/schema/messages/i18n'
 require 'dry/schema/message_set'
 
 module MessageSetSupport
   def eql?(other)
     to_h.eql?(other)
+  end
+end
+
+module Coercions
+  extend Transproc::Registry
+
+  import Transproc::Recursion
+  import Transproc::HashTransformations
+
+  T = self
+
+  def stringify_keys(hash)
+    T[:hash_recursion, T[:stringify_keys]].(hash)
   end
 end
 
@@ -51,6 +66,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
 
   config.include PredicatesIntegration
+  config.include Coercions
 
   config.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true

--- a/spec/unit/dry/schema/message_compiler/visit_spec.rb
+++ b/spec/unit/dry/schema/message_compiler/visit_spec.rb
@@ -16,6 +16,35 @@ RSpec.describe Dry::Schema::MessageCompiler, '#visit' do
     end
   end
 
+  context 'with a predicate with text and extra meta-data' do
+    let(:node) do
+      [:failure, [:msisdn, [:key, [:msisdn, [:predicate, [:format?, [[:input, '31-213']]]]]]]]
+    end
+
+    let(:messages) do
+      Dry::Schema::Messages::YAML.build.merge(
+        stringify_keys(
+          en: {
+            dry_schema: {
+              errors: {
+                format?: {
+                  code: 102,
+                  text: '%{input} looks weird'
+                }
+              }
+            }
+          }
+        )
+      )
+    end
+
+    it 'returns a message for the predicate a long with the additional meta-data' do
+      expect(result.path).to eql([:msisdn])
+      expect(result.text).to eql('31-213 looks weird')
+      expect(result.meta).to eql(code: 102)
+    end
+  end
+
   context 'with an unsupported predicate' do
     let(:node) do
       [:key, [%i[user address street], [:predicate, [:oops?, [[:input, '17']]]]]]

--- a/spec/unit/dry/schema/messages/i18n_spec.rb
+++ b/spec/unit/dry/schema/messages/i18n_spec.rb
@@ -9,8 +9,11 @@ RSpec.describe Dry::Schema::Messages::I18n do
     end
 
     describe '#[]' do
-      it 'returns message template' do
-        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+      it 'returns message template and optional meta' do
+        template, meta = messages[:filled?, path: [:name]]
+
+        expect(template.()).to eql('must be filled')
+        expect(meta).to eql({})
       end
     end
 
@@ -28,7 +31,10 @@ RSpec.describe Dry::Schema::Messages::I18n do
 
     describe '#[]' do
       it 'returns message template' do
-        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+        template, meta = messages[:filled?, path: [:name]]
+
+        expect(template.()).to eql('must be filled')
+        expect(meta).to eql({})
       end
     end
 

--- a/spec/unit/dry/schema/messages/yaml_spec.rb
+++ b/spec/unit/dry/schema/messages/yaml_spec.rb
@@ -3,14 +3,17 @@
 require 'dry/schema/messages/yaml'
 
 RSpec.describe Dry::Schema::Messages::YAML do
+  subject(:messages) do
+    Dry::Schema::Messages::YAML.build
+  end
+
   describe '#[]' do
     context 'with default config' do
-      subject(:messages) do
-        Dry::Schema::Messages::YAML.build
-      end
+      it 'returns message template and optional meta' do
+        template, meta = messages[:filled?, path: [:name]]
 
-      it 'returns message template' do
-        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+        expect(template.()).to eql('must be filled')
+        expect(meta).to eql({})
       end
     end
 
@@ -19,8 +22,132 @@ RSpec.describe Dry::Schema::Messages::YAML do
         Dry::Schema::Messages::YAML.build(top_namespace: 'my_app')
       end
 
-      it 'returns message template' do
-        expect(messages[:filled?, path: [:name]].()).to eql('must be filled')
+      it 'returns message template and optional meta' do
+        template, meta = messages[:filled?, path: [:name]]
+
+        expect(template.()).to eql('must be filled')
+        expect(meta).to eql({})
+      end
+    end
+  end
+
+  describe '#merge' do
+    context 'with :text and meta' do
+      it 'nests the message hash' do
+        merged = messages.merge(
+          stringify_keys(
+            en: {
+              dry_schema: {
+                errors: {
+                  format?: {
+                    text: '%{input} looks weird',
+                    code: 102
+                  }
+                }
+              }
+            }
+          )
+        )
+
+        expect(merged.data['en.dry_schema.errors.format?'])
+          .to eql(text: '%{input} looks weird', meta: { code: 102 })
+      end
+    end
+  end
+
+  describe '.flat_hash' do
+    subject(:output) { Dry::Schema::Messages::YAML.flat_hash(input) }
+
+    let(:input) do
+      stringify_keys(en: { dry_schema: { errors: messages } })
+    end
+
+    describe 'simple text messages' do
+      let(:messages) do
+        { format?: 'not ok',
+          else?: 'should be something else' }
+      end
+
+      it 'returns string templates' do
+        expect(output).to eql(
+          'en.dry_schema.errors.else?' => {
+            text: 'should be something else',
+            meta: {}
+          },
+          'en.dry_schema.errors.format?' => {
+            text: 'not ok',
+            meta: {}
+          }
+        )
+      end
+    end
+
+    describe 'messages with meta' do
+      let(:messages) do
+        {
+          gt?: {
+            text: 'must be greater',
+            code: 856
+          },
+          size?: {
+            arg: {
+              default: 'size must be good',
+              range: {
+                text: 'size must fit within the range',
+                code: 312
+              }
+            },
+            value: {
+              string: {
+                arg: {
+                  default: 'length must be good',
+                  range: {
+                    text: 'length must fit within the range',
+                    code: 423
+                  }
+                }
+              }
+            }
+          },
+          rules: {
+            format?: {
+              text: 'not ok',
+              code: -101
+            },
+            text: {
+              filled?: {
+                text: 'text not filled',
+                code: 476
+              }
+            }
+          }
+        }
+      end
+
+      it 'returns string templates' do
+        expect(output).to eql(
+          'en.dry_schema.errors.gt?' => {
+            text: 'must be greater', meta: { code: 856 }
+          },
+          'en.dry_schema.errors.size?.arg.default' => {
+            text: 'size must be good', meta: {}
+          },
+          'en.dry_schema.errors.size?.arg.range' => {
+            text: 'size must fit within the range', meta: { code: 312 }
+          },
+          'en.dry_schema.errors.size?.value.string.arg.default' => {
+            text: 'length must be good', meta: {}
+          },
+          'en.dry_schema.errors.size?.value.string.arg.range' => {
+            text: 'length must fit within the range', meta: { code: 423 }
+          },
+          'en.dry_schema.errors.rules.format?' => {
+            text: 'not ok', meta: { code: -101 }
+          },
+          'en.dry_schema.errors.rules.text.filled?' => {
+            text: 'text not filled', meta: { code: 476 }
+          }
+        )
       end
     end
   end


### PR DESCRIPTION
This adds support for setting up additional meta data that should be part of a message, ie:

``` yaml
en:
  dry_schema:
    filled?:
      text: "cannot be empty"
      code: 102
```

Closes #39 