### PR TITLE
Extend schemas with dry-logic operators API

### DIFF
--- a/lib/dry/schema/extensions/hints.rb
+++ b/lib/dry/schema/extensions/hints.rb
@@ -22,7 +22,14 @@ module Dry
       # @see Message::Or
       #
       # @api public
-      class Or
+      class Or::SinglePath
+        # @api private
+        def hint?
+          false
+        end
+      end
+
+      class Or::MultiPath
         # @api private
         def hint?
           false

--- a/lib/dry/schema/macros/array.rb
+++ b/lib/dry/schema/macros/array.rb
@@ -25,7 +25,17 @@ module Dry
               )
             end
 
-            hash(&block) if is_hash_block
+            is_op = args.size.equal?(2) && args[1].is_a?(Logic::Operations::Abstract)
+
+            if is_hash_block && !is_op
+              hash(&block)
+            elsif is_op
+              hash = Value.new(schema_dsl: schema_dsl.new, name: name).hash(args[1])
+
+              trace.captures.concat(hash.trace.captures)
+
+              type(schema_dsl.types[name].of(hash.schema_dsl.types[name]))
+            end
           end
 
           self

--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -82,6 +82,13 @@ module Dry
         other.is_a?(String) ? text == other : super
       end
 
+      # @api private
+      def to_or(root)
+        clone = dup
+        clone.instance_variable_set('@path', path - root)
+        clone
+      end
+
       # See which message is higher in the hierarchy
       #
       # @api private

--- a/lib/dry/schema/message.rb
+++ b/lib/dry/schema/message.rb
@@ -85,7 +85,8 @@ module Dry
       # @api private
       def to_or(root)
         clone = dup
-        clone.instance_variable_set('@path', path - root)
+        clone.instance_variable_set('@path', path - root.to_a)
+        clone.instance_variable_set('@_path', nil)
         clone
       end
 

--- a/lib/dry/schema/message/or.rb
+++ b/lib/dry/schema/message/or.rb
@@ -2,6 +2,8 @@
 
 require 'dry/equalizer'
 
+require 'dry/schema/path'
+
 module Dry
   module Schema
     # Message objects used by message sets
@@ -104,7 +106,7 @@ module Dry
           # @api private
           def initialize(*args)
             super
-            @root = [left, right].flatten.map(&:path).reduce(:&)
+            @root = [left, right].flatten.map(&:_path).reduce(:&)
             @left = left.map { |msg| msg.to_or(root) }
             @right = right.map { |msg| msg.to_or(root) }
           end

--- a/lib/dry/schema/message/or.rb
+++ b/lib/dry/schema/message/or.rb
@@ -114,28 +114,8 @@ module Dry
           # @api public
           def to_h
             @to_h ||= Path[[*root, :or]].to_h(
-              [merge(left.map(&:to_h)), merge(right.map(&:to_h))]
+              [left.map(&:to_h).reduce(:merge), right.map(&:to_h).reduce(:merge)]
             )
-          end
-
-          private
-
-          # @api private
-          def merge(messages)
-            messages.reduce(EMPTY_HASH.dup) { |a, e| deep_merge(a, e) }
-          end
-
-          # @api private
-          def deep_merge(h1, h2, &block)
-            h1.merge(h2) do |_, val1, val2|
-              if val1.is_a?(Hash) && val2.is_a?(Hash)
-                deep_merge(val1, val2, &block)
-              elsif val1.is_a?(Array) && val2.is_a?(Array)
-                val1 + val2
-              else
-                [val1, val2]
-              end
-            end
           end
         end
       end

--- a/lib/dry/schema/message/or.rb
+++ b/lib/dry/schema/message/or.rb
@@ -77,7 +77,7 @@ module Dry
           #
           # @api public
           def dump
-            "#{left.dump} #{messages[:or][:text]} #{right.dump}"
+            @dump ||= "#{left.dump} #{messages[:or][:text]} #{right.dump}"
           end
           alias_method :to_s, :dump
 
