### PR TITLE
Reject attempts to build a nested schema for array types built on Dry::Types::Nominal

### DIFF
--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -28,6 +28,12 @@ module Dry
         #   @api private
         option :predicate_inferrer, default: proc { PredicateInferrer.new(compiler.predicates) }
 
+        # @!attribute [r] primitive_inferrer
+        #   PrimitiveInferrer used to get a list of primitive classes from configured type
+        #   @return [PrimitiveInferrer]
+        #   @api private
+        option :primitive_inferrer, default: proc { PrimitiveInferrer.new }
+
         # @overload value(*predicates, **predicate_opts)
         #   Set predicates without and with arguments
         #

--- a/lib/dry/schema/macros/filled.rb
+++ b/lib/dry/schema/macros/filled.rb
@@ -10,12 +10,6 @@ module Dry
       #
       # @api private
       class Filled < Value
-        # @!attribute [r] primitive_inferrer
-        #   PrimitiveInferrer used to get a list of primitive classes from configured type
-        #   @return [PrimitiveInferrer]
-        #   @api private
-        option :primitive_inferrer, default: proc { PrimitiveInferrer.new }
-
         # @api private
         def call(*predicates, **opts, &block)
           ensure_valid_predicates(predicates)

--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -28,8 +28,8 @@ module Dry
           definition = schema_dsl.new(&block)
           schema = definition.call
           type_schema =
-            if array?
-              parent_type.of(definition.type_schema)
+            if array?(parent_type)
+              build_array_type(parent_type, definition.type_schema)
             elsif redefined_schema?(args)
               parent_type.schema(definition.types)
             else
@@ -54,11 +54,6 @@ module Dry
         # @api private
         def optional?
           parent_type.optional?
-        end
-
-        # @api private
-        def array?
-          parent_type.respond_to?(:of)
         end
 
         # @api private

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -17,8 +17,8 @@ module Dry
             current_type = schema_dsl.types[name]
 
             updated_type =
-              if current_type.respond_to?(:of)
-                current_type.of(schema.type_schema)
+              if array?(current_type)
+                build_array_type(current_type, schema.type_schema)
               else
                 schema.type_schema
               end
@@ -37,6 +37,25 @@ module Dry
           each(type_spec.type.member) if type_spec.respond_to?(:member)
 
           self
+        end
+
+        # @api private
+        def array?(type)
+          primitive_inferrer[type].eql?([::Array])
+        end
+
+        # @api private
+        def build_array_type(array_type, member)
+          if array_type.respond_to?(:of)
+            array_type.of(member)
+          else
+            raise ArgumentError, <<~ERROR.split("\n").join(' ')
+              Cannot define schema for a nominal array type.
+              Array types must be instances of Dry::Types::Array,
+              usually constructed with Types::Constructor(Array) { ... } or
+              Dry::Types['array'].constructor { ... }
+            ERROR
+          end
         end
 
         # @api private

--- a/lib/dry/schema/primitive_inferrer.rb
+++ b/lib/dry/schema/primitive_inferrer.rb
@@ -32,6 +32,7 @@ module Dry
         def visit_hash(_)
           Hash
         end
+        alias_method :visit_schema, :visit_hash
 
         # @api private
         def visit_array(_)

--- a/spec/integration/schema/macros/array_spec.rb
+++ b/spec/integration/schema/macros/array_spec.rb
@@ -274,4 +274,26 @@ RSpec.describe 'Macros #array' do
       expect(schema.(foo: [{ bar: '123' }])).to be_success
     end
   end
+
+  context 'primitive array type with nested schema' do
+    it 'is not allowed for chained macros' do
+      nominal_array = Dry::Types::Nominal.new(Array)
+      expect {
+        Dry::Schema.Params do
+          required(:values).value(nominal_array).each { hash {  } }
+        end
+      }.to raise_error(ArgumentError, /Types::Constructor/)
+    end
+
+    it 'is not allowed for schemas in parameters' do
+      nominal_array = Dry::Types::Nominal.new(Array)
+      schema = Dry::Schema.Params { required(:bar).value(:integer) }
+
+      expect {
+        Dry::Schema.Params do
+          required(:values).value(nominal_array, schema)
+        end
+      }.to raise_error(ArgumentError, /Types::Constructor/)
+    end
+  end
 end

--- a/spec/unit/dry/schema/primitive_inferrer_spec.rb
+++ b/spec/unit/dry/schema/primitive_inferrer_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Dry::Schema::PrimitiveInferrer, '#[]' do
     expect(inferrer[type(:array)]).to eql([Array])
   end
 
+  it 'returns Array for a primitive array' do
+    expect(inferrer[Types.Constructor(Array)]).to eql([Array])
+  end
+
   it 'returns Hash for a string type' do
     expect(inferrer[type(:hash)]).to eql([Hash])
   end


### PR DESCRIPTION
Considering latest changes in dry-types (not released yet) it shouldn't happen very often since the only way to construct `Nominal<::Array>` is to build it manually. Still, it's better to raise a meaningful error than deal with rather unexpected (and inexplicable for many) behavior.