### PR TITLE
Introduce AST error compiler

### DIFF
--- a/lib/dry/schema/ast_error_compiler.rb
+++ b/lib/dry/schema/ast_error_compiler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'dry/schema/error_compiler'
+require 'dry/schema/ast_error_set'
+
+module Dry
+  module Schema
+    # Compiles rule results AST into machine-readable format
+    #
+    # @api private
+    class AstErrorCompiler < ErrorCompiler
+      # @api private
+      def call(ast)
+        AstErrorSet[ast]
+      end
+    end
+  end
+end

--- a/lib/dry/schema/ast_error_set.rb
+++ b/lib/dry/schema/ast_error_set.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'dry/schema/error_set'
+
+module Dry
+  module Schema
+    # A set of AST errors used to generate machine-readable errors
+    #
+    # @see Result#message_set
+    #
+    # @api public
+    class AstErrorSet < ErrorSet
+      private
+
+      # @api private
+      def errors_map(errors = self.errors)
+        errors
+      end
+    end
+  end
+end

--- a/lib/dry/schema/config.rb
+++ b/lib/dry/schema/config.rb
@@ -36,6 +36,16 @@ module Dry
       # @api public
       setting(:types, Dry::Types)
 
+      # @!method error_compiler
+      #
+      # Return configured error_compiler
+      #
+      # @return [Dry::Schema::ErrorCompiler]
+      #
+      # @api public
+      setting(:error_compiler, :message)
+
+
       # @!method messages
       #
       # Return configuration for message backend

--- a/lib/dry/schema/error_compiler.rb
+++ b/lib/dry/schema/error_compiler.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Dry
+  module Schema
+    # Compiles rule results AST into some type of errors
+    #
+    # @api private
+    class ErrorCompiler
+      # @api private
+      def call(_ast)
+        raise NotImplementedError
+      end
+
+      # @api private
+      def with(*args)
+        self
+      end
+    end
+  end
+end

--- a/lib/dry/schema/error_set.rb
+++ b/lib/dry/schema/error_set.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'dry/equalizer'
+
+module Dry
+  module Schema
+    # A set of generic errors
+    #
+    # @see Result#message_set
+    #
+    # @api public
+    class ErrorSet
+      include Enumerable
+      include Dry::Equalizer(:errors, :options)
+
+      # A list of compiled errors
+      #
+      # @return [Array<Any>]
+      attr_reader :errors
+
+      # Options hash
+      #
+      # @return [Hash]
+      attr_reader :options
+
+      # @api private
+      def self.[](errors, options = EMPTY_HASH)
+        new(errors, options)
+      end
+
+      # @api private
+      def initialize(errors, options = EMPTY_HASH)
+        @errors = errors
+        @options = options
+      end
+
+      # Iterate over errors
+      #
+      # @example
+      #   result.errors.each do |message|
+      #     puts message.text
+      #   end
+      #
+      # @return [Array]
+      #
+      # @api public
+      def each(&block)
+        return self if empty?
+        return to_enum unless block
+
+        errors.each(&block)
+      end
+
+      # Dump message set to a hash
+      #
+      # @return [Hash<Symbol=>Array<String>>]
+      #
+      # @api public
+      def to_h
+        @to_h ||= errors_map
+      end
+      alias_method :to_hash, :to_h
+
+      # Get a list of errors for the given key
+      #
+      # @param [Symbol] key
+      #
+      # @return [Array<String>]
+      #
+      # @api public
+      def [](key)
+        to_h[key]
+      end
+
+      # Get a list of errors for the given key
+      #
+      # @param [Symbol] key
+      #
+      # @return [Array<String>]
+      #
+      # @raise KeyError
+      #
+      # @api public
+      def fetch(key)
+        self[key] || raise(KeyError, "+#{key}+ error was not found")
+      end
+
+      # Check if an error set is empty
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def empty?
+        @empty ||= errors.empty?
+      end
+
+      # @api private
+      def freeze
+        to_h
+        empty?
+        super
+      end
+
+      # @api private
+      def errors_map(_errors)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -2,6 +2,7 @@
 
 require 'dry/initializer'
 
+require 'dry/schema/error_compiler'
 require 'dry/schema/constants'
 require 'dry/schema/message'
 require 'dry/schema/message_set'
@@ -12,7 +13,7 @@ module Dry
     # Compiles rule results AST into human-readable format
     #
     # @api private
