### PR TITLE
make Monads extension to wrap schema ouput

### DIFF
--- a/lib/dry/schema/extensions/monads.rb
+++ b/lib/dry/schema/extensions/monads.rb
@@ -19,9 +19,9 @@ module Dry
       # @api public
       def to_monad
         if success?
-          Success(self)
+          Success(output)
         else
-          Failure(self)
+          Failure(errors.to_h)
         end
       end
     end

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Dry::Schema::Result do
 
         expect(monad).to be_a Dry::Monads::Result
         expect(monad).to be_success
-        expect(monad.value!).to be(result)
+        expect(monad.value!).to eq(result.output)
       end
     end
   end
@@ -33,12 +33,12 @@ RSpec.describe Dry::Schema::Result do
     let(:input) { { name: '' } }
 
     describe '#to_monad' do
-      it 'wraps Reuslt with Failure constructor' do
+      it 'wraps Result with Failure constructor' do
         monad = result.to_monad
 
         expect(monad).to be_a Dry::Monads::Result
         expect(monad).to be_failure
-        expect(monad.failure).to be(result)
+        expect(monad.failure).to eq(result.errors.to_h)
       end
     end
   end


### PR DESCRIPTION
I found out that `Monads` extension is actually not working as it described in [docs](https://dry-rb.org/gems/dry-schema/extensions/monads/)
It _double wraps_ the output which is not very useful:
```ruby
schema = Dry::Schema.Params { required(:name).filled(:str?, size?: 2..4) }
schema.call(name: 'Jane').to_monad
# => Success(#<Dry::Schema::Result{:name=>"Jane"} errors={}>)
schema.call(name: '').to_monad
# => Failure(#<Dry::Schema::Result{:name=>""} errors={:name=>["must be filled"]}>
```

I've changed few lines but I'm concerning of one thing:: should there be `errors.to_h` for `Failure` or just `errors` (instance of `Dry::Schema::MessageSet` class itself)