### PR TITLE
Add support for registering custom types

### DIFF
--- a/lib/dry/schema/config.rb
+++ b/lib/dry/schema/config.rb
@@ -5,6 +5,7 @@ require 'dry/configurable'
 
 require 'dry/schema/constants'
 require 'dry/schema/predicate_registry'
+require 'dry/schema/type_container'
 
 module Dry
   module Schema
@@ -26,6 +27,15 @@ module Dry
       # @api public
       setting(:predicates, Schema::PredicateRegistry.new)
 
+      # @!method types
+      #
+      # Return configured container with extra types
+      #
+      # @return [Hash]
+      #
+      # @api public
+      setting(:types, Dry::Types)
+
       # @!method messages
       #
       # Return configuration for message backend
@@ -40,6 +50,7 @@ module Dry
         setting(:top_namespace, DEFAULT_MESSAGES_ROOT)
         setting(:default_locale, nil)
       end
+
 
       # @api private
       def respond_to_missing?(meth, include_private = false)

--- a/lib/dry/schema/config.rb
+++ b/lib/dry/schema/config.rb
@@ -51,7 +51,6 @@ module Dry
         setting(:default_locale, nil)
       end
 
-
       # @api private
       def respond_to_missing?(meth, include_private = false)
         super || config.respond_to?(meth, include_private)

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -351,7 +351,10 @@ module Dry
       #
       # @api private
       def type_registry
-        processor_type.config.type_registry
+        @type_registry ||= TypeRegistry.new(
+          config.types,
+          processor_type.config.type_registry_namespace
+        )
       end
 
       # Return key map type configured by the processor type

--- a/lib/dry/schema/json.rb
+++ b/lib/dry/schema/json.rb
@@ -12,7 +12,7 @@ module Dry
     # @api public
     class JSON < Processor
       config.key_map_type = :stringified
-      config.type_registry = config.type_registry.namespaced(:json)
+      config.type_registry_namespace = :json
       config.filter_empty_string = false
     end
   end

--- a/lib/dry/schema/params.rb
+++ b/lib/dry/schema/params.rb
@@ -12,7 +12,7 @@ module Dry
     # @api public
     class Params < Processor
       config.key_map_type = :stringified
-      config.type_registry = config.type_registry.namespaced(:params)
+      config.type_registry_namespace = :params
       config.filter_empty_string = true
     end
   end

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -4,6 +4,7 @@ require 'dry/configurable'
 require 'dry/initializer'
 
 require 'dry/schema/type_registry'
+require 'dry/schema/type_container'
 require 'dry/schema/rule_applier'
 require 'dry/schema/key_coercer'
 require 'dry/schema/value_coercer'

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -4,6 +4,7 @@ require 'dry/configurable'
 require 'dry/initializer'
 
 require 'dry/schema/type_registry'
+require 'dry/schema/type_container'
 require 'dry/schema/rule_applier'
 require 'dry/schema/key_coercer'
 require 'dry/schema/value_coercer'
@@ -28,7 +29,7 @@ module Dry
       extend Dry::Configurable
 
       setting :key_map_type
-      setting :type_registry, TypeRegistry.new
+      setting :type_registry_namespace, :nominal
       setting :filter_empty_string, false
 
       option :steps, default: -> { EMPTY_ARRAY.dup }

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -4,7 +4,6 @@ require 'dry/configurable'
 require 'dry/initializer'
 
 require 'dry/schema/type_registry'
-require 'dry/schema/type_container'
 require 'dry/schema/rule_applier'
 require 'dry/schema/key_coercer'
 require 'dry/schema/value_coercer'

--- a/lib/dry/schema/type_container.rb
+++ b/lib/dry/schema/type_container.rb
@@ -5,6 +5,13 @@ require 'dry/types'
 
 module Dry
   module Schema
+    # A class to build containers for custom types, which can be used in schemas
+    #
+    # @example
+    #   MyTypeContainer = Dry::Schema::TypeContainer.new
+    #   MyTypeContainer.register('params.fancy_string', Types::FancyString)
+    #
+    # @api public
     class TypeContainer
       include Dry::Container::Mixin
 

