### PR TITLE
Unexpected keys errors

### DIFF
--- a/config/errors.yml
+++ b/config/errors.yml
@@ -3,6 +3,8 @@ en:
     or: "or"
 
     errors:
+      unexpected_key: "is not allowed"
+
       array?: "must be an array"
 
       empty?: "must be empty"

--- a/lib/dry/schema/config.rb
+++ b/lib/dry/schema/config.rb
@@ -51,6 +51,15 @@ module Dry
         setting(:default_locale, nil)
       end
 
+      # @!method validate_keys
+      #
+      # On/off switch for key validator
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      setting(:validate_keys, false)
+
       # @api private
       def respond_to_missing?(meth, include_private = false)
         super || config.respond_to?(meth, include_private)

--- a/lib/dry/schema/constants.rb
+++ b/lib/dry/schema/constants.rb
@@ -15,7 +15,13 @@ module Dry
     DOT = '.'
 
     # core processor steps in the default execution order
-    STEPS_IN_ORDER = %i[key_coercer filter_schema value_coercer rule_applier].freeze
+    STEPS_IN_ORDER = %i[
+      key_validator
+      key_coercer
+      filter_schema
+      value_coercer
+      rule_applier
+    ].freeze
 
     # Path to the default set of localized messages bundled within the gem
     DEFAULT_MESSAGES_PATH = Pathname(__dir__).join('../../../config/errors.yml').realpath.freeze

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -201,6 +201,7 @@ module Dry
 
         result_steps = all_steps.inject { |result, steps| result.merge(steps) }
 
+        result_steps[:key_validator] = key_validator if config.validate_keys
         result_steps[:key_coercer] = key_coercer
         result_steps[:value_coercer] = value_coercer
         result_steps[:rule_applier] = rule_applier
@@ -405,6 +406,15 @@ module Dry
       # @api private
       def parent_filter_schemas
         parents.select(&:filter_rules?).map(&:filter_schema)
+      end
+
+      # Build a key validator
+      #
+      # @return [KeyValidator]
+      #
+      # @api private
+      def key_validator
+        KeyValidator.new(key_map: key_map + parent_key_map)
       end
 
       # Build a key coercer

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -14,6 +14,7 @@ require 'dry/schema/processor'
 require 'dry/schema/processor_steps'
 require 'dry/schema/key_map'
 require 'dry/schema/key_coercer'
+require 'dry/schema/key_validator'
 require 'dry/schema/value_coercer'
 require 'dry/schema/rule_applier'
 
@@ -197,7 +198,9 @@ module Dry
       # @api private
       def call
         all_steps = parents.map(&:steps) + [steps]
+
         result_steps = all_steps.inject { |result, steps| result.merge(steps) }
+
         result_steps[:key_coercer] = key_coercer
         result_steps[:value_coercer] = value_coercer
         result_steps[:rule_applier] = rule_applier

--- a/lib/dry/schema/key.rb
+++ b/lib/dry/schema/key.rb
@@ -65,6 +65,11 @@ module Dry
       end
 
       # @api private
+      def to_dot_notation
+        [name.to_s]
+      end
+
+      # @api private
       def new(**new_opts)
         self.class.new(id, name: name, coercer: coercer, **new_opts)
       end
@@ -119,6 +124,11 @@ module Dry
       end
 
       # @api private
+      def to_dot_notation
+        [name].product(members.flat_map(&:to_dot_notation)).map { |e| e.join(DOT) }
+      end
+
+      # @api private
       def dump
         { name => members.map(&:dump) }
       end
@@ -153,6 +163,11 @@ module Dry
       # @api private
       def stringified
         new(name: name.to_s, member: member.stringified)
+      end
+
+      # @api private
+      def to_dot_notation
+        [:"#{name}[]", *member.to_dot_notation].join(DOT)
       end
 
       # @api private

--- a/lib/dry/schema/key_coercer.rb
+++ b/lib/dry/schema/key_coercer.rb
@@ -32,8 +32,8 @@ module Dry
       end
 
       # @api private
-      def call(source)
-        key_map.write(source.to_h)
+      def call(result)
+        key_map.write(result.to_h)
       end
       alias_method :[], :call
     end

--- a/lib/dry/schema/key_map.rb
+++ b/lib/dry/schema/key_map.rb
@@ -100,6 +100,11 @@ module Dry
         self.class.new(map(&:stringified))
       end
 
+      # @api private
+      def to_dot_notation
+        @to_dot_notation ||= map(&:to_dot_notation).flatten
+      end
+
       # Iterate over keys
       #
       # @api public

--- a/lib/dry/schema/key_validator.rb
+++ b/lib/dry/schema/key_validator.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'dry/initializer'
+require 'dry/schema/constants'
+
+module Dry
+  module Schema
+    # @api private
+    class KeyValidator
+      extend Dry::Initializer
+
+      INDEX_REGEX = /\[\d+\]/
+      DIGIT_REGEX = /\A\d+\z/
+      BRACKETS = '[]'
+
+      # @api private
+      option :key_map
+
+      # @api private
+      def call(result)
+        input = result.to_h
+
+        input_paths = key_paths(input)
+        key_paths = key_map.to_dot_notation
+
+        input_paths.each do |path|
+          error_path =
+            if path[INDEX_REGEX]
+              key = path.gsub(INDEX_REGEX, BRACKETS)
+
+              unless key_paths.include?(key)
+                arr = path.gsub(INDEX_REGEX) { |m| ".#{m[1]}" }
+                arr.split(DOT).map { |s| DIGIT_REGEX.match?(s) ? s.to_i : s.to_sym }
+              end
+            elsif !key_paths.include?(path)
+              path
+            end
+
+          next unless error_path
+
+          result.add_error([:unexpected_key, [error_path, input]])
+        end
+
+        result
+      end
+
+      private
+
+      # @api private
+      def key_paths(hash)
+        hash.flat_map { |key, _|
+          case (value = hash[key])
+          when Hash
+            [key].product(key_paths(hash[key])).map { |keys| keys.join(DOT) }
+          when Array
+            value.flat_map.with_index { |el, idx|
+              key_paths(el).map { |path| ["#{key}[#{idx}]", *path].join(DOT) }
+            }
+          else
+            key.to_s
+          end
+        }
+      end
+    end
+  end
+end

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -101,6 +101,20 @@ module Dry
       end
 
       # @api private
