### PR TITLE
Make YAML backend safely handle empty load paths

### DIFF
--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -124,7 +124,7 @@ module Dry
 
       # @api private
       def prepare
-        @data = config.load_paths.map { |path| load_translations(path) }.reduce(:merge)
+        @data = config.load_paths.map { |path| load_translations(path) }.reduce({}, :merge)
         self
       end
 

--- a/spec/unit/dry/schema/messages/yaml_spec.rb
+++ b/spec/unit/dry/schema/messages/yaml_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe Dry::Schema::Messages::YAML do
         expect(meta).to eql({})
       end
     end
+
+    context 'with no load paths' do
+      subject(:messages) do
+        Dry::Schema::Messages::YAML.build(load_paths: [])
+      end
+
+      it 'does not cause data to be nil, leading to a NoMethodError' do
+        template, meta = messages[:filled?, path: [:name]]
+
+        expect(template).to be_nil
+        expect(meta).to be_nil
+      end
+    end
   end
 
   describe '#merge' do


### PR DESCRIPTION
Currently, an empty array of load paths within the YAML message
backend's will cause a NoMethodError at message creation time because
the backend's data ends up as nil rather than an empty hash. By
providing reduce with an initial object, this can be avoided.

Since the YAML backend does support programmatic merging with overrides,
then it should be able to handle an initially empty set of messages,
which could be indicated by an empty set of load paths.