### PR TITLE
Fix array predicate regression

### DIFF
--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -28,7 +28,7 @@ module Dry
           definition = schema_dsl.new(&block)
           schema = definition.call
           type_schema =
-            if array?(parent_type)
+            if array_type?(parent_type)
               build_array_type(parent_type, definition.type_schema)
             elsif redefined_schema?(args)
               parent_type.schema(definition.types)

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -17,7 +17,7 @@ module Dry
             current_type = schema_dsl.types[name]
 
             updated_type =
-              if array?(current_type)
+              if array_type?(current_type)
                 build_array_type(current_type, schema.type_schema)
               else
                 schema.type_schema
@@ -40,7 +40,7 @@ module Dry
         end
 
         # @api private
-        def array?(type)
+        def array_type?(type)
           primitive_inferrer[type].eql?([::Array])
         end
 

--- a/spec/integration/params/predicates/array_spec.rb
+++ b/spec/integration/params/predicates/array_spec.rb
@@ -298,4 +298,20 @@ RSpec.describe 'Predicates: Array' do
       end
     end
   end
+
+  context 'with block-based syntax' do
+    subject(:schema) do
+      Dry::Schema.Params do
+        required(:foo) { array? { each(:int?) } }
+      end
+    end
+
+    context 'with valid input' do
+      let(:input) { { foo: [3] } }
+
+      it 'is successful' do
+        expect(result).to be_successful
+      end
+    end
+  end
 end

--- a/spec/integration/schema/predicates/array_spec.rb
+++ b/spec/integration/schema/predicates/array_spec.rb
@@ -144,4 +144,20 @@ RSpec.describe 'Predicates: Array' do
       end
     end
   end
+
+  context 'with block-based syntax' do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:foo) { array? { each(:int?) } }
+      end
+    end
+
+    context 'with valid input' do
+      let(:input) { { foo: [3] } }
+
+      it 'is successful' do
+        expect(result).to be_successful
+      end
+    end
+  end
 end


### PR DESCRIPTION
Renamed method to not interfere with the dry-logic predicate. But I can't think of the way to prevent errors like this with tests.

Fixes #186