@@ -89,12 +89,12 @@ module Dry
           #
           # @api public
           def to_h
-            _path.to_h(dump)
+            @to_h ||= _path.to_h(dump)
           end
 
           # @api private
           def to_a
-            [left, right]
+            @to_a ||= [left, right]
           end
         end
 
@@ -113,7 +113,9 @@ module Dry
 
           # @api public
           def to_h
-            Path[[*root, :or]].to_h([merge(left.map(&:to_h)), merge(right.map(&:to_h))])
+            @to_h ||= Path[[*root, :or]].to_h(
+              [merge(left.map(&:to_h)), merge(right.map(&:to_h))]
+            )
           end
 
           private

--- a/lib/dry/schema/message/or.rb
+++ b/lib/dry/schema/message/or.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'dry/equalizer'
-
-require 'dry/schema/path'
+require 'dry/schema/message/or/single_path'
+require 'dry/schema/message/or/multi_path'
 
 module Dry
   module Schema
@@ -10,9 +9,6 @@ module Dry
     #
     # @api public
     class Message
-      # A message sub-type used by OR operations
-      #
-      # @api public
       module Or
         # @api private
         def self.[](left, right, messages)
@@ -23,99 +19,12 @@ module Dry
             SinglePath.new(left, right, messages)
           elsif right.is_a?(Array)
             if left.is_a?(Array) && paths.uniq.size > 1
-              Or::MultiPath.new(left, right)
+              MultiPath.new(left, right)
             else
               right
             end
           else
             msgs.max
-          end
-        end
-
-        # @api private
-        class Abstract
-          # @api private
-          attr_reader :left
-
-          # @api private
-          attr_reader :right
-
-          # @api private
-          def initialize(left, right, *)
-            @left = left
-            @right = right
-          end
-        end
-
-        # @api public
-        class SinglePath < Abstract
-          # @api private
-          attr_reader :path
-
-          # @api private
-          attr_reader :_path
-
-          # @api private
-          attr_reader :messages
-
-          # @api private
-          def initialize(*args, messages)
-            super(*args)
-            @messages = messages
-            @path = left.path
-            @_path = left._path
-          end
-
-          # Dump a message into a string
-          #
-          # Both sides of the message will be joined using translated
-          # value under `dry_schema.or` message key
-          #
-          # @see Message#dump
-          #
-          # @return [String]
-          #
-          # @api public
-          def dump
-            @dump ||= "#{left.dump} #{messages[:or][:text]} #{right.dump}"
-          end
-          alias_method :to_s, :dump
-
-          # Dump an `or` message into a hash
-          #
-          # @see Message#to_h
-          #
-          # @return [String]
-          #
-          # @api public
-          def to_h
-            @to_h ||= _path.to_h(dump)
-          end
-
-          # @api private
-          def to_a
-            @to_a ||= [left, right]
-          end
-        end
-
-        # @api public
-        class MultiPath < Abstract
-          # @api private
-          attr_reader :root
-
-          # @api private
-          def initialize(*args)
-            super
-            @root = [left, right].flatten.map(&:_path).reduce(:&)
-            @left = left.map { |msg| msg.to_or(root) }
-            @right = right.map { |msg| msg.to_or(root) }
-          end
-
-          # @api public
-          def to_h
-            @to_h ||= Path[[*root, :or]].to_h(
-              [left.map(&:to_h).reduce(:merge), right.map(&:to_h).reduce(:merge)]
-            )
           end
         end
       end

--- a/lib/dry/schema/message/or.rb
+++ b/lib/dry/schema/message/or.rb
@@ -11,71 +11,128 @@ module Dry
       # A message sub-type used by OR operations
       #
       # @api public
-      class Or
-        # @api private
-        attr_reader :left
-
-        # @api private
-        attr_reader :right
-
-        # @api private
-        attr_reader :path
-
-        # @api private
-        attr_reader :_path
-
-        # @api private
-        attr_reader :messages
-
+      module Or
         # @api private
         def self.[](left, right, messages)
