### PR TITLE
Fix sum with member array

### DIFF
--- a/lib/dry/schema/macros/array.rb
+++ b/lib/dry/schema/macros/array.rb
@@ -19,7 +19,10 @@ module Dry
             is_hash_block = type_spec.equal?(:hash)
 
             if predicates.any? || opts.any? || !is_hash_block
-              super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &(is_hash_block ? nil : block))
+              super(
+                *predicates, type_spec: type_spec, type_rule: type_rule, **opts,
+                &(is_hash_block ? nil : block)
+              )
             end
 
             hash(&block) if is_hash_block

--- a/lib/dry/schema/macros/array.rb
+++ b/lib/dry/schema/macros/array.rb
@@ -13,13 +13,13 @@ module Dry
         def value(*args, **opts, &block)
           type(:array)
 
-          extract_type_spec(*args, set_type: false) do |*predicates, type_spec:|
+          extract_type_spec(*args, set_type: false) do |*predicates, type_spec:, type_rule:|
             type(schema_dsl.array[type_spec]) if type_spec
 
             is_hash_block = type_spec.equal?(:hash)
 
             if predicates.any? || opts.any? || !is_hash_block
-              super(*predicates, type_spec: type_spec, **opts, &(is_hash_block ? nil : block))
+              super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &(is_hash_block ? nil : block))
             end
 
             hash(&block) if is_hash_block

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -195,13 +195,7 @@ module Dry
 
         # @api private
         def extract_type_spec(*args, nullable: false, set_type: true)
-          type_spec = args[0]
-
-          is_type_spec = type_spec.is_a?(Dry::Schema::Processor) ||
-                         type_spec.is_a?(Symbol) &&
-                         type_spec.to_s.end_with?(QUESTION_MARK)
-
-          type_spec = nil if is_type_spec
+          type_spec = args[0] unless schema_or_predicate?(args[0])
 
           predicates = Array(type_spec ? args[1..-1] : args)
 
@@ -229,6 +223,13 @@ module Dry
           else
             schema_dsl.resolve_type([:nil, resolved])
           end
+        end
+
+        # @api private
+        def schema_or_predicate?(arg)
+          arg.is_a?(Dry::Schema::Processor) ||
+            arg.is_a?(Symbol) &&
+              arg.to_s.end_with?(QUESTION_MARK)
         end
       end
     end

--- a/lib/dry/schema/macros/each.rb
+++ b/lib/dry/schema/macros/each.rb
@@ -12,12 +12,12 @@ module Dry
       class Each < DSL
         # @api private
         def value(*args, **opts)
-          extract_type_spec(*args, set_type: false) do |*predicates, type_spec:|
+          extract_type_spec(*args, set_type: false) do |*predicates, type_spec:, type_rule:|
             if type_spec && !type_spec.is_a?(Dry::Types::Type)
               type(schema_dsl.array[type_spec])
             end
 
-            super(*predicates, type_spec: type_spec, **opts)
+            super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts)
           end
         end
 

--- a/lib/dry/schema/macros/filled.rb
+++ b/lib/dry/schema/macros/filled.rb
@@ -15,6 +15,8 @@ module Dry
 
           if opts[:type_spec] && !filter_empty_string?
             value(predicates[0], :filled?, *predicates[1..predicates.size - 1], **opts, &block)
