### PR TITLE
Fix filled macro

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -111,6 +111,17 @@ module Dry
         self
       end
 
+      # Return a macro with the provided name
+      #
+      # @param [Symbol] name
+      #
+      # @return [Macros::Core]
+      #
+      # @api public
+      def [](name)
+        macros.detect { |macro| macro.name.equal?(name) }
+      end
+
       # Define a required key
       #
       # @example

--- a/lib/dry/schema/json.rb
+++ b/lib/dry/schema/json.rb
@@ -13,6 +13,7 @@ module Dry
     class JSON < Processor
       config.key_map_type = :stringified
       config.type_registry = config.type_registry.namespaced(:json)
+      config.filter_empty_string = false
     end
   end
 end

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -66,9 +66,10 @@ module Dry
         # @return [Macros::Core]
         #
         # @api public
-        def filled(*args, &block)
+        def filled(*args, **opts, &block)
           append_macro(Macros::Filled) do |macro|
-            macro.call(*args, &block)
+            filter(:filled?) if opts[:type_spec] && macro.filter?
+            macro.call(*args, **opts, &block)
           end
         end
 

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -28,7 +28,7 @@ module Dry
         #
         # @api public
         def filter(*args, &block)
-          filter_schema_dsl.optional(name).value(*args, &block)
+          (filter_schema_dsl[name] || filter_schema_dsl.optional(name)).value(*args, &block)
           self
         end
 

--- a/lib/dry/schema/params.rb
+++ b/lib/dry/schema/params.rb
@@ -13,6 +13,7 @@ module Dry
     class Params < Processor
       config.key_map_type = :stringified
       config.type_registry = config.type_registry.namespaced(:params)
+      config.filter_empty_string = true
     end
   end
 end

--- a/lib/dry/schema/primitive_inferrer.rb
+++ b/lib/dry/schema/primitive_inferrer.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'dry/core/cache'
+
+module Dry
+  module Schema
+    # PrimitiveInferrer is used internally by `Macros::Filled`
+    # for inferring a list of possible primitives that a given
+    # type can handle.
+    #
+    # @api private
+    class PrimitiveInferrer
+      extend Dry::Core::Cache
+
+      # Compiler reduces type AST into a list of primitives
+      #
+      # @api private
+      class Compiler
+        # @api private
+        def visit(node)
+          meth, rest = node
+          public_send(:"visit_#{meth}", rest)
+        end
+
+        # @api private
+        def visit_nominal(node)
+          type, _ = node
+          type
+        end
+
+        # @api private
+        def visit_hash(_)
+          Hash
+        end
+
+        # @api private
+        def visit_array(_)
+          Array
+        end
+
+        # @api private
+        def visit_lax(node)
+          visit(node)
+        end
+
+        # @api private
+        def visit_constructor(node)
+          other, * = node
+          visit(other)
+        end
+
+        # @api private
+        def visit_enum(node)
+          other, * = node
+          visit(other)
+        end
+
+        # @api private
+        def visit_sum(node)
+          left, right = node
+
+          [visit(left), visit(right)].flatten(1)
+        end
+
+        # @api private
+        def visit_constrained(node)
+          other, * = node
+          visit(other)
+        end
+
+        # @api private
+        def visit_any(_)
+          Object
+        end
+      end
+
+      # @return [Compiler]
+      # @api private
+      attr_reader :compiler
+
+      # @api private
+      def initialize
+        @compiler = Compiler.new
+      end
+
+      # Infer predicate identifier from the provided type
+      #
+      # @return [Symbol]
+      #
+      # @api private
+      def [](type)
+        self.class.fetch_or_store(type.hash) do
+          Array(compiler.visit(type.to_ast)).freeze
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -29,6 +29,7 @@ module Dry
 
       setting :key_map_type
       setting :type_registry, TypeRegistry.new
+      setting :filter_empty_string, false
 
       option :steps, default: -> { EMPTY_ARRAY.dup }
 

--- a/spec/integration/params/predicates/eql_spec.rb
+++ b/spec/integration/params/predicates/eql_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be a string', 'must be equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -158,7 +158,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
       end
