### PR TITLE
Add support for pattern matching to Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# unreleased
+
+### Added
+
+* Pattern matching for `Dry::Schema::Result` objects (@flash-gordon)
+
+[Compare v1.4.2...master](https://github.com/dry-rb/dry-schema/compare/v1.4.2...master)
+
 # 1.4.2 2019-12-19
 
 ### Fixed

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -136,6 +136,15 @@ module Dry
         "#<#{self.class}#{to_h.inspect} errors=#{errors.to_h.inspect}>"
       end
 
+      if RUBY_VERSION >= '2.7'
+        # Pattern matching support
+        #
+        # @api private
+        def deconstruct_keys(_)
+          output
+        end
+      end
+
       private
 
       # A list of failure ASTs produced by rule result objects

--- a/spec/integration/result/pattern_matching_spec.rb
+++ b/spec/integration/result/pattern_matching_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Schema::Result, 'pattern matching' do
+  subject(:result) { schema.(input) }
+
+  context 'basic match' do
+    let(:input) { { 'name' => 'John' } }
+
+    let(:schema) do
+      Dry::Schema.Params { required(:name).filled(min_size?: 3) }
+    end
+
+    it 'allows case analysis' do
+      case result
+      in { name: } => captured if name.eql?('John')
+        expect(name).to eql('John')
+        expect(captured).to eql(result)
+      end
+    end
+
+    it 'works in nested structure' do
+      case [1, result]
+      in [Integer => int, { name: 'John'}]
+        expect(int).to be(1)
+      end
+    end
+
+    context 'with monads' do
+      before { Dry::Schema.load_extensions(:monads) }
+
+      before do
+        require 'dry/monads'
+      end
+
+      it 'supports nesting nicely' do
+        case schema.('name' => 'John').to_monad
+        in Dry::Monads::Result::Success(name: 'John') => captured
+          expect(captured).to eql(result.to_monad)
+          expect(captured).to be_success
+        end
+
+        case schema.('name' => 'J').to_monad
+        in Dry::Monads::Result::Failure(name:) => captured
+          expect(captured).to be_failure
+          expect(name).to eql('J')
+        end
+      end
+    end
+  end
+
+  context 'nested match' do
+    let(:input) { { 'name' => 'John', 'address' => { 'city' => 'London' } } }
+
+    let(:schema) do
+      Dry::Schema.Params do
+        required(:name).filled
+        required(:address).hash do
+          required(:city).filled
+        end
+      end
+    end
+
+    it 'is supported' do
+      case result
+      in address: { city: }
+        expect(city).to eql('London')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,9 @@ end
 Dry::Schema::MessageSet.include(MessageSetSupport)
 
 RSpec.configure do |config|
+  unless RUBY_VERSION >= '2.7'
+    config.exclude_pattern = '**/pattern_matching_spec.rb'
+  end
   config.disable_monkey_patching!
   config.warnings = true
   config.filter_run_when_matching :focus


### PR DESCRIPTION
```ruby
let(:input) { { 'name' => 'John' } }

let(:schema) do
  Dry::Schema.Params { required(:name).filled(min_size?: 3) }
end

example do
  case result
  in { name: } => captured if name.eql?('John')
    name # => "John"
  in { name: other_name }
    # using other_name
  else
    # name not available
  end
end
```

With monads:
```ruby
require 'dry/schema'
require 'dry/monads'

Dry::Schema.load_extensions(:monads)

class Example
  include Dry::Monads[:result]

  Schema = Dry::Schema.Params { required(:name).filled(:string, size?: 2..4) }

  def call(input)
    case schema.(input).to_monad
    in Success(name:)
      "Hello #{name}" # name is captured from result
    in Failure(name:)
      "#{name} is not a valid name"
    end
  end
end

run = Example.new

run.('name' => 'Jane')   # => "Hello Jane"
run.('name' => 'Albert') # => "Albert is not a valid name"
```