### PR TITLE
to_h and message_map fixes for dry-validation

### DIFF
--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -66,7 +66,14 @@ module Dry
         node = hash
 
         while curr_idx <= last_idx
-          (node = node[keys[curr_idx]] = (curr_idx.eql?(last_idx) ? Array(value) : EMPTY_HASH.dup))
+          node =
+            node[keys[curr_idx]] =
+              if curr_idx == last_idx
+                value.is_a?(Array) ? value : [value]
+              else
+                EMPTY_HASH.dup
+              end
+
           curr_idx += 1
         end
 

--- a/spec/unit/dry/schema/message_set_spec.rb
+++ b/spec/unit/dry/schema/message_set_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'dry/schema/message'
+require 'dry/schema/message_set'
+
+RSpec.describe Dry::Schema::MessageSet do
+  describe '#to_h' do
+    def message_set_hash(*tuples, slice_length)
+      Dry::Schema::MessageSet.new(
+        tuples.each_slice(slice_length).map do |text, path, meta = {}|
+          Dry::Schema::Message.new(
+            text: text,
+            path: path,
+            meta: meta,
+            input: nil,
+            predicate: nil
+          )
+        end
+      ).to_h
+    end
+
+    context 'without meta' do
+      def to_h(*tuples)
+        message_set_hash(*tuples, 2)
+      end
+
+      it 'builds an empty message hash' do
+        expect(to_h).to eq({})
+      end
+
+      it 'builds a shallow hash' do
+        expect(
+          to_h(
+            'just a', %i[a]
+          )
+        ).to eq(
+          a: ['just a']
+        )
+      end
+
+      it 'builds a nested hash' do
+        expect(
+          to_h(
+            'a then b', %i[a b]
+          )
+        ).to eq(
+          a: {
+            b: ['a then b']
+          }
+        )
+      end
+
+      it 'builds a mixed hash' do
+        expect(
+          to_h(
+            'just a', %i[a],
+            'a then b', %i[a b]
+          )
+        ).to eq(
+          a: [
+            ['just a'],
+            {
+              b: ['a then b']
+            }
+          ]
+        )
+      end
+
+      it 'combines arrays' do
+        expect(
+          to_h(
+            'just a', %i[a],
+            'just a again', %i[a]
+          )
+        ).to eq(
+          a: ['just a', 'just a again']
+        )
+      end
+
+      it 'combines arrays and hashes' do
+        expect(
+          to_h(
+            'just a', %i[a],
+            'a then b', %i[a b],
+            'just a again', %i[a]
+          )
+        ).to eq(
+          a: [
+            ['just a', 'just a again'],
+            {
+              b: ['a then b']
+            }
+          ]
+        )
+      end
+
+      it 'builds a large hash' do
+        expect(
+          to_h(
+            'just c', %i[c],
+            'a then b', %i[a b],
+            'just a', %i[a],
+            'just b', %i[b],
+            'a then b again', %i[a b],
+            'just b again', %i[b],
+            'just a again', %i[a],
+            'a then b then c', %i[a b c]
+          )
+        ).to eq(
+          a: [
+            ['just a', 'just a again'],
+            {
+              b: [
+                ['a then b', 'a then b again'],
+                {
+                  c: ['a then b then c']
+                }
+              ]
+            }
+          ],
+          b: ['just b', 'just b again'],
+          c: ['just c']
+        )
+      end
+    end
+
+    context 'with some meta' do
+      def to_h(*tuples)
+        message_set_hash(*tuples, 3)
+      end
+
+      it 'builds a large hash' do
+        expect(
+          to_h(
+            'just a', %i[a], { code: 123 },
+            'a then b', %i[a b], {},
+            'just a again', %i[a], { code: 234 },
+            'a then b again', %i[a b], { code: 456 },
+            'just a again again', %i[a], {}
+          )
+        ).to eq(
+          a: [
+            [
+              {
+                text: 'just a',
+                code: 123
+              },
+              {
+                text: 'just a again',
+                code: 234
+              },
+              'just a again again'
+            ],
+            {
+              b: [
+                'a then b',
+                {
+                  text: 'a then b again',
+                  code: 456
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/dry/schema/message_spec.rb
+++ b/spec/unit/dry/schema/message_spec.rb
@@ -3,26 +3,54 @@
 require 'dry/schema/message'
 
 RSpec.describe Dry::Schema::Message do
-  def msg(path)
-    Dry::Schema::Message.new(text: 'failed', predicate: :int?, path: path, input: nil)
+  let(:text) { 'failed' }
+  let(:path) { %i[user] }
+  let(:meta) { { code: 123 } }
+
+  def msg(path: self.path, meta: self.meta)
+    Dry::Schema::Message.new(text: text, predicate: :int?, path: path, input: nil, meta: meta)
   end
 
   describe '#<=>' do
+    let(:child) { [*path, :age] }
+
     it 'returns -1 when path is lower in hierarchy' do
-      expect(msg(%i[user]) <=> msg(%i[user age])).to be(-1)
+      expect(msg <=> msg(path: child)).to be(-1)
     end
 
     it 'returns 0 when path is the same' do
-      expect(msg(%i[user age]) <=> msg(%i[user age])).to be(0)
+      # rubocop:disable Lint/UselessComparison
+      expect(msg(path: child) <=> msg(path: child)).to be(0)
+      # rubocop:enable Lint/UselessComparison
     end
 
     it 'returns 1 when path is higher in hierarchy' do
-      expect(msg(%i[user age]) <=> msg(%i[user])).to be(1)
+      expect(msg(path: child) <=> msg).to be(1)
     end
 
     it 'raises when paths have a different root' do
-      expect { msg(%i[user]) <=> msg(%i[address]) }
+      expect { msg <=> msg(path: %i[address]) }
         .to raise_error(ArgumentError, 'Cannot compare messages from different root paths')
+    end
+  end
+
+  describe '#dump' do
+    it 'returns just the text when meta is empty' do
+      expect(msg(meta: {}).dump).to eq(text)
+    end
+
+    it 'returns the text and splatted meta when meta is not empty' do
+      expect(msg.dump).to eq(meta.merge(text: text))
+    end
+  end
+
+  describe '#to_h' do
+    it 'has arrays of strings for values when meta is empty' do
+      expect(msg(meta: {}).to_h).to eq(path.first => [text])
+    end
+
+    it 'has arrays of hashes for values when meta is empty' do
+      expect(msg.to_h).to eq(path.first => [{ text: text, **meta }])
     end
   end
 end


### PR DESCRIPTION
dry-validation's master branch is currently failing CI because it uses some old code from dry-schema pre-to_h simplification. Fixing that code leads to some test failures in dry-validation. These changes indirectly address those test failures.

Required for https://github.com/dry-rb/dry-validation/pull/627 to pass CI.