### PR TITLE
Fix schema config docs

### DIFF
--- a/docsite/source/basics/working-with-schemas.html.md
+++ b/docsite/source/basics/working-with-schemas.html.md
@@ -45,10 +45,10 @@ result.failure?
 
 ```ruby
 class AppSchema < Dry::Schema::Params
-  config.messages.load_paths << '/my/app/config/locales/en.yml'
-  config.messages.backend = :i18n
-
   define do
+    config.messages.load_paths << '/my/app/config/locales/en.yml'
+    config.messages.backend = :i18n
+
     # define common rules, if any
   end
 end


### PR DESCRIPTION
Looks like #240 is just a documentation mistake, as the configuration is available within a `define` block, which is also already reflected in some specs.

Resolves #240.