### PR TITLE
More verbose messages for MissingMessageError

### DIFF
--- a/lib/dry/schema/constants.rb
+++ b/lib/dry/schema/constants.rb
@@ -30,7 +30,7 @@ module Dry
         *rest, rule = path
         super(<<~STR)
           Message template for #{rule.inspect} under #{rest.join(DOT).inspect} was not found. Searched in:
-          #{paths.map { |path| "\"#{path}\"" }.join("\n")}
+          #{paths.map { |string| "\"#{string}\"" }.join("\n")}
         STR
       end
     end

--- a/lib/dry/schema/constants.rb
+++ b/lib/dry/schema/constants.rb
@@ -26,10 +26,11 @@ module Dry
     # An error raised when a localized message cannot be found
     MissingMessageError = Class.new(StandardError) do
       # @api private
-      def initialize(path)
+      def initialize(path, paths = [])
         *rest, rule = path
         super(<<~STR)
-          Message template for #{rule.inspect} under #{rest.join(DOT).inspect} was not found
+          Message template for #{rule.inspect} under #{rest.join(DOT).inspect} was not found. Searched in:
+          #{paths.map { |path| "\"#{path}\"" }.join("\n")}
         STR
       end
     end

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -130,7 +130,7 @@ module Dry
           path: path.last, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
         ).to_h
 
-        template, meta = messages[predicate, options] || raise(MissingMessageError, path)
+        template, meta = messages[predicate, options] || raise(MissingMessageError.new(path, (messages.looked_up_paths(predicate, options))))
 
         text = message_text(template, tokens, options)
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -130,7 +130,8 @@ module Dry
           path: path.last, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
         ).to_h
 
-        template, meta = messages[predicate, options] || raise(MissingMessageError.new(path, (messages.looked_up_paths(predicate, options))))
+        template, meta = messages[predicate, options] ||
+          raise(MissingMessageError.new(path, messages.looked_up_paths(predicate, options)))
 
         text = message_text(template, tokens, options)
 

--- a/lib/dry/schema/messages/namespaced.rb
+++ b/lib/dry/schema/messages/namespaced.rb
@@ -55,7 +55,7 @@ module Dry
         end
 
         # @api private
-        def lookup_paths(tokens)
+        def filled_lookup_paths(tokens)
           super(tokens.merge(root: "#{tokens[:root]}.#{namespace}")) + super
         end
 

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -68,6 +68,18 @@ module Dry
         @t = proc { |key, locale: default_locale| get("%<locale>s.#{key}", locale: locale) }
       end
 
+      # Get an array of looked up paths
+      #
+      # @param [Symbol] predicate
+      # @param [Hash] options
+      #
+      # @return [String]
+      #
+      # @api public
+      def looked_up_paths(predicate, options)
+        super.map { |path| path % { locale: options[:locale] || default_locale } }
+      end
+
       # Get a message for the given key and its options
       #
       # @param [Symbol] key

--- a/spec/unit/dry/schema/message_compiler/visit_spec.rb
+++ b/spec/unit/dry/schema/message_compiler/visit_spec.rb
@@ -52,7 +52,15 @@ RSpec.describe Dry::Schema::MessageCompiler, '#visit' do
 
     it 'raises MissingMessageError' do
       expect { result }.to raise_error(Dry::Schema::MissingMessageError, <<~STR)
-        Message template for :street under "user.address" was not found
+        Message template for :street under "user.address" was not found. Searched in:
+        "en.dry_schema.errors.rules.street.oops?.arg.default"
+        "en.dry_schema.errors.rules.street.oops?"
+        "en.dry_schema.errors.oops?.failure"
+        "en.dry_schema.errors.oops?.value.street"
+        "en.dry_schema.errors.oops?.value.string.arg.default"
+        "en.dry_schema.errors.oops?.value.string"
+        "en.dry_schema.errors.oops?.arg.default"
+        "en.dry_schema.errors.oops?"
       STR
     end
   end


### PR DESCRIPTION
This PR adds more verbose error messages for `MissingMessageError` which shows all looked up paths:
```
Message template for :street under "user.address" was not found. Searched in:
"en.dry_schema.errors.rules.street.oops?.arg.default"
"en.dry_schema.errors.rules.street.oops?"
"en.dry_schema.errors.oops?.failure"
"en.dry_schema.errors.oops?.value.street"
"en.dry_schema.errors.oops?.value.string.arg.default"
"en.dry_schema.errors.oops?.value.string"
"en.dry_schema.errors.oops?.arg.default"
"en.dry_schema.errors.oops?"
```

Closes #178 