### PR TITLE
Consistently use Template#key when evaluating templates in backends

### DIFF
--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -107,6 +107,15 @@ module Dry
 
         alias_method :[], :call
 
+        # Check if given key is defined
+        #
+        # @return [Boolean]
+        #
+        # @api public
+        def key?(_key, _options = EMPTY_HASH)
+          raise NotImplementedError
+        end
+
         # Retrieve an array of looked up paths
         #
         # @param [Symbol] predicate
@@ -157,6 +166,16 @@ module Dry
         # @api private
         def default_locale
           config.default_locale
+        end
+
+        # @api private
+        def interpolatable_data(_key, _options, **_data)
+          raise NotImplementedError
+        end
+
+        # @api private
+        def interpolate(_key, _options, **_data)
+          raise NotImplementedError
         end
 
         private

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -99,7 +99,6 @@ module Dry
             Template.new(
               messages: self,
               key: path,
-              text: result[:text],
               options: opts
             ),
             result[:meta]

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -95,23 +95,23 @@ module Dry
       end
 
       # @api private
-      def interpolatable_data(_template, **input)
-        input
+      def interpolatable_data(_key, _options, **data)
+        data
       end
 
       # @api private
-      def interpolate(template, **data)
-        text_key = "#{template.key}.text"
+      def interpolate(key, options, **data)
+        text_key = "#{key}.text"
 
         opts = {
           locale: default_locale,
-          **template.options,
+          **options,
           **data
         }
 
-        key = key?(text_key, opts) ? text_key : template.key
+        resolved_key = key?(text_key, opts) ? text_key : key
 
-        t.(key, **opts)
+        t.(resolved_key, **opts)
       end
 
       private

--- a/lib/dry/schema/messages/i18n.rb
+++ b/lib/dry/schema/messages/i18n.rb
@@ -95,7 +95,7 @@ module Dry
       end
 
       # @api private
-      def pruned_data(_template, **input)
+      def interpolatable_data(_template, **input)
         input
       end
 

--- a/lib/dry/schema/messages/namespaced.rb
+++ b/lib/dry/schema/messages/namespaced.rb
@@ -71,8 +71,8 @@ module Dry
         end
 
         # @api private
-        def pruned_data(template, **input)
-          messages.pruned_data(template, **input)
+        def interpolatable_data(template, **input)
+          messages.interpolatable_data(template, **input)
         end
 
         # @api private

--- a/lib/dry/schema/messages/namespaced.rb
+++ b/lib/dry/schema/messages/namespaced.rb
@@ -71,13 +71,13 @@ module Dry
         end
 
         # @api private
-        def interpolatable_data(template, **input)
-          messages.interpolatable_data(template, **input)
+        def interpolatable_data(key, options, **data)
+          messages.interpolatable_data(key, options, **data)
         end
 
         # @api private
-        def interpolate(template, **data)
-          messages.interpolate(template, **data)
+        def interpolate(key, options, **data)
+          messages.interpolate(key, options, **data)
         end
       end
     end

--- a/lib/dry/schema/messages/template.rb
+++ b/lib/dry/schema/messages/template.rb
@@ -18,15 +18,15 @@ module Dry
         option :options
 
         # @api private
-        def data(input = EMPTY_HASH)
+        def data(data = EMPTY_HASH)
           ensure_message!
-          messages.interpolatable_data(self, **options, **input)
+          messages.interpolatable_data(key, options, **options, **data)
         end
 
         # @api private
         def call(data = EMPTY_HASH)
           ensure_message!
-          messages.interpolate(self, **data)
+          messages.interpolate(key, options, **data)
         end
         alias_method :[], :call
 

--- a/lib/dry/schema/messages/template.rb
+++ b/lib/dry/schema/messages/template.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/initializer'
+require 'dry/equalizer'
 
 require 'dry/schema/constants'
 
@@ -10,15 +11,15 @@ module Dry
       # @api private
       class Template
         extend Dry::Initializer
+        include Dry::Equalizer(:messages, :key, :options)
 
         option :messages
         option :key
-        option :text
         option :options
 
         # @api private
         def data(input = EMPTY_HASH)
-          messages.pruned_data(self, **options, **input)
+          messages.interpolatable_data(self, **options, **input)
         end
 
         # @api private

--- a/lib/dry/schema/messages/template.rb
+++ b/lib/dry/schema/messages/template.rb
@@ -19,14 +19,24 @@ module Dry
 
         # @api private
         def data(input = EMPTY_HASH)
+          ensure_message!
           messages.interpolatable_data(self, **options, **input)
         end
 
         # @api private
         def call(data = EMPTY_HASH)