-          if [left, right].flatten.map(&:path).uniq.size == 1
-            new(left, right, messages)
+          msgs = [left, right].flatten
+          paths = msgs.map(&:path)
+
+          if paths.uniq.size == 1
+            SinglePath.new(left, right, messages)
           elsif right.is_a?(Array)
-            right
+            if left.is_a?(Array) && paths.uniq.size > 1
+              Or::MultiPath.new(left, right)
+            else
+              right
+            end
           else
-            [left, right].flatten.max
+            msgs.max
           end
         end
 
         # @api private
-        def initialize(left, right, messages)
-          @left = left
-          @right = right
-          @messages = messages
-          @path = left.path
-          @_path = left._path
+        class Abstract
+          # @api private
+          attr_reader :left
+
+          # @api private
+          attr_reader :right
+
+          # @api private
+          def initialize(left, right, *)
+            @left = left
+            @right = right
+          end
         end
 
-        # Dump a message into a string
-        #
-        # Both sides of the message will be joined using translated
-        # value under `dry_schema.or` message key
-        #
-        # @see Message#dump
-        #
-        # @return [String]
-        #
         # @api public
-        def dump
-          "#{left.dump} #{messages[:or][:text]} #{right.dump}"
-        end
-        alias to_s dump
+        class SinglePath < Abstract
+          # @api private
+          attr_reader :path
 
-        # Dump an `or` message into a hash
-        #
-        # @see Message#to_h
-        #
-        # @return [String]
-        #
+          # @api private
+          attr_reader :_path
+
+          # @api private
+          attr_reader :messages
+
+          # @api private
+          def initialize(*args, messages)
+            super(*args)
+            @messages = messages
+            @path = left.path
+            @_path = left._path
+          end
+
+          # Dump a message into a string
+          #
+          # Both sides of the message will be joined using translated
+          # value under `dry_schema.or` message key
+          #
+          # @see Message#dump
+          #
+          # @return [String]
+          #
+          # @api public
+          def dump
+            "#{left.dump} #{messages[:or][:text]} #{right.dump}"
+          end
+          alias_method :to_s, :dump
+
+          # Dump an `or` message into a hash
+          #
+          # @see Message#to_h
+          #
+          # @return [String]
+          #
+          # @api public
+          def to_h
+            _path.to_h(dump)
+          end
+
+          # @api private
+          def to_a
+            [left, right]
+          end
+        end
+
         # @api public
-        def to_h
-          _path.to_h(dump)
-        end
+        class MultiPath < Abstract
+          # @api private
+          attr_reader :root
 
-        # @api private
-        def to_a
-          [left, right]
+          # @api private
+          def initialize(*args)
+            super
+            @root = [left, right].flatten.map(&:path).reduce(:&)
+            @left = left.map { |msg| msg.to_or(root) }
+            @right = right.map { |msg| msg.to_or(root) }
+          end
+
+          # @api public
+          def to_h
+            Path[[*root, :or]].to_h([merge(left.map(&:to_h)), merge(right.map(&:to_h))])
+          end
+
+          private
+
+          # @api private
+          def merge(messages)
+            messages.reduce(EMPTY_HASH.dup) { |a, e| deep_merge(a, e) }
+          end
+
+          # @api private
+          def deep_merge(h1, h2, &block)
+            h1.merge(h2) do |_, val1, val2|
+              if val1.is_a?(Hash) && val2.is_a?(Hash)
+                deep_merge(val1, val2, &block)
+              elsif val1.is_a?(Array) && val2.is_a?(Array)
+                val1 + val2
+              else
+                [val1, val2]
+              end
+            end
+          end
         end
       end
     end

