### PR TITLE
Add struct extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'dry-configurable', github: 'dry-rb/dry-configurable', branch: 'master' if E
 
 group :test do
   gem 'dry-monads', require: false
+  gem 'dry-struct', require: false
   gem 'i18n', require: false
   gem 'transproc'
 end

--- a/lib/dry/schema/extensions.rb
+++ b/lib/dry/schema/extensions.rb
@@ -7,3 +7,7 @@ end
 Dry::Schema.register_extension(:hints) do
   require 'dry/schema/extensions/hints'
 end
+
+Dry::Schema.register_extension(:struct) do
+  require 'dry/schema/extensions/struct'
+end

--- a/lib/dry/schema/extensions/struct.rb
+++ b/lib/dry/schema/extensions/struct.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'dry/struct'
+require 'dry/schema/predicate_inferrer'
+require 'dry/schema/primitive_inferrer'
+require 'dry/schema/macros/dsl'
+require 'dry/schema/macros/hash'
+
+module Dry
+  module Schema
+    module Macros
+      Hash.prepend(::Module.new {
+        def call(*args)
+          if args.size >= 1 && args[0].is_a?(::Class) && args[0] <= ::Dry::Struct
+            if block_given?
+              raise ArgumentError, "blocks are not supported when using "\
+                                   "a struct class (#{name.inspect} => #{args[0]})"
+            end
+
+            super(args[0].schema, *args.drop(1))
+            type(schema_dsl.types[name].constructor(args[0]))
+          else
+            super
+          end
+        end
+      })
+    end
+
+    PredicateInferrer::Compiler.send(:alias_method, :visit_struct, :visit_hash)
+    PrimitiveInferrer::Compiler.send(:alias_method, :visit_struct, :visit_hash)
+  end
+end

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'dry/logic/operators'
-require 'dry/types/predicate_inferrer'
-require 'dry/types/primitive_inferrer'
 
 require 'dry/schema/macros/core'
+require 'dry/schema/predicate_inferrer'
+require 'dry/schema/primitive_inferrer'
 
 module Dry
   module Schema
@@ -28,13 +28,13 @@ module Dry
         #   PredicateInferrer is used to infer predicate type-check from a type spec
         #   @return [PredicateInferrer]
         #   @api private
-        option :predicate_inferrer, default: proc { ::Dry::Types::PredicateInferrer.new(compiler.predicates) }
+        option :predicate_inferrer, default: proc { PredicateInferrer.new(compiler.predicates) }
 
         # @!attribute [r] primitive_inferrer
         #   PrimitiveInferrer used to get a list of primitive classes from configured type
         #   @return [PrimitiveInferrer]
         #   @api private
-        option :primitive_inferrer, default: proc { ::Dry::Types::PrimitiveInferrer.new }
+        option :primitive_inferrer, default: proc { PrimitiveInferrer.new }
 
         # @overload value(*predicates, **predicate_opts)
         #   Set predicates without and with arguments

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -38,7 +38,7 @@ module Dry
 
             if block && type_spec.equal?(:hash)
               hash(&block)
-            elsif type_spec.respond_to?(:keys)
+            elsif type_spec.is_a?(::Dry::Types::Type) && hash_type?(type_spec)
               hash(type_spec)
             elsif block
               trace.append(new(chain: false).instance_exec(&block))
@@ -57,6 +57,10 @@ module Dry
         # @api private
         def array_type?(type)
           primitive_inferrer[type].eql?([::Array])
+        end
+
+        def hash_type?(type)
+          primitive_inferrer[type].eql?([::Hash])
         end
 
         # @api private

--- a/lib/dry/schema/predicate_inferrer.rb
+++ b/lib/dry/schema/predicate_inferrer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'dry/types/predicate_inferrer'
+
+module Dry
+  module Schema
+    # @api private
+    class PredicateInferrer < ::Dry::Types::PredicateInferrer
+      Compiler = ::Class.new(superclass::Compiler)
+
+      def initialize(registry = PredicateRegistry.new)
+        @compiler = Compiler.new(registry)
+      end
+    end
+  end
+end

--- a/lib/dry/schema/primitive_inferrer.rb
+++ b/lib/dry/schema/primitive_inferrer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'dry/types/primitive_inferrer'
+
+module Dry
+  module Schema
+    # @api private
+    class PrimitiveInferrer < ::Dry::Types::PrimitiveInferrer
+      Compiler = ::Class.new(superclass::Compiler)
+
+      def initialize
+        @compiler = Compiler.new
+      end
+    end
+  end
+end

--- a/spec/extensions/struct_spec.rb
+++ b/spec/extensions/struct_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe 'struct extension' do
+  before { Dry::Schema.load_extensions(:struct) }
+
+  let(:struct) do
+    Dry.Struct(name: 'string', email: 'string')
+  end
+
+  context 'inferring schemas from structs' do
+    let(:schema) do
+      struct = self.struct
+
+      Dry::Schema.define do
+        required(:foo).hash(struct)
+      end
+    end
+
+    let(:input) { { foo: { name: 'John' } } }
+
+    it 'infers predicates from struct' do
+      expect(result).to be_failing(email: ["is missing", "must be a string"])
+    end
+
+    context 'extra predicates' do
+      let(:schema) do
+        struct = self.struct
+
+        Dry::Schema.define do
+          required(:foo).hash(struct, :filled?)
+        end
+      end
+
+      let(:input) { { foo: {} } }
+
+      it 'adds predicates' do
+        expect(result).to be_failing(["must be filled"])
+      end
+    end
+
+    context 'more options' do
+      it 'raises an error when a block is given (not supported)' do
+        struct = self.struct
+        expect { Dry::Schema.define { required(:foo).hash(struct) { } } }.to raise_error(
+          ArgumentError,
+          /blocks are not supported/
+        )
+      end
+    end
+  end
+
+  context 'value macro' do
+    let(:schema) do
+      struct = self.struct
+
+      Dry::Schema.define do
+        required(:foo).value(struct)
+      end
+    end
+
+    let(:input) { { foo: { name: 'John' } } }
+
+    it 'infers predicates from struct' do
+      expect(result).to be_failing(email: ["is missing", "must be a string"])
+    end
+
+    context 'complex struct' do
+      let(:struct) do
+        Class.new(Dry::Struct) do
+          attribute :name, Types::String
+          attribute :addresses, Types::Array do
+            attribute  :city,   Types::String
+            attribute? :street, Types::String
+          end
+        end
+      end
+
+      let(:input) do
+        { foo: { name: 'Jane', addresses: [{}] } }
+      end
+
+      it 'produces errors for nested structs' do
+        expect(result).to be_failing(
+          addresses: { 0 => { city: ["is missing", "must be a string"] } }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
It simply infers a hash schema from a struct. More complex scenarios are not supported, there are reasons for this. In future, we plan to infer structs from schema definition, similarly to how it works in rom.