@@ -272,7 +272,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be a string', 'must be equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -280,7 +280,7 @@ RSpec.describe 'Predicates: Eql' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must be equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
       end

--- a/spec/integration/params/predicates/even_spec.rb
+++ b/spec/integration/params/predicates/even_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be even']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -206,7 +206,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be even']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -214,7 +214,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be even']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -368,7 +368,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be even']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -376,7 +376,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be even']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -384,7 +384,7 @@ RSpec.describe 'Predicates: Even' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be even']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/excluded_from_spec.rb
+++ b/spec/integration/params/predicates/excluded_from_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'Predicates: Excluded From' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be a string', 'must not be one of: 1, 3, 5']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -206,7 +206,7 @@ RSpec.describe 'Predicates: Excluded From' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must not be one of: 1, 3, 5']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/excludes_spec.rb
+++ b/spec/integration/params/predicates/excludes_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be a string', 'must not include foo']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -182,7 +182,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must not include foo']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -320,7 +320,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be a string', 'must not include foo']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -328,7 +328,7 @@ RSpec.describe 'Predicates: Excludes' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be filled', 'must not include foo']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/false_spec.rb
+++ b/spec/integration/params/predicates/false_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be false']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -214,7 +214,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be false']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -222,7 +222,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be false']
+            expect(result).to be_failing ['must be filled']
           end
         end
       end
@@ -376,7 +376,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be false']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -384,7 +384,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be false']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -392,7 +392,7 @@ RSpec.describe 'Predicates: False' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be false']
+            expect(result).to be_failing ['must be filled']
           end
         end
       end

--- a/spec/integration/params/predicates/gt_spec.rb
+++ b/spec/integration/params/predicates/gt_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -238,7 +238,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -416,7 +416,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -424,7 +424,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -432,7 +432,7 @@ RSpec.describe 'Predicates: Gt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/gteq_spec.rb
+++ b/spec/integration/params/predicates/gteq_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -238,7 +238,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -416,7 +416,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -424,7 +424,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -432,7 +432,7 @@ RSpec.describe 'Predicates: Gteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be greater than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/lt_spec.rb
+++ b/spec/integration/params/predicates/lt_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -238,7 +238,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -416,7 +416,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -424,7 +424,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -432,7 +432,7 @@ RSpec.describe 'Predicates: Lt' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/lteq_spec.rb
+++ b/spec/integration/params/predicates/lteq_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -238,7 +238,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -416,7 +416,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -424,7 +424,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -432,7 +432,7 @@ RSpec.describe 'Predicates: Lteq' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be less than or equal to 23']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/odd_spec.rb
+++ b/spec/integration/params/predicates/odd_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be odd']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -206,7 +206,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be odd']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -214,7 +214,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be odd']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -368,7 +368,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be odd']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -376,7 +376,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be odd']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -384,7 +384,7 @@ RSpec.describe 'Predicates: Odd' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer', 'must be odd']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/params/predicates/size/fixed_spec.rb
+++ b/spec/integration/params/predicates/size/fixed_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be an array or must be a string', 'size must be 3']
+              expect(result).to be_failing ['must be filled']
             end
           end
 
@@ -183,7 +183,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'size must be 3']
+              expect(result).to be_failing ['must be filled']
             end
           end
 
@@ -321,7 +321,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be an array or must be a string', 'size must be 3']
+              expect(result).to be_failing ['must be filled']
             end
           end
 
@@ -329,7 +329,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'size must be 3']
+              expect(result).to be_failing ['must be filled']
             end
           end
 

--- a/spec/integration/params/predicates/size/range_spec.rb
+++ b/spec/integration/params/predicates/size/range_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => nil } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be a string', 'size must be within 2 - 3']
+              expect(result).to be_failing ['must be filled']
             end
           end
 
@@ -332,7 +332,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { 'foo' => '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['must be filled', 'length must be within 2 - 3']
+              expect(result).to be_failing ['must be filled']
             end
           end
 

--- a/spec/integration/params/predicates/true_spec.rb
+++ b/spec/integration/params/predicates/true_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be true']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -214,7 +214,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be true']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -222,7 +222,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be true']
+            expect(result).to be_failing ['must be filled']
           end
         end
       end