--- a/lib/dry/schema/message/or/abstract.rb
+++ b/lib/dry/schema/message/or/abstract.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Dry
+  module Schema
+    class Message
+      module Or
+        # A message type used by OR operations
+        #
+        # @abstract
+        #
+        # @api private
+        class Abstract
+          # @api private
+          attr_reader :left
+
+          # @api private
+          attr_reader :right
+
+          # @api private
+          def initialize(left, right)
+            @left = left
+            @right = right
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/schema/message/or/multi_path.rb
+++ b/lib/dry/schema/message/or/multi_path.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'dry/equalizer'
+
+require 'dry/schema/message/or/abstract'
+require 'dry/schema/path'
+
+module Dry
+  module Schema
+    class Message
+      module Or
+        # A message type used by OR operations with different paths
+        #
+        # @api public
+        class MultiPath < Abstract
+          # @api private
+          attr_reader :root
+
+          # @api private
+          def initialize(*args)
+            super
+            @root = [left, right].flatten.map(&:_path).reduce(:&)
+            @left = left.map { |msg| msg.to_or(root) }
+            @right = right.map { |msg| msg.to_or(root) }
+          end
+
+          # @api public
+          def to_h
+            @to_h ||= Path[[*root, :or]].to_h(
+              [left.map(&:to_h).reduce(:merge), right.map(&:to_h).reduce(:merge)]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/schema/message/or/single_path.rb
+++ b/lib/dry/schema/message/or/single_path.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'dry/schema/message/or/abstract'
+
+module Dry
+  module Schema
+    class Message
+      module Or
+        # A message type used by OR operations with the same path
+        #
+        # @api public
+        class SinglePath < Abstract
+          # @api private
+          attr_reader :path
+
+          # @api private
+          attr_reader :_path
+
+          # @api private
+          attr_reader :messages
+
+          # @api private
+          def initialize(*args, messages)
+            super(*args)
+            @messages = messages
+            @path = left.path
+            @_path = left._path
+          end
+
+          # Dump a message into a string
+          #
+          # Both sides of the message will be joined using translated
+          # value under `dry_schema.or` message key
+          #
+          # @see Message#dump
+          #
+          # @return [String]
+          #
+          # @api public
+          def dump
+            @dump ||= "#{left.dump} #{messages[:or][:text]} #{right.dump}"
+          end
+          alias_method :to_s, :dump
+
+          # Dump an `or` message into a hash
+          #
+          # @see Message#to_h
+          #
+          # @return [String]
+          #
+          # @api public
+          def to_h
+            @to_h ||= _path.to_h(dump)
+          end
+
+          # @api private
+          def to_a
+            @to_a ||= [left, right]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -111,8 +111,19 @@ module Dry
       end
 
       # @api private
-      def key_matches(other)
-        map { |key| (idx = other.index(key)) && keys[idx].equal?(key) }
+      def &(other)
+        unless same_root?(other)
+          raise ArgumentError, "#{other.inspect} doesn't have the same root #{inspect}"
+        end
+
+        self.class.new(
+          key_matches(other, :select).compact.reject { |value| value.equal?(false) }
+        )
+      end
+
+      # @api private
+      def key_matches(other, meth = :map)
+        public_send(meth) { |key| (idx = other.index(key)) && keys[idx].equal?(key) }
       end
 
       # @api private

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -2,6 +2,7 @@
 
 require 'dry/configurable'
 require 'dry/initializer'
+require 'dry/logic/operators'
 
 require 'dry/schema/type_registry'
 require 'dry/schema/type_container'
@@ -23,6 +24,8 @@ module Dry
     class Processor
       extend Dry::Initializer
       extend Dry::Configurable
+
+      include Dry::Logic::Operators
 
       setting :key_map_type
       setting :type_registry_namespace, :strict
@@ -137,9 +140,10 @@ module Dry
       # Return AST representation of the rules
       #
       # @api private
-      def to_ast
+      def to_ast(*)
         rule_applier.to_ast
       end
+      alias_method :ast, :to_ast
 
       # Return the message compiler
       #

--- a/spec/integration/json/logic_spec.rb
+++ b/spec/integration/json/logic_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Dry::Schema::JSON do
+  it_behaves_like 'schema logic operators' do
+    let(:schema_method) { :JSON }
+  end
+
+  context 'with coercion' do
+    subject(:schema) do
+      Dry::Schema.JSON do
+        required(:user).hash(Test::UserSchema | Test::GuestSchema)
+      end
+    end
+
+    before do
+      Test::UserSchema = Dry::Schema.JSON do
+        required(:login).filled(:string)
+        required(:bday).value(:date_time)
+      end
+
+      Test::GuestSchema = Dry::Schema.JSON do
+        required(:name).filled(:string)
+      end
+    end
+
+    let(:result) do
+      schema.(input)
+    end
+
+    context 'with unexpected keys' do
+      let(:input) do
+        { user: { foo: 'bar', login: 'jane', bday: DateTime.parse('1990-01-02') } }
+      end
+
+      it 'uses a merged key-map to sanitize keys' do
+        expect(result[:user].keys).to eql(%i[login bday])
+      end
+    end
+
+    context 'with values that need coercion' do
+      let(:input) do
+        { user: { login: 'jane', bday: '1990-01-02' } }
+      end
+
+      it 'uses a merged key-map to sanitize keys' do
+        expect(result[:user]).to eql(login: 'jane', bday: DateTime.parse('1990-01-02'))
+      end
+    end
+  end
+end

--- a/spec/integration/params/logic_spec.rb
+++ b/spec/integration/params/logic_spec.rb
@@ -115,6 +115,39 @@ RSpec.describe Dry::Schema::Params do
           expect(result[:sites][1]).to eql(login: 'john', age: 25)
         end
       end
+
+      context 'with invalid values' do
+        let(:input) do
+          { sites: [
+            { login: 'jane', age: '' },
+            { name: '' },
+            { login: '', age: '25' }
+          ] }
+        end
+
+        it 'builds a deeply nested error hash' do
+          expect(result.errors[:sites]).to eql(
+            0 => {
+              or: [
+                { age: ['must be an integer'] },
+                { name: ['is missing'] }
+              ]
+            },
+            1 => {
+              or: [
+                { age: ['is missing'], login: ['is missing'] },
+                { name: ['must be filled'] }
+              ]
+            },
+            2 => {
+              or: [
+                { login: ['must be filled'] },
+                { name: ['is missing'] }
+              ]
+            }
+          )
+        end
+      end
     end
   end
 

--- a/spec/integration/params/logic_spec.rb
+++ b/spec/integration/params/logic_spec.rb
@@ -1,0 +1,164 @@
+RSpec.describe Dry::Schema::Params do
+  it_behaves_like 'schema logic operators' do
+    let(:schema_method) { :Params }
+  end
+
+  before do
+    Test::UserSchema = Dry::Schema.Params do
+      required(:login).filled(:string)
+      required(:age).value(:integer)
+    end
+
+    Test::GuestSchema = Dry::Schema.Params do
+      required(:name).filled(:string)
+    end
+  end
+
+  context 'with a hash that needs coercion' do
+    shared_examples 'nested composed schemas' do
+      context 'with coercion' do
+        let(:result) do
+          schema.(input)
+        end
+
+        context 'with unexpected keys' do
+          let(:input) do
+            { user: { foo: 'bar', login: 'jane', age: 36 } }
+          end
+
+          it 'uses a merged key-map to sanitize keys' do
+            expect(result[:user].keys).to eql(%i[login age])
+          end
+        end
+
+        context 'with values that need coercion' do
+          let(:input) do
+            { user: { login: 'jane', age: '36' } }
+          end
+
+          it 'uses a merged key-map to sanitize keys' do
+            expect(result[:user]).to eql(login: 'jane', age: 36)
+          end
+        end
+
+        context 'with invalid values' do
+          let(:input) do
+            { user: { login: '', age: '36' } }
+          end
+
+          it 'builds a nested error hash' do
+            expect(result.errors[:user]).to eql(
+              or: [{ login: ['must be filled'] }, { name: ['is missing'] }]
+            )
+          end
+        end
+      end
+    end
+
+    context 'using `hash`' do
+      subject(:schema) do
+        Dry::Schema.Params do
+          required(:user).hash(Test::UserSchema | Test::GuestSchema)
+        end
+      end
+
+      include_context 'nested composed schemas'
+    end
+
+    context 'using `schema`' do
+      subject(:schema) do
+        Dry::Schema.Params do
+          required(:user).schema(Test::UserSchema | Test::GuestSchema)
+        end
+      end
+
+      include_context 'nested composed schemas'
+    end
+  end
+
+  context 'with an array with hashes that need coercion' do
+    context 'with coercion' do
+      subject(:schema) do
+        Dry::Schema.Params do
+          required(:sites).array(:hash, Test::UserSchema | Test::GuestSchema)
+        end
+      end
+
+      let(:result) do
+        schema.(input)
+      end
+
+      context 'with unexpected keys' do
+        let(:input) do
+          { sites: [
+            { foo: 'bar', login: 'jane', age: 36 },
+            { bar: 'foo', login: 'john', age: 25 }
+          ] }
+        end
+
+        it 'uses a merged key-map to sanitize keys' do
+          expect(result[:sites][0].keys).to eql(%i[login age])
+          expect(result[:sites][1].keys).to eql(%i[login age])
+        end
+      end
+
+      context 'with values that need coercion' do
+        let(:input) do
+          { sites: [
+            { login: 'jane', age: '36' },
+            { login: 'john', age: '25' }
+          ] }
+        end
+
+        it 'uses a merged key-map to sanitize keys' do
+          expect(result[:sites][0]).to eql(login: 'jane', age: 36)
+          expect(result[:sites][1]).to eql(login: 'john', age: 25)
+        end
+      end
+    end
+  end
+
+  context 'with an array with deeply nested hashes that need coercion' do
+    context 'with coercion' do
+      subject(:schema) do
+        Dry::Schema.Params do
+          required(:sites).array(:hash) do
+            required(:visitor).hash(Test::UserSchema | Test::GuestSchema)
+          end
+        end
+      end
+
+      let(:result) do
+        schema.(input)
+      end
+
+      context 'with unexpected keys' do
+        let(:input) do
+          { sites: [
+              { visitor: { foo: 'bar', login: 'jane', age: 36 } },
+              { visitor: { bar: 'foo', login: 'john', age: 25 } }
+            ] }
+        end
+
+        it 'uses a merged key-map to sanitize keys' do
+          expect(result[:sites][0][:visitor].keys).to eql(%i[login age])
+          expect(result[:sites][1][:visitor].keys).to eql(%i[login age])
+        end
+      end
+
+      context 'with values that need coercion' do
+        let(:input) do
+          { sites: [
+              { visitor: { login: 'jane', age: '36' } },
+              { visitor: { login: 'john', age: '25' } }
+            ] }
+        end
+
+        it 'uses a merged key-map to sanitize keys' do
+          expect(result[:sites][0][:visitor]).to eql(login: 'jane', age: 36)
+          expect(result[:sites][1][:visitor]).to eql(login: 'john', age: 25)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/schema/logic_spec.rb
+++ b/spec/integration/schema/logic_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Dry::Schema::Processor do
+  it_behaves_like 'schema logic operators' do
+    let(:schema_method) { :define }
+  end
+
+  context 'with unexpected keys' do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:user).hash(Test::UserSchema | Test::GuestSchema)
+      end
+    end
+
+    before do
+      Test::UserSchema = Dry::Schema.define do
+        required(:login).filled(:string)
+        required(:age).value(:integer)
+      end
+
+      Test::GuestSchema = Dry::Schema.define do
+        required(:name).filled(:string)
+      end
+    end
+
+    let(:result) do
+      schema.(input)
+    end
+
+    context 'with input matching left side' do
+      let(:input) do
+        { user: { foo: 'bar', login: 'jane', age: 36 } }
+      end
+
+      it 'uses a merged key-map to sanitize keys' do
+        expect(result[:user].keys).to eql(%i[login age])
+      end
+    end
+
+    context 'with input matching right side' do
+      let(:input) do
+        { user: { foo: 'bar', name: 'jane' } }
+      end
+
+      it 'uses a merged key-map to sanitize keys' do
+        expect(result[:user].keys).to eql(%i[name])
+      end
+    end
+  end
+end