+          ensure_message!
           messages.interpolate(self, **data)
         end
         alias_method :[], :call
+
+        private
+
+        def ensure_message!
+          return if messages.key?(key, options)
+
+          raise KeyError, "No message found for template, template=#{inspect}"
+        end
       end
     end
   end

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -134,43 +134,53 @@ module Dry
       end
 
       # @api private
-      def cache
-        @cache ||= self.class.cache[self]
-      end
-
-      # @api private
       def prepare
         @data = config.load_paths.map { |path| load_translations(path) }.reduce({}, :merge)
         self
       end
 
       # @api private
-      def pruned_data(template, **input)
-        tokens, = evaluation_context(template)
+      def interpolatable_data(template, **input)
+        tokens = evaluation_context(template).fetch(:tokens)
         input.select { |k,| tokens.include?(k) }
       end
 
       # @api private
       def interpolate(template, **data)
-        _, evaluator = evaluation_context(template)
+        evaluator = evaluation_context(template).fetch(:evaluator)
         data.empty? ? evaluator.() : evaluator.(**data)
       end
 
       private
 
+      # @api private
       def evaluation_context(template)
-        cache.fetch_or_store(template.text) do
-          tokens = template.text.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym).to_set
-          text = template.text.gsub('%', '#')
+        result = get(template.key, template.options)
+
+        unless result
+          raise KeyError, "No message found when evaluating template, template=#{template.inspect}"
+        end
+
+        cache.fetch_or_store(result.fetch(:text)) do |input|
+          tokens = input.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym).to_set
+          text = input.gsub('%', '#')
 
           # rubocop:disable Security/Eval
-          evaluator = eval(<<~RUBY, EMPTY_CONTEXT, __FILE__, __LINE__)
+          evaluator = eval(<<~RUBY, EMPTY_CONTEXT, __FILE__, __LINE__ + 1)
             -> (#{tokens.map { |token| "#{token}:" }.join(', ')}) { "#{text}" }
           RUBY
           # rubocop:enable Security/Eval
 
-          [tokens, evaluator]
+          {
+            tokens: tokens,
+            evaluator: evaluator
+          }
         end
+      end
+
+      # @api private
+      def cache
+        @cache ||= self.class.cache[self]
       end
 
       # @api private

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -155,13 +155,7 @@ module Dry
 
       # @api private
       def evaluation_context(template)
-        result = get(template.key, template.options)
-
-        unless result
-          raise KeyError, "No message found when evaluating template, template=#{template.inspect}"
-        end
-
-        cache.fetch_or_store(result.fetch(:text)) do |input|
+        cache.fetch_or_store(get(template.key, template.options).fetch(:text)) do |input|
           tokens = input.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym).to_set
           text = input.gsub('%', '#')
 

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -140,22 +140,22 @@ module Dry
       end
 
       # @api private
-      def interpolatable_data(template, **input)
-        tokens = evaluation_context(template).fetch(:tokens)
-        input.select { |k,| tokens.include?(k) }
+      def interpolatable_data(key, options, **data)
+        tokens = evaluation_context(key, options).fetch(:tokens)
+        data.select { |k,| tokens.include?(k) }
       end
 
       # @api private
-      def interpolate(template, **data)
-        evaluator = evaluation_context(template).fetch(:evaluator)
+      def interpolate(key, options, **data)
+        evaluator = evaluation_context(key, options).fetch(:evaluator)
         data.empty? ? evaluator.() : evaluator.(**data)
       end
 
       private
 
       # @api private
-      def evaluation_context(template)
-        cache.fetch_or_store(get(template.key, template.options).fetch(:text)) do |input|
+      def evaluation_context(key, options)
+        cache.fetch_or_store(get(key, options).fetch(:text)) do |input|
           tokens = input.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym).to_set
           text = input.gsub('%', '#')
 

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -33,11 +33,19 @@ RSpec.describe Dry::Schema::Messages::I18n do
         { default_locale: :pl }
       end
 
-      it 'returns a message' do
-        template, meta = messages[:size?, path: :age, size: 10]
+      it 'returns a template' do
+        template, = messages[:size?, path: :age, size: 10]
 
-        expect(template.()).to eql('wielkość musi być równa 10')
-        expect(meta).to eql({})
+        expect(template).to eq(
+          Dry::Schema::Messages::Template.new(
+            messages: messages,
+            key: 'dry_schema.errors.size?.arg.default',
+            options: {
+              locale: :pl,
+              size: 10
+            }
+          )
+        )
       end
     end
 
@@ -50,35 +58,35 @@ RSpec.describe Dry::Schema::Messages::I18n do
         expect(messages[:not_here, path: :srsly]).to be(nil)
       end
 