@@ -376,7 +376,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be true']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -384,7 +384,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be true']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -392,7 +392,7 @@ RSpec.describe 'Predicates: True' do
           let(:input) { { 'foo' => [] } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be true']
+            expect(result).to be_failing ['must be filled']
           end
         end
       end

--- a/spec/integration/params/predicates/type_spec.rb
+++ b/spec/integration/params/predicates/type_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -182,7 +182,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -320,7 +320,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => nil } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 
@@ -328,7 +328,7 @@ RSpec.describe 'Predicates: Type' do
           let(:input) { { 'foo' => '' } }
 
           it 'is not successful' do
-            expect(result).to be_failing ['must be an integer']
+            expect(result).to be_failing ['must be filled']
           end
         end
 

--- a/spec/integration/schema/macros/filled_spec.rb
+++ b/spec/integration/schema/macros/filled_spec.rb
@@ -16,16 +16,58 @@ RSpec.describe 'Macros #filled' do
   end
 
   describe 'with a type specification' do
-    subject(:schema) do
-      Dry::Schema.define do
-        required(:age).filled(:string)
+    context ':string' do
+      subject(:schema) do
+        Dry::Schema.define do
+          required(:name).filled(:string)
+        end
+      end
+
+      it 'generates str? && filled? rule' do
+        expect(schema.(name: nil).errors).to eql(name: ['must be a string'])
       end
     end
 
-    it 'generates str? && filled? rule' do
-      expect(schema.(age: nil).messages).to eql(
-        age: ['must be a string']
-      )
+    context ':integer' do
+      context 'Params' do
+        subject(:schema) do
+          Dry::Schema.Params do
+            required(:age).filled(:integer)
+          end
+        end
+
+        it 'applies filter(:filled?) for empty strings' do
+          expect(schema.(age: '').errors).to eql(age: ['must be filled'])
+        end
+
+        it 'applies filter(:filled?) for nil' do
+          expect(schema.(age: nil).errors).to eql(age: ['must be filled'])
+        end
+
+        it 'applies int?' do
+          expect(schema.(age: 'not-a-number').errors).to eql(age: ['must be an integer'])
+        end
+      end
+
+      context 'JSON' do
+        subject(:schema) do
+          Dry::Schema.JSON do
+            required(:age).filled(:integer)
+          end
+        end
+
+        it 'applies type-spec predicate for empty strings' do
+          expect(schema.(age: '').errors).to eql(age: ['must be an integer'])
+        end
+
+        it 'applies type-spec predicate for nil' do
+          expect(schema.(age: nil).errors).to eql(age: ['must be an integer'])
+        end
+
+        it 'applies int?' do
+          expect(schema.(age: 'not-a-number').errors).to eql(age: ['must be an integer'])
+        end
+      end
     end
   end
 

--- a/spec/unit/dry/schema/params_spec.rb
+++ b/spec/unit/dry/schema/params_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Dry::Schema::Params do
     it 'returns a params schema instance' do
       schema = klass.new
 
-      expect(schema.('name' => 'Jane', 'age' => '').errors).to eql(age: ['must be an integer'])
+      expect(schema.('name' => 'Jane', 'age' => '').errors).to eql(age: ['must be filled'])
     end
 
     it 'raises exception when definition is missing' do
@@ -36,7 +36,7 @@ RSpec.describe Dry::Schema::Params do
 
     it 'returns a representation of a params object' do
       expect(klass.new.inspect).to eql(<<~STR.strip)
-        #<Test::UserSchema keys=["name"] rules={:name=>"key?(:name) AND key[name](str? AND filled?)"}>
+        #<Test::UserSchema keys=["name"] rules={:name=>"key?(:name) AND key[name](str?)"}>
       STR
     end
 