--- a/spec/shared/schema/logic.rb
+++ b/spec/shared/schema/logic.rb
@@ -1,0 +1,67 @@
+RSpec.shared_examples 'schema logic operators' do
+  subject(:schema) do
+    Dry::Schema.public_send(schema_method) do
+      required(:user).hash(Test::Operation)
+    end
+  end
+
+  let(:left) do
+    Dry::Schema.define { required(:age).value(:integer) }
+  end
+
+  let(:right) do
+    Dry::Schema.define { required(:name).value(:string) }
+  end
+
+  before do
+    Test::Operation = left.public_send(operator, right)
+  end
+
+  describe '#and' do
+    let(:operator) { :and }
+
+    it 'composes schemas using conjunction' do
+      expect(schema.(user: { age: 36, name: 'Jane' })).to be_success
+
+      expect(schema.(user: { age: '36', name: 'Jane' }).errors.to_h).to eql(
+        user: { age: ['must be an integer'] }
+      )
+    end
+  end
+
+  describe '#or' do
+    let(:operator) { :or }
+
+    it 'composes schemas using disjunction' do
+      expect(schema.(user: { age: 36, name: 'Jane' })).to be_success
+      expect(schema.(user: { age: 36 })).to be_success
+      expect(schema.(user: { name: 'Jane' })).to be_success
+
+      expect(schema.(user: { age: '36', name: :Jane }).errors.to_h).to eql(
+        user: { or: [{ age: ['must be an integer'] }, { name: ['must be a string'] }] }
+      )
+    end
+  end
+
+  describe '#then' do
+    let(:operator) { :then }
+
+    it 'composes schemas using implication' do
+      expect(schema.(user: { age: 36, name: 'Jane' })).to be_success
+      expect(schema.(user: { age: '36', name: :Jane })).to be_success
+
+      expect(schema.(user: { age: 36, name: :Jane }).errors.to_h).to eql(
+        user: { name: ['must be a string'] }
+      )
+    end
+  end
+
+  describe '#xor' do
+    let(:operator) { :xor }
+
+    it 'composes schemas using exclusive disjunction' do
+      expect(schema.(user: { age: 36, name: :Jane })).to be_success
+      expect(schema.(user: { age: '36', name: 'Jane' })).to be_success
+    end
+  end
+end