-    class MessageCompiler
+    class MessageCompiler < ErrorCompiler
       extend Dry::Initializer
 
       resolve_key_predicate = proc { |node, opts|
@@ -65,7 +66,7 @@ module Dry
         current_messages = EMPTY_ARRAY.dup
         compiled_messages = ast.map { |node| visit(node, EMPTY_OPTS.dup(current_messages)) }
 
-        MessageSet[compiled_messages, failures: options.fetch(:failures, true)]
+        MessageSet[compiled_messages.flatten, failures: options.fetch(:failures, true)]
       end
 
       # @api private

--- a/lib/dry/schema/message_compiler/visitor_opts.rb
+++ b/lib/dry/schema/message_compiler/visitor_opts.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
+require 'dry/schema/error_compiler'
 require 'dry/schema/constants'
 require 'dry/schema/message'
 
 module Dry
   module Schema
     # @api private
-    class MessageCompiler
+    class MessageCompiler < ErrorCompiler
       # Optimized option hash used by visitor methods in message compiler
       #
       # @api private

--- a/lib/dry/schema/message_set.rb
+++ b/lib/dry/schema/message_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/equalizer'
+require 'dry/schema/error_set'
 
 module Dry
   module Schema
@@ -9,15 +9,7 @@ module Dry
     # @see Result#message_set
     #
     # @api public
-    class MessageSet
-      include Enumerable
-      include Dry::Equalizer(:messages, :options)
-
-      # A list of compiled message objects
-      #
-      # @return [Array<Message>]
-      attr_reader :messages
-
+    class MessageSet < ErrorSet
       # An internal hash that is filled in with dumped messages
       # when a message set is coerced to a hash
       #
@@ -29,92 +21,14 @@ module Dry
       # @return [Hash]
       attr_reader :options
 
-      # @api private
-      def self.[](messages, options = EMPTY_HASH)
-        new(messages.flatten, options)
-      end
-
-      # @api private
-      def initialize(messages, options = EMPTY_HASH)
-        @messages = messages
-        @options = options
-        initialize_placeholders!
-      end
-
-      # Iterate over messages
-      #
-      # @example
-      #   result.errors.each do |message|
-      #     puts message.text
-      #   end
-      #
-      # @return [Array]
-      #
-      # @api public
-      def each(&block)
-        return self if empty?
-        return to_enum unless block
-
-        messages.each(&block)
-      end
-
-      # Dump message set to a hash
-      #
-      # @return [Hash<Symbol=>Array<String>>]
-      #
-      # @api public
-      def to_h
-        @to_h ||= messages_map
-      end
-      alias_method :to_hash, :to_h
-
-      # Get a list of message texts for the given key
-      #
-      # @param [Symbol] key
-      #
-      # @return [Array<String>]
-      #
-      # @api public
-      def [](key)
-        to_h[key]
-      end
-
-      # Get a list of message texts for the given key
-      #
-      # @param [Symbol] key
-      #
-      # @return [Array<String>]
-      #
-      # @raise KeyError
-      #
-      # @api public
-      def fetch(key)
-        self[key] || raise(KeyError, "+#{key}+ message was not found")
-      end
-
-      # Check if a message set is empty
-      #
-      # @return [Boolean]
-      #
-      # @api public
-      def empty?
-        @empty ||= messages.empty?
-      end
-
-      # @api private
-      def freeze
-        to_h
-        empty?
-        super
-      end
-
       private
 
       # @api private
-      def messages_map(messages = self.messages)
+      def errors_map(errors = self.errors)
         return EMPTY_HASH if empty?
 
-        messages.group_by(&:path).reduce(placeholders) do |hash, (path, msgs)|
+        initialize_placeholders!
+        errors.group_by(&:path).reduce(placeholders) do |hash, (path, msgs)|
           node = path.reduce(hash) { |a, e| a[e] }
 
           msgs.each do |msg|
@@ -129,14 +43,14 @@ module Dry
 
       # @api private
       def paths
-        @paths ||= messages.map(&:path).uniq
+        @paths ||= errors.map(&:path).uniq
       end
 
       # @api private
       def initialize_placeholders!
         return @placeholders = EMPTY_HASH if empty?
 
-        @placeholders = paths.reduce(EMPTY_HASH.dup) do |hash, path|
+        @placeholders ||= paths.reduce(EMPTY_HASH.dup) do |hash, path|
           curr_idx = 0
           last_idx = path.size - 1
           node = hash

--- a/lib/dry/schema/rule_applier.rb
+++ b/lib/dry/schema/rule_applier.rb
@@ -7,6 +7,7 @@ require 'dry/schema/config'
 require 'dry/schema/result'
 require 'dry/schema/messages'
 require 'dry/schema/message_compiler'
+require 'dry/schema/ast_error_compiler'
 
 module Dry
   module Schema
@@ -23,7 +24,13 @@ module Dry
       option :config, default: -> { Config.new }
 
       # @api private
-      option :message_compiler, default: -> { MessageCompiler.new(Messages.setup(config.messages)) }
+      option :message_compiler, default: (proc do
+        if config.error_compiler == :ast
+          AstErrorCompiler.new
+        else
+          MessageCompiler.new(Messages.setup(config.messages))
+        end
+      end)
 
       # @api private
       def call(input)

--- a/spec/unit/dry/schema/ast_error_compiler_spec.rb
+++ b/spec/unit/dry/schema/ast_error_compiler_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Schema::AstErrorCompiler, '#call' do
+  subject(:ast_error_compiler) do
+    Dry::Schema::AstErrorCompiler.new
+  end
+
+  it 'returns an empty hash when there are no errors' do
+    expect(ast_error_compiler.([])).to be_empty
+  end
+end

--- a/spec/unit/dry/schema/error_compiler_spec.rb
+++ b/spec/unit/dry/schema/error_compiler_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Schema::ErrorCompiler, '#call' do
+  subject(:message_compiler) do
+    Dry::Schema::MessageCompiler.new(Dry::Schema::Messages::YAML.build)
+  end
+
+  it 'returns an empty hash when there are no errors' do
+    expect(message_compiler.([])).to be_empty
+  end
+end


### PR DESCRIPTION
From #216 :

It makes message compiler a specific case of a generic error compiler,
just like new ast error compiler.

References dry-rb/dry-validation#604

This is a WIP in regard of adding the possibility to return something different than human readable messages as result errors. It'd be particularly useful in a RESTful scenario when you want your frontend to take care of everything UI-related. I don't want to go any further without having some feedback, as there are some considerations to take into account.

As you can see, I've generalized what it was a `MessageCompiler` in favor of an `ErrorCompiler`, being the former a subclass of the latest. I've added an `AstErrorCompiler` which just returns the plain error ast. Probably it's too raw and we should digest it a little bit, but at the same time it keeps all the flexibility for the machine consuming it.

I've also generalized `MessageSet` and new `AstErrorSet` as two subclasses of `ErrorSet`. As in the `ErrorCompiler` it makes explicit the interface that dry-schema internals expect for them.

As it'd do the error type polymorphic, probably some result methods should be renamed or aliased, as in the case of `#messages`.