### PR TITLE
Fix regression around coercion of arrays of hashes in Params schema

### DIFF
--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -33,7 +33,9 @@ module Dry
 
           type(final_type)
 
-          schema_dsl[name].filter(:hash?, schema.filter_schema) if schema.filter_rules?
+          if schema.filter_rules?
+            schema_dsl[name].filter { hash?.then(schema(schema.filter_schema)) }
+          end
 
           schema
         end

--- a/spec/integration/params/macros/array_spec.rb
+++ b/spec/integration/params/macros/array_spec.rb
@@ -1,4 +1,21 @@
 RSpec.describe 'Params / Macros / array' do
+  context 'array of hashes' do
+    subject(:schema) do
+      Dry::Schema.Params do
+        required(:songs).array(:hash) do
+          required(:title).filled(:string)
+        end
+      end
+    end
+
+    it 'coerces an empty string to an array' do
+      result = schema.("songs" => "")
+
+      expect(result).to be_success
+      expect(result.to_h).to eq(songs: [])
+    end
+  end
+
   context 'when inherited' do
     subject(:schema) do
       Dry::Schema.Params(parent: parent) do


### PR DESCRIPTION
This behaviour broke when https://github.com/dry-rb/dry-schema/pull/154 was merged.

I've added a failing spec. Here's how it fails:

```

1) Params / Macros / array array of hashes coerces an empty string to an array
    Got 2 failures:

    1.1) Failure/Error: expect(result).to be_success
          expected `#<Dry::Schema::Result{:songs=>""} errors={:songs=>["must be a hash"]}>.success?` to return true, got false
        # ./spec/integration/params/macros/array_spec.rb:14:in `block (3 levels) in <top (required)>'

    1.2) Failure/Error: expect(result.to_h).to eq(songs: [])
        
          expected: {:songs=>[]}
                got: {:songs=>""}
        
          (compared using ==)
        
          Diff:
          @@ -1,2 +1,2 @@
          -:songs => [],
          +:songs => "",
          
        # ./spec/integration/params/macros/array_spec.rb:15:in `block (3 levels) in <top (required)>'
```

If I comment out this line inside `Dry::Schema::Macros::Schema#define`, then this spec passes!

```ruby
def define(&block)
  definition = schema_dsl.new(&block)
  schema = definition.call

  type_schema = array? ? parent_type.of(definition.type_schema) : definition.type_schema
  final_type = optional? ? type_schema.optional : type_schema

  type(final_type)

  # schema_dsl[name].filter(:hash?, schema.filter_schema) if schema.filter_rules?
  # ^^^^ COMMENTING OUT THIS LINE

  schema
end
```

I'd like to actually make a fix but I the whole `schema.filter_rules?` behaviour is not clear to me yet.

I think the problem is that it's incorrectly adding a `hash?` filter to the top level key that is _actually_ intended to be an array