-      it 'returns a message for a predicate' do
+      it 'returns a template for a predicate' do
         template, meta = messages[:filled?, path: :name]
 
         expect(template.()).to eql('nie może być pusty')
         expect(meta).to eql({})
       end
 
-      it 'returns a message for a specific rule' do
+      it 'returns a template for a specific rule' do
         template, meta = messages[:filled?, path: :email]
 
         expect(template.()).to eql('Proszę podać adres email')
         expect(meta).to eql({})
       end
 
-      it 'returns a message for a specific val type' do
+      it 'returns a template for a specific val type' do
         template, meta = messages[:size?, path: :pages, val_type: String]
 
         expect(template.(size: 2)).to eql('wielkość musi być równa 2')
         expect(meta).to eql({})
       end
 
-      it 'returns a message for a specific rule and its default arg type' do
+      it 'returns a template for a specific rule and its default arg type' do
         template, meta = messages[:size?, path: :pages]
 
         expect(template.(size: 2)).to eql('wielkość musi być równa 2')
         expect(meta).to eql({})
       end
 
-      it 'returns a message for a specific rule and its arg type' do
+      it 'returns a template for a specific rule and its arg type' do
         template, meta = messages[:size?, path: :pages, arg_type: Range]
 
         expect(template.(size_left: 1, size_right: 2)).to eql('wielkość musi być między 1 a 2')
@@ -130,7 +138,7 @@ RSpec.describe Dry::Schema::Messages::I18n do
           I18n.fallbacks = I18n::Locale::Fallbacks.new(:en)
         end
 
-        it 'returns a message for a predicate in the default_locale' do
+        it 'returns a template for a predicate in the default_locale' do
           template, meta = messages[:even?, path: :some_number]
 
           expect(I18n.locale).to eql(:pl)
@@ -141,28 +149,28 @@ RSpec.describe Dry::Schema::Messages::I18n do
     end
 
     context 'with a different locale' do
-      it 'returns a message for a predicate' do
+      it 'returns a template for a predicate' do
         template, meta = messages[:filled?, path: :name, locale: :en]
 
         expect(template.()).to eql('must be filled')
         expect(meta).to eql({})
       end
 
-      it 'returns a message for a specific rule' do
+      it 'returns a template for a specific rule' do
         template, meta = messages[:filled?, path: :email, locale: :en]
 
         expect(template.()).to eql('Please provide your email')
         expect(meta).to eql({})
       end
 
-      it 'returns a message for a specific rule and its default arg type' do
+      it 'returns a template for a specific rule and its default arg type' do
         template, meta = messages[:size?, path: :pages, locale: :en]
 
         expect(template.(size: 2)).to eql('size must be 2')
         expect(meta).to eql({})
       end
 
-      it 'returns a message for a specific rule and its arg type' do
+      it 'returns a template for a specific rule and its arg type' do
         template, meta = messages[:size?, path: :pages, arg_type: Range, locale: :en]
 
         expect(template.(size_left: 1, size_right: 2)).to eql('size must be within 1 - 2')

--- a/spec/unit/dry/schema/messages/i18n_spec.rb
+++ b/spec/unit/dry/schema/messages/i18n_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Dry::Schema::Messages::I18n do
       Dry::Schema::Messages::I18n.build
     end
 
-    describe '#lookup' do
-      it 'returns lookup result' do
+    describe '#[]' do
+      it 'returns template result' do
         template, meta = messages[:filled?, path: [:name]]
 
         expect(template.()).to eql('must be filled')
@@ -29,8 +29,8 @@ RSpec.describe Dry::Schema::Messages::I18n do
       Dry::Schema::Messages::I18n.build(top_namespace: 'my_app')
     end
 
-    describe '#lookup' do
-      it 'returns lookup result' do
+    describe '#[]' do
+      it 'returns template result' do
         template, meta = messages[:filled?, path: [:name]]
 
         expect(template.()).to eql('must be filled')

--- a/spec/unit/dry/schema/messages/template_spec.rb
+++ b/spec/unit/dry/schema/messages/template_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'dry/schema/messages/template'
+require 'dry/schema/messages/yaml'
+
+RSpec.describe Dry::Schema::Messages::Template do
+  let(:messages) do
+    Dry::Schema::Messages::YAML.new.merge(
+      stringify_keys(
+        en: {
+          dry_schema: {
+            errors: {
+              neato?: '%{name} is awesome and %{adjective}'
+            }
+          }
+        }
+      )
+    )
+  end
+
+  subject(:template) do
+    Dry::Schema::Messages::Template.new(
+      messages: messages,
+      key: '%<locale>s.dry_schema.errors.neato?',
+      options: {
+        name: 'Alice',
+        locale: :en
+      }
+    )
+  end
+
+  describe '#data' do
+    it 'delegates to the message backend' do
+      expect(template.data(adjective: 'rad', ignored: 'param'))
+        .to eq(adjective: 'rad', name: 'Alice')
+    end
+  end
+
+  describe '#call' do
+    it 'delegates to the message backend' do
+      expect(template.(name: 'Alice', adjective: 'rad')).to eq('Alice is awesome and rad')
+    end
+  end
+end

