### PR TITLE
New processor steps interface and before/after step callbacks

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -59,9 +59,6 @@ module Dry
       # @return [Compiler] The type of the processor (Params, JSON, or a custom sub-class)
       option :processor_type, default: -> { Processor }
 
-      # @return [Hash] Steps for the processor
-      option :steps, default: -> { ProcessorSteps.new }
-
       # @return [Array] An array with macros defined within the DSL
       option :macros, default: -> { EMPTY_ARRAY.dup }
 
@@ -73,6 +70,9 @@ module Dry
 
       # @return [Config] Configuration object exposed via `#configure` method
       option :config, optional: true, default: proc { parent ? parent.config.dup : Config.new }
+
+      # @return [ProcessorSteps] Steps for the processor
+      option :steps, default: proc { parent ? parent.steps.dup : ProcessorSteps.new }
 
       # Build a new DSL object and evaluate provided block
       #

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -77,16 +77,6 @@ module Dry
         end
       end
 
-      # Append a step
-      #
-      # @return [Processor]
-      #
-      # @api private
-      def <<(step)
-        steps << step
-        self
-      end
-
       # Apply processing steps to the provided input
       #
       # @param [Hash] input

--- a/lib/dry/schema/processor_steps.rb
+++ b/lib/dry/schema/processor_steps.rb
@@ -89,9 +89,9 @@ module Dry
 
       # @api private
       def validate_step_name(name)
-        unless STEPS_IN_ORDER.include?(name)
-          raise ArgumentError, "Undefined step name #{name}. Available names: #{STEPS_IN_ORDER}"
-        end
+        return if STEPS_IN_ORDER.include?(name)
+
+        raise ArgumentError, "Undefined step name #{name}. Available names: #{STEPS_IN_ORDER}"
       end
     end
   end

--- a/lib/dry/schema/processor_steps.rb
+++ b/lib/dry/schema/processor_steps.rb
@@ -27,9 +27,9 @@ module Dry
 
       def call(result)
         STEPS_IN_ORDER.each do |name|
-          process_step(before_steps[name], result)
+          before_steps[name]&.each { |step| process_step(step, result) }
           process_step(steps[name], result)
-          process_step(after_steps[name], result)
+          after_steps[name]&.each { |step| process_step(step, result) }
         end
         result
       end
@@ -62,7 +62,8 @@ module Dry
       # @api public
       def after(name, &block)
         validate_step_name(name)
-        after_steps[name] = block.to_proc
+        after_steps[name] ||= EMPTY_ARRAY.dup
+        after_steps[name] << block.to_proc
         self
       end
 
@@ -75,7 +76,8 @@ module Dry
       # @api public
       def before(name, &block)
         validate_step_name(name)
-        before_steps[name] = block.to_proc
+        before_steps[name] ||= EMPTY_ARRAY.dup
+        before_steps[name] << block.to_proc
         self
       end
 

--- a/spec/integration/schema/defining_base_schema_spec.rb
+++ b/spec/integration/schema/defining_base_schema_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe 'Defining base schema class' do
 
       optional(:email).filled
       required(:name).filled
+
+      before(:rule_applier) do |result|
+        { name: 'default' }.merge(result.to_h)
+      end
     end
   end
 
@@ -40,6 +44,24 @@ RSpec.describe 'Defining base schema class' do
 
     it 'overrides parent config' do
       expect(schema.config.messages.backend).to eql(:yaml)
+    end
+  end
+
+  it 'inherits callbacks' do
+    expect(schema.(age: 21).errors).to eql(email: ['is missing'])
+  end
+
+  context 'when child schema defines callback' do
+    subject(:schema) do
+      Dry::Schema.define(parent: parent) do
+        required(:email).filled
+
+        before(:rule_applier, &:to_h)
+      end
+    end
+
+    it 'overrides callbacks' do
+      expect(schema.(age: 21).errors).to eql(email: ['is missing'], name: ['is missing'])
     end
   end
 end

--- a/spec/integration/schema/defining_base_schema_spec.rb
+++ b/spec/integration/schema/defining_base_schema_spec.rb
@@ -48,20 +48,24 @@ RSpec.describe 'Defining base schema class' do
   end
 
   it 'inherits callbacks' do
-    expect(schema.(age: 21).errors).to eql(email: ['is missing'])
+    result = schema.(age: 21)
+
+    expect(result.errors).to eql(email: ['is missing'])
+    expect(result.to_h).to eql(age: 21, name: 'default')
   end
 
   context 'when child schema defines callback' do
     subject(:schema) do
       Dry::Schema.define(parent: parent) do
-        required(:email).filled
-
-        before(:rule_applier, &:to_h)
+        before(:rule_applier) do |result|
+          hash = result.to_h
+          hash.merge(name: "new #{hash[:name]}")
+        end
       end
     end
 
-    it 'overrides callbacks' do
-      expect(schema.(age: 21).errors).to eql(email: ['is missing'], name: ['is missing'])
+    it 'stacks callbacks' do
+      expect(schema.({}).to_h).to eql(name: 'new default')
     end
   end
 end

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -98,6 +98,27 @@ RSpec.describe Dry::Schema, '.define' do
     end
   end
 
+  context 'schema with hooks' do
+    subject(:schema) do
+      Dry::Schema.define do
+        optional(:date).maybe(:date?)
+
+        after(:rule_applier) do |result|
+          result.to_h.compact
+        end
+      end
+    end
+
+    it 'calls compact after rule_applier' do
+      expect(schema.(date: nil).to_h).to eq({})
+    end
+
+    it 'calls compact after rule_applier' do
+      expect(schema.(date: "1999-12-12").to_h).to eq({date: "1999-12-12"})
+    end
+
+  end
+
   context 'nested schema' do
     subject(:schema) do
       Dry::Schema.define do

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -98,10 +98,15 @@ RSpec.describe Dry::Schema, '.define' do
     end
   end
 
-  context 'schema with hooks' do
+  context 'schema with callbacks' do
     subject(:schema) do
       Dry::Schema.define do
-        optional(:date).maybe(:date?)
+        optional(:name).maybe(:str?)
+        required(:date).maybe(:date?)
+
+        before(:key_coercer) do |result|
+          { name: 'default' }.merge(result.to_h)
+        end
 
         after(:rule_applier) do |result|
           result.to_h.compact
@@ -109,14 +114,9 @@ RSpec.describe Dry::Schema, '.define' do
       end
     end
 
-    it 'calls compact after rule_applier' do
-      expect(schema.(date: nil).to_h).to eq({})
+    it 'calls callbacks' do
+      expect(schema.(date: nil).to_h).to eq(name: 'default')
     end
-
-    it 'calls compact after rule_applier' do
-      expect(schema.(date: "1999-12-12").to_h).to eq({date: "1999-12-12"})
-    end
-
   end
 
   context 'nested schema' do


### PR DESCRIPTION
This PR implements mentioned in #40 before/after step callbacks and refactors processor steps introducing new class `ProcessorSteps`.

I have some questions:
- should we just ignore callbacks on schema reusing (`required(:foo).schema(FooSchema)`)?
- when a base schema class is used (`Dry::Schema.define(parent: parent)`), should we override callbacks or stack them?
- is the current implementation of `ProcessorSteps` ok? =)