### PR TITLE
Add :info extension

### DIFF
--- a/lib/dry/schema/extensions.rb
+++ b/lib/dry/schema/extensions.rb
@@ -11,3 +11,7 @@ end
 Dry::Schema.register_extension(:struct) do
   require 'dry/schema/extensions/struct'
 end
+
+Dry::Schema.register_extension(:info) do
+  require 'dry/schema/extensions/info'
+end

--- a/lib/dry/schema/extensions/info.rb
+++ b/lib/dry/schema/extensions/info.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'dry/schema/extensions/info/schema_compiler'
+
+module Dry
+  module Schema
+    # Info extension
+    #
+    # @api public
+    module Info
+      module SchemaMethods
+        # Return information about keys and types
+        #
+        # @return [Hash<Symbol=>Hash>]
+        #
+        # @api public
+        def info
+          compiler = SchemaCompiler.new
+          compiler.call(to_ast)
+          compiler.to_h
+        end
+      end
+    end
+
+    Processor.include(Info::SchemaMethods)
+  end
+end

--- a/lib/dry/schema/extensions/info/schema_compiler.rb
+++ b/lib/dry/schema/extensions/info/schema_compiler.rb
@@ -1,0 +1,103 @@
+require 'dry/schema/constants'
+
+module Dry
+  module Schema
+    # @api private
+    module Info
+      # @api private
+      class SchemaCompiler
+        PREDICATE_TO_TYPE = {
+          array?: 'array',
+          bool?: 'bool',
+          date?: 'date',
+          date_time?: 'date_time',
+          decimal?: 'float',
+          float?: 'float',
+          hash?: 'hash',
+          int?: 'integer',
+          nil?: 'nil',
+          str?: 'string',
+          time?: 'time'
+        }.freeze
+
+        # @api private
+        attr_reader :keys
+
+        # @api private
+        def initialize
+          @keys = EMPTY_HASH.dup
+        end
+
+        # @api private
+        def to_h
+          { keys: keys }
+        end
+
+        # @api private
+        def call(ast)
+          visit(ast)
+        end
+
+        # @api private
+        def visit(node, opts = EMPTY_HASH)
+          meth, rest = node
+          public_send(:"visit_#{meth}", rest, opts)
+        end
+
+        # @api private
+        def visit_set(node, opts = EMPTY_HASH)
+          target = (key = opts[:key]) ? self.class.new : self
+
+          node.map { |child| target.visit(child, opts) }
+
+          return unless key
+
+          target_info = opts[:member] ? { member: target.to_h } : target.to_h
+          type = opts[:member] ? 'array' : 'hash'
+
+          keys.update(key => { **keys[key], type: type, **target_info })
+        end
+
+        # @api private
+        def visit_and(node, opts = EMPTY_HASH)
+          left, right = node
+
+          visit(left, opts)
+          visit(right, opts)
+        end
+
+        # @api private
+        def visit_implication(node, opts = EMPTY_HASH)
+          node.each do |el|
+            visit(el, opts.merge(required: false))
+          end
+        end
+
+        # @api private
+        def visit_each(node, opts = EMPTY_HASH)
+          visit(node, opts.merge(member: true))
+        end
+
+        # @api private
+        def visit_key(node, opts = EMPTY_HASH)
+          name, rest = node
+          visit(rest, opts.merge(key: name, required: true))
+        end
+
+        # @api private
+        def visit_predicate(node, opts = EMPTY_HASH)
+          name, rest = node
+
+          key = opts[:key]
+
+          if name.equal?(:key?)
+            keys[rest[0][1]] = { required: opts.fetch(:required, true) }
+          else
+            type = PREDICATE_TO_TYPE[name]
+            keys[key][:type] = type if type
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/info/schema_spec.rb
+++ b/spec/extensions/info/schema_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Schema::JSON, '#info' do
+  before do
+    Dry::Schema.load_extensions(:info)
+  end
+
+  subject(:schema) do
+    Dry::Schema.JSON do
+      required(:email).filled(:string)
+      optional(:age).filled(:integer)
+
+      required(:roles).array(:hash) do
+        required(:name).filled(:string)
+        optional(:desc).filled(:string)
+      end
+
+      optional(:address).hash do
+        required(:street).filled(:string)
+        required(:zipcode).filled(:string)
+        required(:city).filled(:string)
+        optional(:phone).filled(:string)
+      end
+    end
+  end
+
+  let(:info) do
+    {
+      keys: {
+        email: {
+          required: true,
+          type: 'string'
+        },
+        age: {
+          required: false,
+          type: 'integer'
+        },
+        roles: {
+          required: true,
+          type: 'array',
+          member: {
+            keys: {
+              name: {
+                required: true,
+                type: 'string'
+              },
+              desc: {
+                required: false,
+                type: 'string'
+              }
+            }
+          }
+        },
+        address: {
+          required: false,
+          type: 'hash',
+          keys: {
+            street: {
+              required: true,
+              type: 'string'
+            },
+            zipcode: {
+              required: true,
+              type: 'string'
+            },
+            city: {
+              required: true,
+              type: 'string'
+            },
+            phone: {
+              required: false,
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  end
+
+  it 'returns info hash' do
+    expect(schema.info).to eql(info)
+  end
+
+  describe 'inferring types' do
+    {
+      array: 'array',
+      bool: 'bool',
+      date: 'date',
+      date_time: 'date_time',
+      decimal: 'float',
+      float: 'float',
+      hash: 'hash',
+      integer: 'integer',
+      nil: 'nil',
+      string: 'string',
+      time: 'time'
+    }.each do |type_spec, type_name|
+      it "infers '#{type_name}' from '#{type_spec}'" do
+        expect(Dry::Schema.define { required(:key).value(type_spec) }.info).to eql(
+          keys: { key: { required: true, type: type_name } }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `:info` extension which adds `#info` method to all schema types which produces a hash with key and type information.

```ruby
require 'dry/schema'

Dry::Schema.load_extensions(:info)

UserSchema = Dry::Schema.JSON do
  required(:email).filled(:string)
  optional(:age).filled(:integer)
  optional(:address).hash do
    required(:street).filled(:string)
    required(:zipcode).filled(:string)
    required(:city).filled(:string)
  end
end

UserSchema.info
# {
#   :keys=> {
#     :email=>{
#       :required=>true,
#       :type=>"string"
#     },
#     :age=>{
#       :required=>false,
#       :type=>"integer"
#      },
#     :address=>{
#       :type=>"hash",
#       :required=>false,
#       :keys=>{
#         :street=>{
#           :required=>true,
#           :type=>"string"
#         },
#         :zipcode=>{
#           :required=>true,
#           :type=>"string"
#         },
#         :city=>{
#           :required=>true,
#           :type=>"string"
#         }
#       }
#     }
#   }
# }
```

### TODO

- [x] add support for all type predicates
- [x] add support for `[:each, [... ]]` rule

Closes #36 

[changelog]

added: "`:info` extension which adds `#info` method to your schemas which produces a simple hash providing information about keys and types (issue #36 closed via #262) (@solnic)"