### PR TITLE
Support callbacks in nested schemas

### DIFF
--- a/lib/dry/schema/constants.rb
+++ b/lib/dry/schema/constants.rb
@@ -14,6 +14,9 @@ module Dry
     QUESTION_MARK = '?'
     DOT = '.'
 
+    # core processor steps in the default execution order
+    STEPS_IN_ORDER = %i[key_coercer filter_schema value_coercer rule_applier].freeze
+
     # Path to the default set of localized messages bundled within the gem
     DEFAULT_MESSAGES_PATH = Pathname(__dir__).join('../../../config/errors.yml').realpath.freeze
 

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -4,6 +4,7 @@ require 'dry/initializer'
 
 require 'dry/schema'
 require 'dry/schema/constants'
+require 'dry/schema/path'
 require 'dry/schema/config'
 require 'dry/schema/compiler'
 require 'dry/schema/types'
@@ -72,6 +73,9 @@ module Dry
 
       # @return [ProcessorSteps] Steps for the processor
       option :steps, default: proc { ProcessorSteps.new }
+
+      # @return [Path, Array] Path under which the schema is defined
+      option :path, -> *args { Path[*args] if args.any? }, default: proc { EMPTY_ARRAY }
 
       # Build a new DSL object and evaluate provided block
       #

--- a/lib/dry/schema/macros/core.rb
+++ b/lib/dry/schema/macros/core.rb
@@ -33,6 +33,11 @@ module Dry
         end
 
         # @api private
+        def path
+          schema_dsl.path
+        end
+
+        # @api private
         def to_rule
           compiler.visit(to_ast)
         end

--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -19,6 +19,7 @@ module Dry
 
           if block
             schema = define(*args, &block)
+            import_steps(schema)
             trace << schema.to_rule
           end
 
@@ -45,7 +46,7 @@ module Dry
 
         # @api private
         def define(*args, &block)
-          definition = schema_dsl.new(&block)
+          definition = schema_dsl.new(path: schema_dsl.path, &block)
           schema = definition.call
           type_schema =
             if array_type?(parent_type)

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'dry/schema/path'
 require 'dry/schema/macros/dsl'
 
 module Dry
@@ -22,6 +23,8 @@ module Dry
               else
                 schema.type_schema
               end
+
+            import_steps(schema)
 
             type(updated_type)
           end
@@ -75,6 +78,11 @@ module Dry
               Dry::Types['array'].constructor { ... }
             ERROR
           end
+        end
+
+        # @api private
+        def import_steps(schema)
+          schema_dsl.steps.import_callbacks(Path[[*path, name]], schema.steps)
         end
 
         # @api private

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -110,15 +110,6 @@ module Dry
         ->(input) { call(input) }
       end
 
-      # Return the key map
-      #
-      # @return [KeyMap]
-      #
-      # @api public
-      def key_map
-        steps[:key_coercer].key_map
-      end
-
       # Return string represntation
       #
       # @return [String]
@@ -130,14 +121,31 @@ module Dry
         STR
       end
 
+      # Return the key map
+      #
+      # @return [KeyMap]
+      #
+      # @api public
+      def key_map
+        steps.key_map
+      end
+
       # Return the type schema
       #
       # @return [Dry::Types::Safe]
       #
       # @api private
       def type_schema
-        steps[:value_coercer].type_schema
+        steps.type_schema
       end
+
+      # Return the rule applier
+      #
+      # @api private
+      def rule_applier
+        steps.rule_applier
+      end
+      alias_method :to_rule, :rule_applier
 
       # Return the rules config
       #
@@ -173,14 +181,6 @@ module Dry
       def rules
         rule_applier.rules
       end
-
-      # Return the rule applier
-      #
-      # @api private
-      def rule_applier
-        steps[:rule_applier]
-      end
-      alias_method :to_rule, :rule_applier
 
       # Check if there are filter rules
       #

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -32,10 +32,41 @@ module Dry
       option :message_compiler
 
       # @api private
+      option :parent, default: -> { nil }
+
+      # @api private
       def self.new(*, **)
         result = super
-        yield(result)
+        yield(result) if block_given?
         result.freeze
