### PR TITLE
Fix example suggesting conversion to empty array

### DIFF
--- a/docsite/source/params.html.md
+++ b/docsite/source/params.html.md
@@ -31,17 +31,16 @@ puts errors.to_h.inspect
 
 ### Handling empty strings
 
-Your schema will automatically coerce empty strings to `nil` or an empty array, provided that you allow a value to be nil:
+Your schema will automatically coerce empty strings to `nil`, provided that you allow a value to be nil:
 
 ```ruby
 schema = Dry::Schema.Params do
   required(:email).filled(:string)
   required(:age).maybe(:integer, gt?: 18)
-  required(:tags).maybe(:array)
 end
 
-result = schema.call('email' => 'jane@doe.org', 'age' => '', 'tags' => '')
+result = schema.call('email' => 'jane@doe.org', 'age' => '')
 
 puts result.to_h
-# {:email=>'jane@doe.org', :age=>nil, :tags=>[]}
+# {:email=>'jane@doe.org', :age=>nil}
 ```


### PR DESCRIPTION
I noticed that dry-schema doesn't coerce an empty string to an empty array in this example, it converts it to nil:

```rb
require "dry/schema"
require "dry/schema/version"

Dry::Schema::VERSION # => "1.4.3"

schema = Dry::Schema.Params do
  required(:email).filled(:string)
  required(:age).maybe(:integer, gt?: 18)
  required(:tags).maybe(:array)
end

result = schema.call('email' => 'jane@doe.org', 'age' => '', 'tags' => '')

puts result.to_h
# >> {:email=>"jane@doe.org", :age=>nil, :tags=>nil}
```

So I'm just sending a PR correcting this 😃 