### PR TITLE
Fix setting type in nested schemas when a custom type was used

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -176,7 +176,7 @@ module Dry
       def key(name, macro:, &block)
         raise ArgumentError, "Key +#{name}+ is not a symbol" unless name.is_a?(::Symbol)
 
-        set_type(name, Types::Any)
+        set_type(name, Types::Any.meta(default: true))
 
         macro = macro.new(
           name: name,
@@ -311,6 +311,15 @@ module Dry
         meta = { required: false, maybe: type.optional? }
 
         types[name] = type.meta(meta)
+      end
+
+      # Check if a custom type was set under provided key name
+      #
+      # @return [Bool]
+      #
+      # @api private
+      def custom_type?(name)
+        !types[name].meta[:default].equal?(true)
       end
 
       # Resolve type object from the provided spec

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -177,6 +177,11 @@ module Dry
           self
         end
 
+        # @api private
+        def custom_type?
+          schema_dsl.custom_type?(name)
+        end
+
         private
 
         # @api private

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -14,6 +14,8 @@ module Dry
         def call(*predicates, **opts, &block)
           schema = predicates.detect { |predicate| predicate.is_a?(Processor) }
 
+          type_spec = opts[:type_spec]
+
           if schema
             current_type = schema_dsl.types[name]
 
@@ -26,7 +28,7 @@ module Dry
 
             import_steps(schema)
 
-            type(updated_type)
+            type(updated_type) unless custom_type? && !current_type.respond_to?(:of)
           end
 
           trace_opts = opts.reject { |key, _| key == :type_spec || key == :type_rule }
@@ -36,8 +38,6 @@ module Dry
             trace.append(new(chain: false).instance_exec(&block)) if block
           else
             trace.evaluate(*predicates, **trace_opts)
-
-            type_spec = opts[:type_spec]
 
             if block && type_spec.equal?(:hash)
               hash(&block)

--- a/spec/integration/schema/type_spec.rb
+++ b/spec/integration/schema/type_spec.rb
@@ -297,5 +297,34 @@ RSpec.describe Dry::Schema, 'types specs' do
         end
       end
     end
+
+    context 'when default type is overridden in a nested schema' do
+      subject(:schema) do
+        Dry::Schema.define do
+          required(:person).type(Test::ToHash).schema(Test::PersonSchema)
+        end
+      end
+
+      before do
+        Test::ToHash = Types::Nominal::Any.constructor(&:to_h)
+
+        Test::Person = Class.new do
+          def to_h
+            { name: 'Luke', age: 21 }
+          end
+        end
+
+        Test::PersonSchema = Dry::Schema.define do
+          required(:name).filled(:string)
+          required(:age).value(:integer, gt?: 18)
+        end
+      end
+
+      it 'respects the overridden type' do
+        person = Test::Person.new
+
+        expect(schema.(person: person)).to be_success
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #174 

[changelog]

fixed: "Custom type is respected when defining nested schemas (issue #174 closed via #263) (@solnic)"