### PR TITLE
Add each keyword to define arrays as root nodes

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -160,6 +160,32 @@ module Dry
         key(name, macro: Macros::Optional, &block)
       end
 
+      # Define an array
+      #
+      # @see DSL#required
+      #
+      # @example
+      #   each(:integer, gt?: 0)
+      #
+      #   each do
+      #    schema do
+      #      required(:method).filled(:str?)
+      #      required(:amount).filled(:float?)
+      #    end
+      #  end
+      #
+      # @return [Macros::Required]
+      #
+      # @api public
+      def each(*args, **opts, &block)
+        @__root__ = true
+        required(:__root__).array(*args, **opts, &block)
+      end
+
+      def with_root?
+        instance_variable_defined?('@__root__')
+      end
+
       # A generic method for defining keys
       #
       # @param [Symbol] name The key name

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -34,6 +34,7 @@ module Dry
 
       option :full, default: -> { false }
       option :locale, default: -> { :en }
+      option :crop_path, default: -> { EMPTY_ARRAY.dup }
       option :predicate_resolvers, default: -> { DEFAULT_PREDICATE_RESOLVERS }
 
       attr_reader :options
@@ -125,7 +126,7 @@ module Dry
 
         tokens = message_tokens(args)
         path, *arg_vals, input = predicate_resolvers[predicate].(args, opts)
-
+        path = path[crop_path.size..-1] if crop_path.any? && path[0..(crop_path.size - 1)] == crop_path
         options = opts.dup.update(
           path: path.last, **tokens, **lookup_options(arg_vals: arg_vals, input: input)
         ).to_h

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -81,7 +81,9 @@ module Dry
       #
       # @api public
       def call(input)
-        Result.new(input, message_compiler: message_compiler) do |result|
+        result_input = schema_dsl.with_root? ? { __root__: input } : input
+        crop_path = schema_dsl.with_root? ? [:__root__] : []
+        Result.new(result_input, message_compiler: message_compiler, crop_path: crop_path) do |result|
           steps.call(result)
         end
       end

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -32,6 +32,9 @@ module Dry
       option :message_compiler
 
       # @api private
+      option :crop_path, default: -> { EMPTY_ARRAY.dup }
+
+      # @api private
       def self.new(*, **)
         result = super
         yield(result)
@@ -124,6 +127,7 @@ module Dry
       #
       # @api public
       def message_set(options = EMPTY_HASH)
+        options = options.merge(crop_path: crop_path)
         message_compiler.with(options).(result_ast)
       end
 

--- a/spec/integration/schema/each_spec.rb
+++ b/spec/integration/schema/each_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Schema with each' do
+  subject(:schema) do
+    Dry::Schema.define do
+      each do
+        schema do
+          required(:method).filled(:str?)
+          required(:amount).filled(:float?)
+        end
+      end
+    end
+  end
+
+  describe '#messages' do
+    it 'validates root array' do
+      expect(schema.([{}]).messages).to eql(
+        0 => { method: ['is missing', 'must be a string'], amount: ['is missing', 'must be a float'] }
+      )
+    end
+
+    it 'validates each element against its set of rules' do
+      input = [
+        { method: 'cc', amount: 1.23 },
+        { method: 'wire', amount: 4.56 }
+      ]
+
+      expect(schema.(input).messages).to eql({})
+    end
+
+    it 'validates presence of the method key for each element' do
+      input = [
+        { method: 'cc', amount: 1.23 },
+        { amount: 4.56 }
+      ]
+
+      expect(schema.(input).messages).to eql(
+        1 => { method: ['is missing', 'must be a string'] }
+      )
+    end
+
+    it 'validates type of the method value for each element' do
+      input = [
+        { method: 'cc', amount: 1.23 },
+        { method: 12, amount: 4.56 }
+      ]
+
+      expect(schema.(input).messages).to eql(
+        1 => { method: ['must be a string'] }
+      )
+    end
+
+    it 'validates type of the amount value for each element' do
+      input = [
+        { method: 'cc', amount: 1.23 },
+        { method: 'wire', amount: '4.56' }
+      ]
+
+      expect(schema.(input).messages).to eql(
+        1 => { amount: ['must be a float'] }
+      )
+    end
+  end
+
+  context 'with array of strings' do
+    subject(:schema) do
+      Dry::Schema.define do
+        each(:integer, gt?: 0)
+      end
+    end
+
+    describe '#messages' do
+      it 'validates root array' do
+        expect(schema.([{}]).messages).to eql(0 => ['must be an integer', 'must be greater than 0'])
+      end
+
+      it 'validates each element' do
+        input = [1, 2, 3]
+
+        expect(schema.(input).messages).to eql({})
+      end
+
+      it 'validates each element against its rules' do
+        input = [1, -1, 3]
+
+        expect(schema.(input).messages).to eql(1 => ['must be greater than 0'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is proof of concept PR. It adds `each` keyword (`array` is already in use, so I decided to leave it as-is for now), which adds `__root__` key to the schema and input and removes it from the message paths later.

I still have some questions:
1. What message should be returned, if the input is not an array: `MessageSet` is a hash-like value, so what is the key for a "root" message like `input must be an array`?
2. How should we set rules for this kind of schemas in dry-v?
3. How can I set rule for the root array, like `value(:array, min_size?: 1)`?

Closes #22 