--- a/spec/unit/dry/schema/path_spec.rb
+++ b/spec/unit/dry/schema/path_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe Dry::Schema::Path do
+  subject(:path) do
+    Dry::Schema::Path.new(segments)
+  end
+
+  describe '#to_h' do
+    let(:segments) do
+      %i[foo bar 1 baz bar foo]
+    end
+
+    it 'returns a nested hash with an array placeholder' do
+      expect(path.to_h).to eql(foo: { bar: { '1': { baz: { bar: { foo: [] } } } } })
+    end
+  end
+
+  describe '#index' do
+    let(:segments) do
+      %i[foo bar 1 baz bar foo]
+    end
+
+    it 'returns index for a given key' do
+      expect(path.index(:'1')).to be(2)
+      expect(path.index(:baz)).to be(3)
+    end
+  end
+
+  describe '#include?' do
+    let(:segments) do
+      %i[foo bar 1 baz bar foo]
+    end
+
+    it 'returns true if a path is within the source path' do
+      other = Dry::Schema::Path.new(%i[foo bar])
+
+      expect(path.include?(other)).to be(true)
+    end
+
+    it 'returns true if a path is the same as the source path' do
+      other = Dry::Schema::Path.new(%i[foo bar 1 baz bar foo])
+
+      expect(path.include?(other)).to be(true)
+    end
+
+    it 'returns false if a path has a different root' do
+      other = Dry::Schema::Path.new(%i[something_else foo bar])
+
+      expect(path.include?(other)).to be(false)
+    end
+
+    it 'returns false if a path is not within the source path' do
+      other = Dry::Schema::Path.new(%i[foo something_else])
+
+      expect(path.include?(other)).to be(false)
+    end
+  end
+end

