### PR TITLE
Fix overcaching in I18n backend

### DIFF
--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -92,7 +92,7 @@ module Dry
         #
         # @api public
         def call(predicate, options)
-          cache.fetch_or_store([predicate, options.reject { |k,| k.equal?(:input) }]) do
+          cache.fetch_or_store(cache_key(predicate, options)) do
             text, meta = lookup(predicate, options)
             [Template[text], meta] if text
           end
@@ -165,6 +165,15 @@ module Dry
         # @api private
         def default_locale
           config.default_locale
+        end
+
+        # @api private
+        def cache_key(predicate, options)
+          if options.key?(:input)
+            [predicate, options.reject { |k,| k.equal?(:input) }]
+          else
+            [predicate, options]
+          end
         end
 
         private

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -81,7 +81,7 @@ module Dry
 
       # @api private
       def cache_key(predicate, options)
-        if options.key?(:locale)
+        if options[:locale]
           super
         else
           [*super, I18n.locale]

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -79,6 +79,15 @@ module Dry
         self
       end
 
+      # @api private
+      def cache_key(predicate, options)
+        if options.key?(:locale)
+          super
+        else
+          [*super, I18n.locale]
+        end
+      end
+
       private
 
       # @api private

--- a/lib/dry/schema/messages/namespaced.rb
+++ b/lib/dry/schema/messages/namespaced.rb
@@ -64,6 +64,11 @@ module Dry
           base_paths = messages.rule_lookup_paths(tokens)
           base_paths.map { |key| key.gsub('dry_schema', "dry_schema.#{namespace}") } + base_paths
         end
+
+        # @api private
+        def cache_key(predicate, options)
+          messages.cache_key(predicate, options)
+        end
       end
     end
   end

--- a/spec/integration/messages/i18n/with_locale_spec.rb
+++ b/spec/integration/messages/i18n/with_locale_spec.rb
@@ -4,46 +4,109 @@ require 'dry/schema'
 require 'dry/schema/messages/i18n'
 
 RSpec.describe 'I18n validation messages / using I18n.with_locale' do
-  subject(:schema) do
-    Dry::Schema.Params do
-      config.messages.backend = :i18n
-      config.messages.namespace = :user
+  around do |ex|
+    I18n.available_locales = %i[en ru]
+    I18n.locale = I18n.default_locale = :en
+    ex.run
+  end
 
-      required(:name).filled(:string)
+  context 'with current locale' do
+    subject(:schema) do
+      Dry::Schema.Params do
+        config.messages.backend = :i18n
+        config.messages.namespace = :user
+
+        required(:name).filled(:string)
+      end
+    end
+
+    around do |example|
+      I18n.backend.store_translations(:en,
+        dry_schema: { errors: { user: { rules: { name: { filled?: 'must be filled' } } } } }
+      )
+
+      I18n.backend.store_translations(:ru,
+        dry_schema: { errors: { user: { rules: { name: { filled?: 'заполните это поле' } } } } }
+      )
+
+      I18n.with_locale(:ru) { example.run }
+    end
+
+    let(:result) { schema.(name: '') }
+
+    let(:expected) { ['заполните это поле'] }
+
+    it 'uses correct locale without providing :locale option for errors' do
+      expect(result.errors[:name]).to eql(expected)
+    end
+
+    it 'uses provided :locale option for errors' do
+      expect(result.errors(locale: I18n.locale)[:name]).to eql(expected)
+    end
+
+    it 'uses correct locale without providing :locale option for messages' do
+      expect(result.messages[:name]).to eql(expected)
+    end
+
+    it 'uses provided :locale option for messages' do
+      expect(result.messages(locale: I18n.locale)[:name]).to eql(expected)
     end
   end
 
-  let(:result) { schema.(name: '') }
-  let(:expected) { ['заполните это поле'] }
+  context 'caching' do
+    shared_examples_for 'caching behavior' do
+      it 'uses current locale in cache key and returns different messages for different locales' do
+        en_message = I18n.with_locale(:en) { schema.(name: '').errors[:name] }
+        ru_message = I18n.with_locale(:ru) { schema.(name: '').errors[:name] }
 
