### PR TITLE
Raise ArgumentError if DSL parent configs differ

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -68,7 +68,7 @@ module Dry
       option :parent, Types::Coercible::Array, default: -> { EMPTY_ARRAY.dup }, as: :parents
 
       # @return [Config] Configuration object exposed via `#configure` method
-      option :config, optional: true, default: proc { (parent || Schema).config.dup }
+      option :config, optional: true, default: proc { default_config }
 
       # @return [ProcessorSteps] Steps for the processor
       option :steps, default: proc { ProcessorSteps.new }
@@ -448,6 +448,18 @@ module Dry
       # @api private
       def parent_key_map
         parents.reduce([]) { |key_map, parent| parent.key_map + key_map }
+      end
+
+      # @api private
+      def default_config
+        parents.each_cons(2) do |left, right|
+          unless left.config == right.config
+            raise ArgumentError,
+                  "Parent configs differ, left=#{left.inspect}, right=#{right.inspect}"
+          end
+        end
+
+        (parent || Schema).config.dup
       end
     end
   end

--- a/spec/unit/dry/schema/dsl_spec.rb
+++ b/spec/unit/dry/schema/dsl_spec.rb
@@ -57,5 +57,24 @@ RSpec.describe Dry::Schema::DSL do
       Dry::Schema.config.messages.namespace = replacement_namespace
       expect(dsl.config.messages.namespace).not_to eq(replacement_namespace)
     end
+
+    it 'raises an ArgumentError if the parent configs differ' do
+      parent = [namespace, namespace, replacement_namespace, namespace].map do |namespace|
+        config = Dry::Schema::Config.new.tap { |c| c.messages.namespace = namespace }
+        Dry::Schema::DSL.new(config: config)
+      end
+
+      expect { Dry::Schema::DSL.new(parent: parent) }
+        .to raise_error(ArgumentError, /Parent configs differ/)
+    end
+
+    it 'does not raise an error if the parent configs are the same' do
+      parent = Array.new(4) do
+        config = Dry::Schema::Config.new.tap { |c| c.messages.namespace = namespace }
+        Dry::Schema::DSL.new(config: config)
+      end
+
+      expect { Dry::Schema::DSL.new(parent: parent) }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
I initally tried removing configuration inheritance from DSL, but this led to some awkward behaviors. For instance, it seems natural to inherit configuration from one parent, but changing that behavior only when multiple parents are given would be confusing. Rather than go down that route and rocking the boat too much, I added a quick transitive equality check for all parent configs.

[changelog]

changed: "Raise ArgumentError in DSL if parent DSL configs differ (@robhanlon22)"