--- a/spec/unit/dry/schema/path_spec.rb
+++ b/spec/unit/dry/schema/path_spec.rb
@@ -53,4 +53,23 @@ RSpec.describe Dry::Schema::Path do
       expect(path.include?(other)).to be(false)
     end
   end
+
+  describe '#&' do
+    let(:segments) do
+      %i[user address street]
+    end
+
+    it 'returns a new path with the common segment as the root' do
+      other = Dry::Schema::Path.new(%i[user address city])
+      root = Dry::Schema::Path.new(%i[user address])
+
+      expect(path & other).to eql(root)
+    end
+
+    it 'raises if other is not included in the source' do
+      other = Dry::Schema::Path.new(%i[foo baz qux])
+
+      expect { path & other }.to raise_error(ArgumentError, /doesn't have the same root/)
+    end
+  end
 end


### PR DESCRIPTION
This adds support for dry-logic's operators API, so `and`, `or`, `then` and `xor`. All should work quite well wrt error messages except `xor` which is not fully supported by error compiler.

## Example

This is an example showing `OR` operation, it introduces a new data structure for error hashes that has `:or` key under which you will find an array with left and right results. This obviously needs special handling in your code when you want to display/return error messages in an app-specific way.

```ruby
require 'dry-schema'

Parameter = Dry::Schema.JSON do
  required(:name).filled(:string)
end

Reference = Dry::Schema.JSON do
  required(:$ref).filled(:string)
end

Operation = Dry::Schema.JSON do
  required(:parameters).array(:hash, Parameter | Reference)
end

Schema = Dry::Schema.JSON do
  required(:paths).array(:hash) do
    required(:get).hash(Operation)
  end
end

valid_hash = {
  'paths' => [
    {
      'get' => {
        'parameters' => [
          { 'name' => 'hello' },
          { '$ref' => '#/internal/ref' }
        ]
      }
    }
  ]
}

result = Schema.(valid_hash)

result.errors.to_h.inspect
# {}

invalid_hash = {
  'paths' => [
    {
      'get' => {
        'parameters' => [
          { 'name' => '' },
          { '$ref' => '#/internal/ref' }
        ]
      }
    }
  ]
}

result = Schema.(invalid_hash)

result.errors.to_h.inspect
# { :paths=>{
#    0=>{
#      :get=>{
#         :parameters=>{
#            :or=>[{:name=>["must be filled"]}, {:$ref=>["is missing"]}]
#          }
#      }
#    }
#  }}
```

## TODO

- [x] Add operators API
- [x] Figure out how to extract key-maps from composed schemas
- [x] Figure out how to extract type-schemas from composed schemas
- [x] Make it work with `hash` syntax
- [x] Make it work with `schema` syntax
- [x] Make it work with `array(:hash) { required(:foo).hash(s1 | s2) }` syntax
- [x] Support schemas with the same keys defined
- [x] Introduce a new type of `Or` message for multi-paths results
- [x] ~Make it work with `array(:hash) { s1 | s2 }` syntax~ this is actually a limitation of the DSL *in general* so it can be addressed separately

Closes #231