### PR TITLE
Support metadata in I18n message backend

### DIFF
--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -123,13 +123,7 @@ module Dry
 
           return unless path
 
-          text = get(path, opts)
-
-          if text.is_a?(Hash)
-            text.values_at(:text, :meta)
-          else
-            [text, EMPTY_HASH]
-          end
+          get(path, opts).values_at(:text, :meta)
         end
         # rubocop:enable Metrics/AbcSize
 

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -29,7 +29,22 @@ module Dry
       #
       # @api public
       def get(key, options = EMPTY_HASH)
-        t.(key, locale: options.fetch(:locale, default_locale)) if key
+        return unless key
+
+        opts = { locale: options.fetch(:locale, default_locale) }
+
+        text = t.(key, opts)
+        text_key = "#{key}.text"
+
+        return { text: text, meta: EMPTY_HASH } if !text.is_a?(Hash) || !key?(text_key, opts)
+
+        {
+          text: t.(text_key, opts),
+          meta: text.keys.each_with_object({}) do |k, meta|
+            meta_key = "#{key}.#{k}"
+            meta[k] = t.(meta_key, opts) if k != :text && key?(meta_key, opts)
+          end
+        }
       end
 
       # Check if given key is defined

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -149,6 +149,41 @@ RSpec.describe Dry::Schema::Messages::I18n do
 
         expect(template.(size_left: 1, size_right: 2)).to eql('size must be within 1 - 2')
       end
+
+      context 'with meta-data' do
+        def store_translation(translation)
+          I18n.backend.store_translations(
+            :en,
+            messages.config.top_namespace => {
+              errors: {
+                predicate_with_meta: translation
+              }
+            }
+          )
+        end
+
+        it 'finds the meta-data' do
+          store_translation(text: 'text', code: 123)
+
+          template, meta = messages[:predicate_with_meta, path: :path]
+
+          aggregate_failures do
+            expect(template.()).to eq('text')
+            expect(meta).to eq(code: 123)
+          end
+        end
+
+        it 'correctly handles the proc form' do
+          store_translation(text: ->(*) { 'text' }, code: ->(*) { 123 })
+
+          template, meta = messages[:predicate_with_meta, path: :path]
+
+          aggregate_failures do
+            expect(template.()).to eq('text')
+            expect(meta).to eq(code: 123)
+          end
+        end
+      end
     end
 
     context 'with dynamic locale' do


### PR DESCRIPTION
* Updates Dry::Schema::Messages::I18n#get to return a Hash including text and meta
* Removes conditional from Dry::Schema::Messages::Abstract#lookup that disambiguated between Strings and Hashes since both backends now return Hashes
* Supports Procs as I18n translations when metadata is present by using I18n.t rather than hash access when looking for text and meta values

resolves #208
resolves #210