--- a/spec/unit/dry/schema/primitive_inferrer_spec.rb
+++ b/spec/unit/dry/schema/primitive_inferrer_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'dry/schema/predicate_inferrer'
+
+RSpec.describe Dry::Schema::PrimitiveInferrer, '#[]' do
+  subject(:inferrer) do
+    Dry::Schema::PrimitiveInferrer.new
+  end
+
+  def type(*args)
+    args.map { |name| Dry::Types[name.to_s] }.reduce(:|)
+  end
+
+  it 'caches results' do
+    expect(inferrer[type(:string)]).to be(inferrer[type(:string)])
+  end
+
+  it 'returns String for a string type' do
+    expect(inferrer[type(:string)]).to eql([String])
+  end
+
+  it 'returns Integer for a integer type' do
+    expect(inferrer[type(:integer)]).to eql([Integer])
+  end
+
+  it 'returns Array for a string type' do
+    expect(inferrer[type(:array)]).to eql([Array])
+  end
+
+  it 'returns Hash for a string type' do
+    expect(inferrer[type(:hash)]).to eql([Hash])
+  end
+
+  it 'returns DateTime for a datetime type' do
+    expect(inferrer[type(:date_time)]).to eql([DateTime])
+  end
+
+  it 'returns NilClass for a nil type' do
+    expect(inferrer[type(:nil)]).to eql([NilClass])
+  end
+
+  it 'returns FalseClass for a false type' do
+    expect(inferrer[type(:false)]).to eql([FalseClass])
+  end
+
+  it 'returns TrueClass for a true type' do
+    expect(inferrer[type(:true)]).to eql([TrueClass])
+  end
+
+  it 'returns FalseClass for a false type' do
+    expect(inferrer[type(:false)]).to eql([FalseClass])
+  end
+
+  it 'returns [TrueClass, FalseClass] for bool type' do
+    expect(inferrer[type(:bool)]).to eql([TrueClass, FalseClass])
+  end
+
+  it 'returns Integer for a lax constructor integer type' do
+    expect(inferrer[type('params.integer').lax]).to eql([Integer])
+  end
+
+  it 'returns [NilClass, Integer] from an optional integer with constructor' do
+    expect(inferrer[type(:integer).optional.constructor(&:to_i)]).to eql([NilClass, Integer])
+  end
+
+  it 'returns Integer for integer enum type' do
+    expect(inferrer[type(:integer).enum(1, 2)]).to eql([Integer])
+  end
+
+  it 'returns custom type for arbitrary types' do
+    custom_type = Dry::Types::Nominal.new(double(:some_type, name: 'ObjectID'))
+
+    expect(inferrer[custom_type]).to eql([custom_type.primitive])
+  end
+
+  it 'returns Object for any' do
+    expect(inferrer[type(:any)]).to eql([Object])
+  end
+end


### PR DESCRIPTION
Fixes #134 

This fixes `filled` macro so that it applies `filter(:filled?)` for primitives that are not supported by the corresponding [filled?](https://github.com/dry-rb/dry-logic/blob/master/lib/dry/logic/predicates.rb#L41-L43) predicate. In practice, this means that using `filled` with a type that should be checked if it's filled **before coercion**, will result in applying `filter(:filled?)`.

In example:

``` ruby
dry-schema> s = params { required(:age).filled(:integer) }
=> #<Dry::Schema::Params keys=["age"] rules={:age=>"key?(:age) AND key[age](int?)"}>
dry-schema> s.(age: "").errors.to_h
=> {:age=>["must be filled"]}
dry-schema> s.(age: "foo").errors.to_h
=> {:age=>["must be an integer"]}
dry-schema> s.(age: "30").errors.to_h
=> {}
dry-schema> s.(age: "30").to_h
=> {:age=>30}
```

`JSON` is configured to apply type checks to `nil` instead of `filled?`, so ie:

```ruby
dry-schema> s = json { required(:age).filled(:integer) }
dry-schema> s.(age: nil).errors.to_h
=> {:age=>["must be an integer"]}
```

Contrast that with `Params`:

```
dry-schema> s = params { required(:age).filled(:integer) }
dry-schema> s.(age: nil).errors.to_h
=> {:age=>["must be filled"]}
```

The reason for this different behaviours is that in case of `Params` empty strings are turned into `nil`, which means that a value wasn't filled in, so `filled?` should be applied and provide a useful error message. In case of `JSON` it does not make sense because `nil` means that `null` was passed as the value and it's not allowed because we expect integers. One thing to notice is that using `filled` with numbers in `JSON` schemas is a bit silly, a type check should be enough.