### PR TITLE
Fix inheriting filter rules

### DIFF
--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -12,9 +12,10 @@ module Dry
       #
       # @api public
       class Key < DSL
-        # @return [Schema::DSL]
-        # @api private
-        option :filter_schema, optional: true, default: proc { schema_dsl&.new }
+        # @!attribute [r] filter_schema_dsl
+        #   @return [Schema::DSL]
+        #   @api private
+        option :filter_schema_dsl, default: proc { schema_dsl&.filter_schema_dsl }
 
         # Specify predicates that should be applied before coercion
         #
@@ -27,7 +28,7 @@ module Dry
         #
         # @api public
         def filter(*args, &block)
-          filter_schema.optional(name).value(*args, &block)
+          filter_schema_dsl.optional(name).value(*args, &block)
           self
         end
 

--- a/lib/dry/schema/value_coercer.rb
+++ b/lib/dry/schema/value_coercer.rb
@@ -22,6 +22,9 @@ module Dry
         else
           type_schema.each_with_object(EMPTY_HASH.dup) do |key, hash|
             name = key.name
+
+            next unless input.key?(name)
+
             value = input[name]
 
             hash[name] = input.error?(name) ? value : key[value]

--- a/spec/integration/params/defining_base_form_spec.rb
+++ b/spec/integration/params/defining_base_form_spec.rb
@@ -3,17 +3,19 @@
 RSpec.describe 'Defining base schema class' do
   subject(:form) do
     Dry::Schema.Params(parent: parent) do
-      required(:email).filled
+      required(:name).filled(:string)
     end
   end
 
   let(:parent) do
     Dry::Schema.Params do
-      required(:name).filled
+      required(:email).filled(:string)
+      required(:age).filter(:filled?).value(:integer)
     end
   end
 
   it 'inherits rules' do
-    expect(form.(name: '').errors).to eql(name: ['must be filled'], email: ['is missing'])
+    expect(form.(name: '', age: '').errors.to_h)
+      .to eql(email: ['is missing'], age: ['must be filled'], name: ['must be filled'])
   end
 end


### PR DESCRIPTION
* Fix value coercer when filtering is used - fixes #142
* Fix inheritance of filtering rules
* Rename `filter_schema` to `filter_schema_dsl` - otherwise it was
   confusing
* Add `schema_dsl` as a new option for processors - we need this to
  keep info about the source DSL that was used to build a processor

Apologies for a bulk-commit but all this work took a lot of my time
already and I'm rushing.