+      end
+
+      # Return a new result scoped to a specific path
+      #
+      # @param [Symbol, Array, Path]
+      #
+      # @return [Result]
+      #
+      # @api private
+      def at(path, &block)
+        new(Path[path].reduce(output) { |a, e| a[e] }, parent: self, &block)
+      end
+
+      # @api private
+      def new(output, **opts, &block)
+        self.class.new(
+          output,
+          message_compiler: message_compiler,
+          results: results,
+          **opts,
+          &block
+        )
+      end
+
+      # @api private
+      def update(hash)
+        output.update(hash)
+        self
       end
 
       # @api private

--- a/lib/dry/schema/step.rb
+++ b/lib/dry/schema/step.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'dry/schema/constants'
+require 'dry/schema/path'
+
+module Dry
+  module Schema
+    # @api private
+    class Step
+      # @api private
+      attr_reader :name
+
+      # @api private
+      attr_reader :type
+
+      # @api private
+      attr_reader :executor
+
+      # @api private
+      class Scoped
+        # @api private
+        attr_reader :path
+
+        # @api private
+        attr_reader :step
+
+        # @api private
+        def initialize(path, step)
+          @path = Path[path]
+          @step = step
+        end
+
+        # @api private
+        def scoped(new_path)
+          self.class.new(Path[[*new_path, *path]], step)
+        end
+
+        # @api private
+        def call(result)
+          result.at(path) do |scoped_result|
+            output = step.(scoped_result).to_h
+            target = Array(path)[0..-2].reduce(result) { |a, e| a[e] }
+
+            target.update(path.last => output)
+          end
+        end
+      end
+
+      # @api private
+      def initialize(type:, name:, executor:)
+        @type = type
+        @name = name
+        @executor = executor
+        validate_name(name)
+      end
+
+      # @api private
+      def call(result)
+        output = executor.(result)
+        result.replace(output) if output.is_a?(Hash)
+        output
+      end
+
+      # @api private
+      def scoped(path)
+        Scoped.new(path, self)
+      end
+
+      private
+
+      # @api private
+      def validate_name(name)
+        return if STEPS_IN_ORDER.include?(name)
+
+        raise ArgumentError, "Undefined step name #{name}. Available names: #{STEPS_IN_ORDER}"
+      end
+    end
+  end
+end

--- a/spec/integration/schema/steps_spec.rb
+++ b/spec/integration/schema/steps_spec.rb
@@ -50,6 +50,38 @@ RSpec.describe Dry::Schema, 'callbacks' do
     end
   end
 
+  context 'under a nested schema in an array' do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:accounts).array(:hash) do
+          required(:user).hash(Test::UserSchema)
+        end
+      end
+    end
+
+    before do
+      Test::UserSchema = Dry::Schema.define do
+        optional(:name).maybe(:string)
+        required(:date).maybe(:date)
+
+        before(:key_coercer) do |result|
+          { name: 'default' }.merge(result.to_h)
+        end
+
+        after(:rule_applier) do |result|
+          result.to_h.compact
+        end
+      end
+    end
+
+    it 'calls callbacks' do
+      pending 'not implemented yet'
+
+      expect(schema.(accounts: [{ user: { date: nil } }]).to_h)
+        .to eql(accounts: [{ user: { name: 'default' } }])
+    end
+  end
+
   context 'invalid step name' do
     it 'raises error' do
       expect {

--- a/spec/integration/schema/steps_spec.rb
+++ b/spec/integration/schema/steps_spec.rb
@@ -19,4 +19,45 @@ RSpec.describe Dry::Schema, 'callbacks' do
       expect(schema.(date: nil).to_h).to eql(name: 'default')
     end
   end
+
+  context 'under a nested schema' do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:account).hash do
+          required(:user).hash(Test::UserSchema)
+        end
+      end
+    end
+
+    before do
+      Test::UserSchema = Dry::Schema.define do
+        optional(:name).maybe(:string)
+        required(:date).maybe(:date)
+
+        before(:key_coercer) do |result|
+          { name: 'default' }.merge(result.to_h)
+        end
+
+        after(:rule_applier) do |result|
+          result.to_h.compact
+        end
+      end
+    end
+
+    it 'calls callbacks' do
+      expect(schema.(account: { user: { date: nil } }).to_h)
+        .to eql(account: { user: { name: 'default' } })
+    end
+  end
+
+  context 'invalid step name' do
+    it 'raises error' do
+      expect {
+        Dry::Schema.define do
+          before(:oops) { }
+          required(:user).value(:hash)
+        end
+      }.to raise_error(ArgumentError, /oops/)
+    end
+  end
 end

