### PR TITLE
Fix predicate inference for BigDecimal

### DIFF
--- a/lib/dry/schema/predicate_inferrer.rb
+++ b/lib/dry/schema/predicate_inferrer.rb
@@ -17,7 +17,8 @@ module Dry
         Integer => :int?,
         NilClass => :nil?,
         String => :str?,
-        TrueClass => :true?
+        TrueClass => :true?,
+        BigDecimal => :decimal?
       }.freeze
 
       REDUCED_TYPES = {

--- a/spec/integration/schema/macros/value_spec.rb
+++ b/spec/integration/schema/macros/value_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Macros #value' do
     end
 
     it 'infers type?(type) predicate' do
-      expect(schema.(price: nil).errors).to eql(price: ['must be BigDecimal'])
+      expect(schema.(price: nil).errors).to eql(price: ['must be a decimal'])
       expect(schema.(price: BigDecimal('19.4'))).to be_success
     end
   end

--- a/spec/unit/dry/schema/predicate_inferrer_spec.rb
+++ b/spec/unit/dry/schema/predicate_inferrer_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe Dry::Schema::PredicateInferrer, '#[]' do
     expect(inferrer[type(:bool)]).to eql([:bool?])
   end
 
+  it 'returns decimal? or str? for a sum type' do
+    expect(inferrer[type(:decimal) | type(:string)]).to eql([:decimal?, :str?])
+  end
+
   it 'returns int? for a lax constructor integer type' do
     expect(inferrer[type('params.integer').lax]).to eql([:int?])
   end


### PR DESCRIPTION
Fixes #158

```ruby
dry-schema> s=schema { required(:foo).value(::Types::Params::Decimal | ::Types::String) }
=> #<Dry::Schema::Processor keys=[:foo] rules={:foo=>"key?(:foo) AND key[foo](decimal? OR str?)"}>
dry-schema> s.(foo: '1.2')
=> #<Dry::Schema::Result{:foo=>0.12e1} errors={}>
dry-schema> s.(foo: [])
=> #<Dry::Schema::Result{:foo=>[]} errors={:foo=>["must be a decimal or must be a string"]}>
```