--- a/lib/dry/schema/type_container.rb
+++ b/lib/dry/schema/type_container.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'dry-container'
+require 'dry-types'
+
 module Dry
   module Schema
     class TypeContainer

--- a/lib/dry/schema/type_container.rb
+++ b/lib/dry/schema/type_container.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Dry
+  module Schema
+    class TypeContainer
+      include Dry::Container::Mixin
+
+      def initialize(types_container = Dry::Types.container)
+        super()
+
+        merge(types_container)
+      end
+
+      alias registered? key?
+    end
+  end
+end

--- a/lib/dry/schema/type_container.rb
+++ b/lib/dry/schema/type_container.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'dry-container'
-require 'dry-types'
+require 'dry/container'
+require 'dry/types'
 
 module Dry
   module Schema

--- a/lib/dry/schema/type_registry.rb
+++ b/lib/dry/schema/type_registry.rb
@@ -36,6 +36,7 @@ module Dry
       # @api private
       def [](name)
         key = [namespace, name].compact.join(DOT)
+
         type = types.registered?(key) ? types[key] : types[name.to_s]
         type
       end

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe 'Registering custom types' do
     Types::Strict::String.constructor(&:strip).constructor(&:downcase)
   end
 
-  let(:params) {
+  let(:params) do
     {
       email: 'some@body.abc',
       age: '  I AM NOT THAT OLD '
     }
-  }
+  end
 
   context 'types not registered' do
     it 'raises exception that nothing is registered with the key' do

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Registering custom types' do
+  subject(:schema) do
+    Dry::Schema.define do
+      # config.types = types
+
+      required(:email).filled(:string)
+      required(:age).filled(:trimmed_string)
+    end
+  end
+
+  let(:trimmed_string) do
+    Types::Strict::String.constructor(&:trim).constructor(&:downcase)
+  end
+
+  let(:types) do
+    Dry::Schema::TypeContainer.new
+  end
+
+  let(:params) {
+    {
+      email: 'some@body.abc',
+      age: '  I AM NOT THAT OLD '
+    }
+  }
+
+  context 'types not registered' do
+    before do
+      types.register('missing_string', trimmed_string)
+    end
+
+    it 'raises exception that nothing is registered with the key' do
+      expect { subject }.to raise_exception(Dry::Container::Error)
+    end
+  end
+
+  context 'custom type is registered' do
+    it 'does not raise any exceptions' do
+      expect { subject }.not_to raise_exception
+    end
+
+    it 'coerces the type' do
+      expect(subject[:age]).to eql('I AM NOT THAT OLD')
+    end
+  end
+end

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -1,25 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Registering custom types' do
-  let(:klass) do
-    Test::Kontainer = type_container
-
-    class Test::CustomTypeSchema < Dry::Schema::Params
-      define do
-        config.types = Test::Kontainer
-
-        required(:email).filled(:string)
-        required(:age).filled(:trimmed_string)
-      end
-    end
-  end
-
-  subject(:schema) { klass.new.call(params) }
-
-  let(:type_container) { Dry::Schema::TypeContainer.new  }
-
-  let(:trimmed_string) do
-    Types::Strict::String.constructor(&:strip).constructor(&:downcase)
+  let(:container_without_types) { Dry::Schema::TypeContainer.new }
+  let(:container_with_types) do
+    Dry::Schema::TypeContainer.new
   end
 
   let(:params) do
@@ -29,24 +13,93 @@ RSpec.describe 'Registering custom types' do
     }
   end
 
