### PR TITLE
Restore Messages::Abstract#call

### DIFF
--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -80,6 +80,20 @@ module Dry
           rule.is_a?(Hash) ? rule[:text] : rule
         end
 
+        # Retrieve a message template
+        #
+        # @return [Hash]
+        #
+        # @api public
+        def call(predicate, options)
+          tokens = options.reject { |key, _|
+            key.equal?(:locale) || config.lookup_options.include?(key)
+          }
+
+          lookup(predicate, tokens, options)
+        end
+        alias [] call
+
         # Retrieve an array of looked up paths
         #
         # @param [Symbol] predicate

--- a/spec/unit/dry/schema/messages/yaml_spec.rb
+++ b/spec/unit/dry/schema/messages/yaml_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe Dry::Schema::Messages::YAML do
     Dry::Schema::Messages::YAML.build
   end
 
+  describe '#[]' do
+    it 'returns text and optional meta' do
+      result = messages[:size?, path: [:name], size: 312]
+
+      expect(result).to eql(
+        text: 'size must be 312',
+        meta: {}
+      )
+    end
+  end
+
   describe '#lookup' do
     context 'with default config' do
       it 'returns text and optional meta' do


### PR DESCRIPTION
This was removed in #233 but it's a public interface that dry-validation
relies on.

Its behavior is now different since it no longer returns a `Template` as
evaluation is handled by the specific backend now (which is a good thing).

This means **we will have to bump version to 2.0.0** already if we decide to release it along with other changes.