### PR TITLE
Add Processor#merge which allows merging schemas

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -202,6 +202,20 @@ module Dry
         processor_type.new(schema_dsl: self, steps: result_steps)
       end
 
+      # Merge with another dsl
+      #
+      # @return [DSL]
+      #
+      # @api private
+      def merge(other)
+        new(
+          parent: parents + other.parents,
+          macros: macros + other.macros,
+          types: types.merge(other.types),
+          steps: steps.merge(other.steps)
+        )
+      end
+
       # Cast this DSL into a rule object
       #
       # @return [RuleApplier]

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -90,6 +90,17 @@ module Dry
       end
       alias_method :[], :call
 
+      # Merge with another schema
+      #
+      # @param [Processor] other
+      #
+      # @return [Processor, Params, JSON]
+      #
+      # @api public
+      def merge(other)
+        schema_dsl.merge(other.schema_dsl).()
+      end
+
       # Return a proc that acts like a schema object
       #
       # @return [Proc]

--- a/spec/unit/dry/schema/processor/merge_spec.rb
+++ b/spec/unit/dry/schema/processor/merge_spec.rb
@@ -1,0 +1,82 @@
+require 'dry/schema/processor'
+
+RSpec.describe Dry::Schema::Processor, '#merge' do
+  context 'without parents' do
+    subject(:schema) { left.merge(right) }
+
+    let(:left) do
+      Dry::Schema.define do
+        after(:rule_applier) do |result|
+          result.output[:left] = true
+        end
+
+        required(:name).filled(:string)
+      end
+    end
+
+    let(:right) do
+      Dry::Schema.define do
+        after(:rule_applier) do |result|
+          result.output[:right] = true
+        end
+
+        required(:age).value(Types::Params::Integer)
+      end
+    end
+
+    it 'maintains rules' do
+      expect(schema.(name: '', age: 'foo').errors.to_h).to eql(
+        name: ['must be filled'], age: ['must be an integer']
+      )
+    end
+
+    it 'maintains types' do
+      expect(schema.(name: '', age: '36').errors.to_h).to eql(
+        name: ['must be filled']
+      )
+    end
+
+    it 'maintains hooks' do
+      expect(schema.(name: 'Jane', age: 36).to_h).to eql(
+        name: 'Jane', age: 36, left: true, right: true
+      )
+    end
+  end
+
+  context 'with parents' do
+    subject(:schema) { left.merge(right) }
+
+    let(:left_parent) do
+      Dry::Schema.define do
+        required(:email).filled(:string)
+      end
+    end
+
+    let(:left) do
+      Dry::Schema.define(parent: left_parent) do
+        required(:name).filled(:string)
+      end
+    end
+
+    let(:right_parent) do
+      Dry::Schema.define do
+        required(:address).filled(:string)
+      end
+    end
+
+    let(:right) do
+      Dry::Schema.define(parent: right_parent) do
+        required(:age).value(:integer)
+      end
+    end
+
+    it 'maintains all rules' do
+      expect(schema.(name: '', age: 'foo').errors.to_h).to eql(
+        name: ['must be filled'],
+        age: ['must be an integer'],
+        email: ['is missing'],
+        address: ['is missing']
+      )
+    end
+  end
+end


### PR DESCRIPTION
Refs dry-rb/dry-validation#593

This adds `merge` interface to all schema types. It allows merging two schemas into a new schema that will include all rules from both schemas as well as their types, steps and parents.

``` ruby
require 'dry/schema'

s1 = Dry::Schema.define do
  required(:name).filled(:string)
end

s2 = Dry::Schema.define do
  required(:age).value(:integer)
end

schema = s1.merge(s2)

puts schema.(name: '', age: 'foo').errors.to_h.inspect
# {:name=>["must be filled"], :age=>["must be an integer"]}
```