### PR TITLE
Fix dot notation when key is an array with multi-key hashes

### DIFF
--- a/lib/dry/schema/key.rb
+++ b/lib/dry/schema/key.rb
@@ -167,7 +167,7 @@ module Dry
 
       # @api private
       def to_dot_notation
-        [:"#{name}[]", *member.to_dot_notation].join(DOT)
+        [:"#{name}[]"].product(member.to_dot_notation).map { |el| el.join(DOT) }
       end
 
       # @api private

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Dry::Schema, "unexpected keys" do
 
       required(:roles).array(:hash) do
         required(:name).filled(:string)
+        required(:expires_at).value(:date)
       end
     end
   end
@@ -23,7 +24,10 @@ RSpec.describe Dry::Schema, "unexpected keys" do
       foo: "unexpected",
       name: "Jane",
       address: {bar: "unexpected", city: "NYC", zipcode: "1234"},
-      roles: [{name: "admin"}, {name: "editor", foo: "unexpected"}]
+      roles: [
+        {name: "admin", expires_at: Date.today},
+        {name: "editor", foo: "unexpected", expires_at: Date.today}
+      ]
     }
 
     expect(schema.(input).errors.to_h)

--- a/spec/unit/dry/schema/key_map_spec.rb
+++ b/spec/unit/dry/schema/key_map_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Dry::Schema::KeyMap do
   end
 
   context "with a nested array" do
-    let(:keys) { [:title, [:tags, [:name]]] }
+    let(:keys) { [:title, [:tags, [:name, :count]]] }
 
     describe "#each" do
       it "yields each key and nested key map" do
@@ -132,7 +132,7 @@ RSpec.describe Dry::Schema::KeyMap do
 
         expect(result).to eql(
           [Dry::Schema::Key[:title],
-           Dry::Schema::Key::Array[:tags, member: Dry::Schema::KeyMap[:name]]]
+           Dry::Schema::Key::Array[:tags, member: Dry::Schema::KeyMap[:name, :count]]]
         )
       end
     end
@@ -143,26 +143,32 @@ RSpec.describe Dry::Schema::KeyMap do
 
         hash = {
           "title" => "Bohemian Rhapsody",
-          "tags" => [{"name" => "queen"}, {"name" => "classic"}]
+          "tags" => [
+            {"name" => "queen", "count" => 312},
+            {"name" => "classic", "count" => 423}
+          ]
         }
 
         key_map.stringified.each { |key| key.read(hash) { |value| result << value } }
 
-        expect(result).to eql(["Bohemian Rhapsody", [{"name" => "queen"}, {"name" => "classic"}]])
+        expect(result).to eql(
+          ["Bohemian Rhapsody",
+           [{"name" => "queen", "count" => 312}, {"name" => "classic", "count" => 423}]]
+          )
       end
     end
 
     describe "#to_dot_notation" do
       it "returns an array with dot-notation strings" do
         expect(key_map.to_dot_notation)
-          .to eql(["title", "tags[].name"])
+          .to eql(["title", "tags[].name", "tags[].count"])
       end
     end
 
     describe "#inspect" do
       it "returns a string representation" do
         expect(key_map.inspect).to eql(<<-STR.strip)
-          #<Dry::Schema::KeyMap[:title, [:tags, [:name]]]>
+          #<Dry::Schema::KeyMap[:title, [:tags, [:name, :count]]]>
         STR
       end
     end


### PR DESCRIPTION
Refs #260 