--- a/spec/integration/schema/steps_spec.rb
+++ b/spec/integration/schema/steps_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Dry::Schema, 'callbacks' do
+  context 'top-level' do
+    subject(:schema) do
+      Dry::Schema.define do
+        optional(:name).maybe(:str?)
+        required(:date).maybe(:date?)
+
+        before(:key_coercer) do |result|
+          { name: 'default' }.merge(result.to_h)
+        end
+
+        after(:rule_applier) do |result|
+          result.to_h.compact
+        end
+      end
+    end
+
+    it 'calls callbacks' do
+      expect(schema.(date: nil).to_h).to eql(name: 'default')
+    end
+  end
+end

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -98,27 +98,6 @@ RSpec.describe Dry::Schema, '.define' do
     end
   end
 
-  context 'schema with callbacks' do
-    subject(:schema) do
-      Dry::Schema.define do
-        optional(:name).maybe(:str?)
-        required(:date).maybe(:date?)
-
-        before(:key_coercer) do |result|
-          { name: 'default' }.merge(result.to_h)
-        end
-
-        after(:rule_applier) do |result|
-          result.to_h.compact
-        end
-      end
-    end
-
-    it 'calls callbacks' do
-      expect(schema.(date: nil).to_h).to eq(name: 'default')
-    end
-  end
-
   context 'nested schema' do
     subject(:schema) do
       Dry::Schema.define do

--- a/spec/unit/dry/schema/step_spec.rb
+++ b/spec/unit/dry/schema/step_spec.rb
@@ -1,0 +1,25 @@
+require 'dry/schema/step'
+
+RSpec.describe Dry::Schema::Step do
+  describe '#call' do
+    context 'when scoped with a deep path' do
+      subject(:step) do
+        root_step.scoped([:foo, :bar])
+      end
+
+      let(:root_step) do
+        Dry::Schema::Step.new(type: :core, name: :rule_applier, executor: -> result {
+          result.update(test: true)
+        })
+      end
+
+      it 'updates results using nested path' do
+        result = Dry::Schema::Result.new({ foo: { bar: {} } }, message_compiler: proc {}) do |r|
+          step.(r)
+        end
+
+        expect(result.to_h).to eql(foo: { bar: { test: true } })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support callbacks in nested schemas
    
* Add `Step` concept
* Add `Step::Scoped` that narrows down execution to a specific path
* Move `STEPS_IN_ORDER` to `Constants` because both `Step` and `ProcessorSteps` rely on it
* Move step name validation to `Step` and add a spec for this case
* Add `Result#update` so that it's easy to update a result
* Add `Schema::DSL#path` which tracks path under which rules are defined

## Example

```ruby
require 'dry/schema'

PersonSchema = Dry::Schema.define do
  before(:rule_applier) do |result|
    { name: 'anonymous' }.merge(result.to_h)
  end

  after(:rule_applier) do |result|
    result.to_h.compact
  end

  required(:email).filled(:string)
  optional(:name).maybe(:string)
  optional(:bday).maybe(:date)
end

GuestSchema = Dry::Schema.define do
  required(:guest).hash(PersonSchema)
end

UserSchema = Dry::Schema.define do
  required(:user).hash(PersonSchema)
end

GuestSchema.(guest: { email: 'jane@doe.org' })
# #<Dry::Schema::Result{:guest=>{:name=>"anonymous", :email=>"jane@doe.org"}} errors={}>

UserSchema.(user: { name: 'John', email: 'john@doe.org' })
# #<Dry::Schema::Result{:user=>{:name=>"John", :email=>"john@doe.org"}} errors={}>
```

### TODO

- [x] Refactor `StepProcessor` to use `Step` objects
- [x] make it work with 1 level deep schemas
- [x] make it work with 2+ level deep nested schemas

Closes #209 