+          elsif opts[:type_rule]
+            value(:filled?).value(*predicates, **opts, &block)
           else
             value(:filled?, *predicates, **opts, &block)
           end

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -54,8 +54,8 @@ module Dry
         #
         # @api public
         def value(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:|
-            super(*predicates, type_spec: type_spec, **opts, &block)
+          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+            super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
           end
         end
 
@@ -70,8 +70,8 @@ module Dry
         #
         # @api public
         def filled(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:|
-            super(*predicates, type_spec: type_spec, **opts, &block)
+          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+            super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
           end
         end
 
@@ -86,9 +86,9 @@ module Dry
         #
         # @api public
         def maybe(*args, **opts, &block)
-          extract_type_spec(*args, nullable: true) do |*predicates, type_spec:|
+          extract_type_spec(*args, nullable: true) do |*predicates, type_spec:, type_rule:|
             append_macro(Macros::Maybe) do |macro|
-              macro.call(*predicates, type_spec: type_spec, **opts, &block)
+              macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
             end
           end
         end

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -26,11 +26,13 @@ module Dry
             schema_dsl.set_type(name, updated_type)
           end
 
+          trace_opts = opts.reject { |key, _| key == :type_spec || key == :type_rule }
+
           if (type_rule = opts[:type_rule])
-            trace.append(type_rule).evaluate(*predicates, **opts)
+            trace.append(type_rule).evaluate(*predicates, trace_opts)
             trace.append(new(chain: false).instance_exec(&block)) if block
           else
-            trace.evaluate(*predicates, **opts)
+            trace.evaluate(*predicates, **trace_opts)
 
             type_spec = opts[:type_spec]
 

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -26,13 +26,19 @@ module Dry
             schema_dsl.set_type(name, updated_type)
           end
 
-          trace.evaluate(*predicates, **opts)
+          if (type_rule = opts[:type_rule])
+            trace.append(type_rule).evaluate(*predicates, **opts)
+            trace.append(new(chain: false).instance_exec(&block)) if block
+          else
+            trace.evaluate(*predicates, **opts)
 
-          type_spec = opts[:type_spec]
-          if block && type_spec.equal?(:hash)
-            hash(&block)
-          elsif block
-            trace.append(new(chain: false).instance_exec(&block))
+            type_spec = opts[:type_spec]
+
+            if block && type_spec.equal?(:hash)
+              hash(&block)
+            elsif block
+              trace.append(new(chain: false).instance_exec(&block))
+            end
           end
 
           if trace.captures.empty?

--- a/lib/dry/schema/trace.rb
+++ b/lib/dry/schema/trace.rb
@@ -29,7 +29,7 @@ module Dry
       end
 
       # @api private
-      def evaluate(*args, type_rule: ::Dry::Schema::Undefined, type_spec: ::Dry::Schema::Undefined, **opts)
+      def evaluate(*args, **opts)
         predicates = opts.empty? ? args : args.push(opts)
 
         evaluate_predicates(predicates).each do |rule|

--- a/lib/dry/schema/trace.rb
+++ b/lib/dry/schema/trace.rb
@@ -29,8 +29,9 @@ module Dry
       end
 
       # @api private
-      def evaluate(*args, type_spec: ::Dry::Schema::Undefined, **opts)
+      def evaluate(*args, type_rule: ::Dry::Schema::Undefined, type_spec: ::Dry::Schema::Undefined, **opts)
         predicates = opts.empty? ? args : args.push(opts)
+
         evaluate_predicates(predicates).each do |rule|
           append(rule)
         end

--- a/spec/integration/schema/type_spec.rb
+++ b/spec/integration/schema/type_spec.rb
@@ -70,6 +70,32 @@ RSpec.describe Dry::Schema, 'types specs' do
     end
   end
 
+  context 'sum with a member-array' do
+    subject(:schema) do
+      Dry::Schema.Params do
+        required(:nums).value([:integer, array[:integer]])
+      end
+    end
+
+    it 'infers int? | (array? & each(int?))' do
+      expect(schema.(nums: 1)).to be_success
+      expect(schema.(nums: [3, 1, 2])).to be_success
+
+      expect(schema.(nums: 1)).to be_success
+      expect(schema.(nums: '1')).to be_success
+      expect(schema.(nums: [])).to be_success
+      expect(schema.(nums: %w[3 1 2])).to be_success
+
+      expect(schema.(nums: nil).errors.to_h).to eql(
+        nums: ['must be an integer or must be an array']
+      )
+
+      expect(schema.(nums: ['3', nil, 2]).errors.to_h).to eql(
+        nums: { 1 => ['must be an integer'] }
+      )
+    end
+  end
+
   context 'sum type spec without rules' do
     subject(:schema) do
       Dry::Schema.Params do


### PR DESCRIPTION
This adds support for inferring rules from complex sum-type specs ie `value([:integer, array[:integer])`. This should work with any combination of types now, *except* hash schemas which will be added via #237.

Closes #214 