+      def visit_unexpected_key(node, opts)
+        path, input = node
+
+        msg = messages.translate('errors.unexpected_key')
+
+        Message.new(
+          path: path,
+          text: msg[:text],
+          predicate: nil,
+          input: input
+        )
+      end
+
+      # @api private
       def visit_or(node, opts)
         left, right = node.map { |n| visit(n, opts) }
         Message::Or[left, right, or_translator]

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -84,7 +84,7 @@ module Dry
       #
       # @api public
       def call(input)
-        Result.new(input, message_compiler: message_compiler) do |result|
+        Result.new(input, input: input, message_compiler: message_compiler) do |result|
           steps.call(result)
         end
       end

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -176,6 +176,13 @@ module Dry
         end
       end
 
+      # Add a new error AST node
+      #
+      # @api private
+      def add_error(node)
+        result_ast << node
+      end
+
       private
 
       # A list of failure ASTs produced by rule result objects

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Schema, 'unexpected keys' do
+  subject(:schema) do
+    Dry::Schema.define do
+      config.validate_keys = true
+
+      required(:name).filled(:string)
+
+      required(:address).hash do
+        required(:city).filled(:string)
+        required(:zipcode).filled(:string)
+      end
+
+      required(:roles).array(:hash) do
+        required(:name).filled(:string)
+      end
+    end
+  end
+
+  it 'adds error messages about unexpected keys' do
+    input = {
+      foo: 'unexpected',
+      name: 'Jane',
+      address: { bar: 'unexpected', city: 'NYC', zipcode: '1234' },
+      roles: [{ name: 'admin' }, { name: 'editor', foo: 'unexpected' }]
+    }
+
+    expect(schema.(input).errors.to_h)
+      .to eql(
+        foo: ['is not allowed'],
+        address: { bar: ['is not allowed'] },
+        roles: { 1 => { foo: ['is not allowed'] } }
+      )
+  end
+end

--- a/spec/unit/dry/schema/key_map_spec.rb
+++ b/spec/unit/dry/schema/key_map_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe Dry::Schema::KeyMap do
       end
     end
 
+    describe '#to_dot_notation' do
+      it 'returns an array with dot-notation strings' do
+        expect(key_map.to_dot_notation).to eql(['id', 'name', 'email'])
+      end
+    end
+
     describe '#+' do
       let(:other) { Dry::Schema::KeyMap.new([:age, :address]) }
       let(:keys) { %i[id name] }
@@ -99,6 +105,13 @@ RSpec.describe Dry::Schema::KeyMap do
       end
     end
 
+    describe '#to_dot_notation' do
+      it 'returns an array with dot-notation strings' do
+        expect(key_map.to_dot_notation)
+          .to eql(['id', 'name', 'contact.email', 'contact.phone'])
+      end
+    end
+
     describe '#inspect' do
       it 'returns a string representation' do
         expect(key_map.inspect).to eql(<<-STR.strip)
@@ -118,7 +131,8 @@ RSpec.describe Dry::Schema::KeyMap do
         key_map.each { |key| result << key }
 
         expect(result).to eql(
-          [Dry::Schema::Key[:title], Dry::Schema::Key::Array[:tags, member: Dry::Schema::KeyMap[:name]]]
+          [Dry::Schema::Key[:title],
+           Dry::Schema::Key::Array[:tags, member: Dry::Schema::KeyMap[:name]]]
         )
       end
     end
@@ -135,6 +149,13 @@ RSpec.describe Dry::Schema::KeyMap do
         key_map.stringified.each { |key| key.read(hash) { |value| result << value } }
 
         expect(result).to eql(['Bohemian Rhapsody', [{ 'name' => 'queen' }, { 'name' => 'classic' }]])
+      end
+    end
+
+    describe '#to_dot_notation' do
+      it 'returns an array with dot-notation strings' do
+        expect(key_map.to_dot_notation)
+          .to eql(['title', 'tags[].name'])
       end
     end
 


### PR DESCRIPTION
This adds a new processor step called `:key_validator` which validates if there are no unexpected keys. This works with both nested hashes and arrays with hashes.

```ruby
require 'dry/schema'

UserSchema = Dry::Schema.Params do
  config.validate_keys = true

  required(:name).filled(:string)

  required(:address).hash do
    required(:city).filled(:string)
    required(:zipcode).filled(:string)
  end

  required(:roles).array(:hash) do
    required(:name).filled(:string)
  end
end

input = {
  foo: 'unexpected',
  name: 'Jane',
  address: { bar: 'unexpected', city: 'NYC', zipcode: '1234' },
  roles: [{ name: 'admin' }, { name: 'editor', foo: 'unexpected' }]
}

UserSchema.(input).errors.to_h
# {
#  :foo=>["is not allowed"],
#  :address=>{:bar=>["is not allowed"]},
#  :roles=>{1=>{:foo=>["is not allowed"]}}
# }
```

Closes #35 

[changelog]

added: "You can now validate keys by setting `config.validate_keys = true". When enabled, schemas will provide error messages about unexpected keys in the input (issue #35 closed via #260) (@solnic)"
