### PR TITLE
Adds support for multiple schema parents

### DIFF
--- a/spec/integration/params/macros/array_spec.rb
+++ b/spec/integration/params/macros/array_spec.rb
@@ -35,5 +35,27 @@ RSpec.describe 'Params / Macros / array' do
       expect(result.errors.to_h).to eql(user: ['must be an array'])
       expect(result.to_h).to eql(id: 1, user: nil)
     end
+
+    context 'from multiple parents' do
+      subject(:schema) do
+        Dry::Schema.Params(parent: [parent, parent2]) do
+          optional(:user).array(:hash)
+        end
+      end
+
+      let(:parent2) do
+        Dry::Schema.Params do
+          optional(:age).value(:integer, gt?: 17)
+        end
+      end
+
+      it 'applies coercion and rules from both parents' do
+        result = schema.('id' => '1', 'age' => '12', 'user' => nil)
+
+        expect(result.errors.to_h).to eql(user: ['must be an array'],
+                                          age: ['must be greater than 17'])
+        expect(result.to_h).to eql(id: 1, user: nil, age: 12)
+      end
+    end
   end
 end

--- a/spec/integration/params/multiple_parents_schema_spec.rb
+++ b/spec/integration/params/multiple_parents_schema_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Defining a schema with multiple parents' do
+  subject(:form) do
+    Dry::Schema.Params(parent: [parent1, parent2]) do
+      required(:name).filled(:string)
+    end
+  end
+
+  let(:parent1) do
+    Dry::Schema.Params do
+      required(:email).filled(:string)
+    end
+  end
+
+  let(:parent2) do
+    Dry::Schema.Params do
+      required(:age).filter(:filled?).value(:integer)
+    end
+  end
+
+  it 'inherits rules' do
+    expect(form.(name: '', age: '').errors.to_h)
+      .to eql(email: ['is missing'], age: ['must be filled'], name: ['must be filled'])
+  end
+end


### PR DESCRIPTION
Re issue #42

This allows an array of parents to be passed as the **parent:** option when creating a schema DSL.

It's a BC change (the schema API for parent: allows an optional DSL (prev API) or array of DSLs).
I've added additional tests for the new behaviour where the parent behaviour was already tested.

The strategy in the solution is to merge all mergeable config with the RHS of the parents overriding the LHS.  In the case of non mergeable config, the last parent is used.

Cheers,
Ian