-  around do |example|
-    I18n.available_locales = %i[en ru]
-    I18n.locale = I18n.default_locale = :en
+        expect(en_message).to eql(['must be filled'])
+        expect(ru_message).to eql(['заполните это поле'])
+      end
+    end
 
-    I18n.backend.store_translations(:en,
-      dry_schema: { errors: { user: { rules: { name: { filled?: 'must be filled' } } } } }
-    )
+    context 'without namespace' do
+      subject(:schema) do
+        Dry::Schema.Params do
+          config.messages.backend = :i18n
 
-    I18n.backend.store_translations(:ru,
-      dry_schema: { errors: { user: { rules: { name: { filled?: 'заполните это поле' } } } } }
-    )
+          required(:name).filled(:string)
+        end
+      end
 
-    I18n.with_locale(:ru) { example.run }
-  end
+      before do
+        I18n.backend.store_translations(:en,
+          dry_schema: { errors: { rules: { name: { filled?: 'must be filled' } } } }
+        )
 
-  it 'uses correct locale without providing :locale option for errors' do
-    expect(result.errors[:name]).to eql(expected)
-  end
+        I18n.backend.store_translations(:ru,
+          dry_schema: { errors: { rules: { name: { filled?: 'заполните это поле' } } } }
+        )
+      end
 
-  it 'uses provided :locale option for errors' do
-    expect(result.errors(locale: I18n.locale)[:name]).to eql(expected)
-  end
+      include_examples 'caching behavior'
+    end
 
-  it 'uses correct locale without providing :locale option for messages' do
-    expect(result.messages[:name]).to eql(expected)
-  end
+    context 'with namespace' do
+      subject(:schema) do
+        Dry::Schema.Params do
+          config.messages.backend = :i18n
+          config.messages.namespace = :user
 
-  it 'uses provided :locale option for messages' do
-    expect(result.messages(locale: I18n.locale)[:name]).to eql(expected)
+          required(:name).filled(:string)
+        end
+      end
+
+      before do
+        I18n.backend.store_translations(:en,
+          dry_schema: { errors: { user: { rules: { name: { filled?: 'must be filled' } } } } }
+        )
+
+        I18n.backend.store_translations(:ru,
+          dry_schema: { errors: { user: { rules: { name: { filled?: 'заполните это поле' } } } } }
+        )
+      end
+
+      include_examples 'caching behavior'
+    end
   end
 end

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -161,4 +161,20 @@ RSpec.describe Dry::Schema::Messages::I18n do
       end
     end
   end
+
+  describe '#cache_key' do
+    it "uses adds current locale when it's not passed or nil" do
+      expect(I18n.with_locale(:en) { messages.cache_key(:size?, {}) })
+        .to eql([:size?, {}, :en])
+      expect(I18n.with_locale(:pl) { messages.cache_key(:size?, {}) })
+        .to eql([:size?, {}, :pl])
+      expect(I18n.with_locale(:en) { messages.cache_key(:size?, locale: nil) })
+        .to eql([:size?, { locale: nil }, :en])
+    end
+
+    it "doesn't add current locale if it's passed explicitly" do
+      expect(I18n.with_locale(:en) { messages.cache_key(:size?, locale: :pl) })
+        .to eql([:size?, { locale: :pl }])
+    end
+  end
 end

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -150,5 +150,15 @@ RSpec.describe Dry::Schema::Messages::I18n do
         expect(template.(size_left: 1, size_right: 2)).to eql('size must be within 1 - 2')
       end
     end
+
+    context 'with dynamic locale' do
+      it 'uses current locale in cache key and returns different messages for different locales' do
+        template, = I18n.with_locale(:en) { messages[:filled?, path: :name] }
+        expect(template.()).to eql('must be filled')
+
+        template, = I18n.with_locale(:pl) { messages[:filled?, path: :name] }
+        expect(template.()).to eql('nie może być pusty')
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes a bug where the same message gets used even when you change current locale with I18n.with_locale. There are two failing cases: for a simple I18n backend and for namespaced messages wrapping I18n. 