### PR TITLE
Use strict types in the default processor

### DIFF
--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -29,7 +29,7 @@ module Dry
       extend Dry::Configurable
 
       setting :key_map_type
-      setting :type_registry_namespace, :nominal
+      setting :type_registry_namespace, :strict
       setting :filter_empty_string, false
 
       option :steps, default: -> { EMPTY_ARRAY.dup }

--- a/lib/dry/schema/type_registry.rb
+++ b/lib/dry/schema/type_registry.rb
@@ -18,12 +18,12 @@ module Dry
       attr_reader :namespace
 
       # @api private
-      def self.new(types = Dry::Types, namespace = :nominal)
+      def self.new(types = Dry::Types, namespace = :strict)
         super
       end
 
       # @api private
-      def initialize(types, namespace = :nominal)
+      def initialize(types, namespace = :strict)
         @types = types
         @namespace = namespace
       end

--- a/spec/integration/params/constructor_types_spec.rb
+++ b/spec/integration/params/constructor_types_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe 'Params / Constructor Types' do
       expect(result.to_h).to eql(nums: [])
     end
   end
+
+  context 'using Schema processor' do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:name).maybe(Types::String.constructor(&:upcase))
+      end
+    end
+
+    it 'uses the constructor' do
+      expect(schema.(name: nil)[:name]).to be_nil
+      expect(schema.(name: 'John')[:name]).to eql('JOHN')
+    end
+  end
 end


### PR DESCRIPTION
This might look like a big change but it's actually not. It fixes one corner case when `maybe` is used with a constructor type, everything else seems to work 👌