### PR TITLE
Remove broken Dry::Equalizer from DSL class

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -51,8 +51,6 @@ module Dry
 
       extend Dry::Initializer
 
-      include ::Dry::Equalizer(:options)
-
       # @return [Compiler] The rule compiler object
       option :compiler, default: -> { Compiler.new }
 


### PR DESCRIPTION
Fixes DSL#inspect and DSL#eql? raises `NoMethodError: undefined method 'options'`