-  context 'types not registered' do
-    it 'raises exception that nothing is registered with the key' do
-      expect { subject }.to raise_exception(Dry::Container::Error)
+  before do
+    container_with_types.register(
+      'params.trimmed_string',
+      Types::Strict::String.constructor(&:strip).constructor(&:downcase)
+    )
+
+    stub_const('ContainerWithoutTypes', container_without_types)
+    stub_const('ContainerWithTypes', container_with_types)
+  end
+
+  context 'class-based definition' do
+    subject(:schema) { klass.new.call(params) }
+
+    context 'custom type is not registered' do
+      let(:klass) do
+        class Test::CustomTypeSchema < Dry::Schema::Params
+          define do
+            config.types = ContainerWithoutTypes
+
+            required(:email).filled(:string)
+            required(:age).filled(:trimmed_string)
+          end
+        end
+      end
+
+      it 'raises exception that nothing is registered with the key' do
+        expect { subject }.to raise_exception(Dry::Container::Error)
+      end
+    end
+
+    context 'custom type is registered' do
+      let(:klass) do
+        class Test::CustomTypeSchema < Dry::Schema::Params
+          define do
+            config.types = ContainerWithTypes
+
+            required(:email).filled(:string)
+            required(:age).filled(:trimmed_string)
+          end
+        end
+      end
+
+      it 'does not raise any exceptions' do
+        expect { subject }.not_to raise_exception
+      end
+
+      it 'coerces the type' do
+        expect(subject[:age]).to eql('i am not that old')
+      end
     end
   end
 
-  context 'custom type is registered' do
-    before do
-      type_container.register('trimmed_string', trimmed_string)
-      type_container.register('params.trimmed_string', trimmed_string)
+  context 'DSL-based definition' do
+    subject(:schema) { schema_object.call(params) }
+
+    context 'custom type is not registered' do
+      let(:schema_object) do
+        Dry::Schema.Params do
+          config.types = ContainerWithoutTypes
+
+          required(:email).filled(:string)
+          required(:age).filled(:trimmed_string)
+        end
+      end
+
+      it 'raises exception that nothing is registered with the key' do
+        expect { subject }.to raise_exception(Dry::Container::Error)
+      end
     end
 
-    it 'does not raise any exceptions' do
-      expect { subject }.not_to raise_exception
-    end
+    context 'custom type is registered' do
+      let(:schema_object) do
+        Dry::Schema.Params do
+          config.types = ContainerWithTypes
 
-    it 'coerces the type' do
-      expect(subject[:age]).to eql('i am not that old')
+          required(:email).filled(:string)
+          required(:age).filled(:trimmed_string)
+        end
+      end
+
+      it 'does not raise any exceptions' do
+        expect { subject }.not_to raise_exception
+      end
+
+      it 'coerces the type' do
+        expect(subject[:age]).to eql('i am not that old')
+      end
     end
   end
 end


### PR DESCRIPTION
So [I wanted this feature](https://dry-rb.zulipchat.com/#narrow/stream/191662-general/topic/dry-validation/near/167066346) and I tried to implement it. 

The implementation is kind of straightforward:

1. Instead of using the global processor's type registry, we're instantiating a new registry for each DSL instance. It damages the total RAM usage, but it enables us to configure types per-instance
2. Since we no longer use global registries, I've renamed `Processor`'s `type_registry` to `type_registry_namespace`.
3. `config` has a new field now: `types`. I was thinking about renaming it to `type_container`, WDYT?
4. I've introduced a new class: `Dry::Schema::TypeContainer`, which is a simple wrapper around `Dry::Types` container. We need it for a couple of reasons:
* `Dry::Types` quacks *kind of* like a container. Except it has `registered?` instead of `key?`. Don't want to change the dependency — it would break backwards compatibility
* I don't want people to manually run `container.merge(Dry::Types.container)` as it exposes internal API, nor do I want them to alias `registered?` to `key?` for compatibility


So the idiomatic code would look something like this:

```ruby
module MyFancyProject
  SchemaTypes = Dry::Schema::TypeContainer.new
  SchemaTypes.register('params.my_string', Types::MyString)
end

Schema = Dry::Validation.Params do
  config.types = MyFancyProject::SchemaTypes
  optional(:foo).filled(:my_string)
end
```