--- a/spec/unit/dry/schema/messages/template_spec.rb
+++ b/spec/unit/dry/schema/messages/template_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Dry::Schema::Messages::Template do
     )
   end
 
-  subject(:template) do
+  let(:valid_template) do
     Dry::Schema::Messages::Template.new(
       messages: messages,
       key: '%<locale>s.dry_schema.errors.neato?',
@@ -29,16 +29,32 @@ RSpec.describe Dry::Schema::Messages::Template do
     )
   end
 
+  let(:broken_template) do
+    Dry::Schema::Messages::Template.new(
+      messages: messages,
+      key: 'this does not exist',
+      options: {}
+    )
+  end
+
   describe '#data' do
     it 'delegates to the message backend' do
-      expect(template.data(adjective: 'rad', ignored: 'param'))
+      expect(valid_template.data(adjective: 'rad', ignored: 'param'))
         .to eq(adjective: 'rad', name: 'Alice')
+    end
+
+    it 'raises a KeyError when the key does not exist' do
+      expect { broken_template.data }.to raise_error(KeyError)
     end
   end
 
   describe '#call' do
     it 'delegates to the message backend' do
-      expect(template.(name: 'Alice', adjective: 'rad')).to eq('Alice is awesome and rad')
+      expect(valid_template.(name: 'Alice', adjective: 'rad')).to eq('Alice is awesome and rad')
+    end
+
+    it 'raises a KeyError when the key does not exist' do
+      expect { broken_template.call }.to raise_error(KeyError)
     end
   end
 end

--- a/spec/unit/dry/schema/messages/yaml_spec.rb
+++ b/spec/unit/dry/schema/messages/yaml_spec.rb
@@ -190,26 +190,4 @@ RSpec.describe Dry::Schema::Messages::YAML do
       end
     end
   end
-
-  context 'evaluating a bad template' do
-    let(:template) do
-      Dry::Schema::Messages::Template.new(
-        messages: messages,
-        key: 'does not exist',
-        options: {}
-      )
-    end
-
-    describe '#interpolatable_data' do
-      it 'raises a KeyError when the template has a bad key' do
-        expect { messages.interpolatable_data(template) }.to raise_error(KeyError)
-      end
-    end
-
-    describe '#interpolate' do
-      it 'raises a KeyError when the template has a bad key' do
-        expect { messages.interpolate(template) }.to raise_error(KeyError)
-      end
-    end
-  end
 end

--- a/spec/unit/dry/schema/messages/yaml_spec.rb
+++ b/spec/unit/dry/schema/messages/yaml_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require 'dry/schema/messages/yaml'
+require 'dry/schema/messages/template'
 
 RSpec.describe Dry::Schema::Messages::YAML do
   subject(:messages) do
     Dry::Schema::Messages::YAML.build
   end
 
-  describe '#lookup' do
+  describe '#[]' do
     context 'with default config' do
       it 'returns text and optional meta' do
         template, meta = messages[:filled?, path: [:name]]
@@ -186,6 +187,28 @@ RSpec.describe Dry::Schema::Messages::YAML do
             text: 'text not filled', meta: { code: 476 }
           }
         )
+      end
+    end
+  end
+
+  context 'evaluating a bad template' do
+    let(:template) do
+      Dry::Schema::Messages::Template.new(
+        messages: messages,
+        key: 'does not exist',
+        options: {}
+      )
+    end
+
+    describe '#interpolatable_data' do
+      it 'raises a KeyError when the template has a bad key' do
+        expect { messages.interpolatable_data(template) }.to raise_error(KeyError)
+      end
+    end
+
+    describe '#interpolate' do
+      it 'raises a KeyError when the template has a bad key' do
+        expect { messages.interpolate(template) }.to raise_error(KeyError)
       end
     end
   end


### PR DESCRIPTION
When I reintroduced the Template class, I added both the key and text of the message that was looked up at Template instantiation as attributes of the Template class. This led to an inconsistency in how message parameter interpolation is implemented—while the I18n backend just uses the key and looks up the message again, the YAML backend would use the text. This PR makes the approach consistent, and has both message backends look up the message again at the time that interpolation occurs. 