### PR TITLE
Make type specs mandatory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc
 .vscode
 pkg/
 .byebug_history
+spec/examples.txt

--- a/docsite/source/advanced/filtering.html.md
+++ b/docsite/source/advanced/filtering.html.md
@@ -10,7 +10,7 @@ Here's a common example - your system supports only one specific date format, an
 
 ```ruby
 schema = Dry::Schema.Params do
-  required(:email).filled
+  required(:email).filled(:string)
   required(:birthday).filter(format?: /\d{4}-\d{2}-\d{2}/).value(:date)
 end
 

--- a/docsite/source/basics/built-in-predicates.html.md
+++ b/docsite/source/basics/built-in-predicates.html.md
@@ -449,7 +449,7 @@ Checks that a value is included in a given array.
 describe 'included_in?' do
   let(:schema) do
     Dry::Schema.Params do
-      required(:sample).value(included_in?: [1,3,5])
+      required(:sample).value(:integer, included_in?: [1, 3, 5])
     end
   end
 

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -3,7 +3,7 @@
 require "dry-schema"
 
 schema = Dry::Schema.define do
-  required(:email).filled
+  required(:email).filled(:string)
 
   required(:age).filled(:int?, gt?: 18)
 end

--- a/examples/json.rb
+++ b/examples/json.rb
@@ -4,7 +4,7 @@ require "json"
 require "dry-schema"
 
 schema = Dry::Schema.JSON do
-  required(:email).filled
+  required(:email).filled(:string)
 
   required(:age).filled(:integer, gt?: 18)
 end

--- a/examples/params.rb
+++ b/examples/params.rb
@@ -3,7 +3,7 @@
 require "dry-schema"
 
 schema = Dry::Schema.Params do
-  required(:email).filled
+  required(:email).filled(:string)
 
   required(:age).filled(:integer, gt?: 18)
 end

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -146,8 +146,8 @@ module Dry
       # @return [Macros::Required]
       #
       # @api public
-      def required(name, &block)
-        key(name, macro: Macros::Required, &block)
+      def required(name)
+        key(name, macro: Macros::Required)
       end
 
       # Define an optional key
@@ -162,8 +162,8 @@ module Dry
       # @return [Macros::Optional]
       #
       # @api public
-      def optional(name, &block)
-        key(name, macro: Macros::Optional, &block)
+      def optional(name)
+        key(name, macro: Macros::Optional)
       end
 
       # A generic method for defining keys
@@ -174,7 +174,7 @@ module Dry
       # @return [Macros::Key]
       #
       # @api public
-      def key(name, macro:, &block)
+      def key(name, macro:)
         raise ArgumentError, "Key +#{name}+ is not a symbol" unless name.is_a?(::Symbol)
 
         set_type(name, Types::Any.meta(default: true))
@@ -186,7 +186,6 @@ module Dry
           filter_schema_dsl: filter_schema_dsl
         )
 
-        macro.value(&block) if block
         macros << macro
         macro
       end

--- a/lib/dry/schema/macros/array.rb
+++ b/lib/dry/schema/macros/array.rb
@@ -10,32 +10,30 @@ module Dry
       # @api private
       class Array < DSL
         # @api private
-        def value(*args, **opts, &block)
+        def value(*predicates, type_spec:, type_rule:, **opts, &block)
           type(:array)
 
-          extract_type_spec(*args, set_type: false) do |*predicates, type_spec:, type_rule:|
-            type(schema_dsl.array[type_spec]) if type_spec
+          type(schema_dsl.array[type_spec]) if type_spec
 
-            is_hash_block = type_spec.equal?(:hash)
+          is_hash_block = type_spec.equal?(:hash)
 
-            if predicates.any? || opts.any? || !is_hash_block
-              super(
-                *predicates, type_spec: type_spec, type_rule: type_rule, **opts,
-                &(is_hash_block ? nil : block)
-              )
-            end
+          if predicates.any? || opts.any? || !is_hash_block
+            super(
+              *predicates, type_spec: type_spec, type_rule: type_rule, **opts,
+              &(is_hash_block ? nil : block)
+            )
+          end
 
-            is_op = args.size.equal?(2) && args[1].is_a?(Logic::Operations::Abstract)
+          is_op = predicates.size.equal?(2) && predicates[1].is_a?(Logic::Operations::Abstract)
 
-            if is_hash_block && !is_op
-              hash(&block)
-            elsif is_op
-              hash = Value.new(schema_dsl: schema_dsl.new, name: name).hash(args[1])
+          if is_hash_block && !is_op
+            hash(&block)
+          elsif is_op
+            hash = Value.new(schema_dsl: schema_dsl.new, name: name).hash(args[1])
 
-              trace.captures.concat(hash.trace.captures)
+            trace.captures.concat(hash.trace.captures)
 
-              type(schema_dsl.types[name].of(hash.schema_dsl.types[name]))
-            end
+            type(schema_dsl.types[name].of(hash.schema_dsl.types[name]))
           end
 
           self

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -26,8 +26,8 @@ module Dry
         # @return [Macros::Key]
         #
         # @api public
-        def filter(*args, &block)
-          (filter_schema_dsl[name] || filter_schema_dsl.optional(name)).value(*args, &block)
+        def filter(type_spec, *args, &block)
+          (filter_schema_dsl[name] || filter_schema_dsl.optional(name)).value(type_spec, *args, &block)
           self
         end
         ruby2_keywords(:filter) if respond_to?(:ruby2_keywords, true)
@@ -53,8 +53,8 @@ module Dry
         # @see Macros::DSL#value
         #
         # @api public
-        def value(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+        def value(type_spec, *args, **opts, &block)
+          extract_type_spec(type_spec, *args) do |*predicates, type_spec:, type_rule:|
             super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
           end
         end
@@ -69,8 +69,8 @@ module Dry
         # @return [Macros::Key]
         #
         # @api public
-        def filled(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+        def filled(type_spec, *args, **opts, &block)
+          extract_type_spec(type_spec, *args) do |*predicates, type_spec:, type_rule:|
             super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
           end
         end
@@ -85,11 +85,27 @@ module Dry
         # @return [Macros::Key]
         #
         # @api public
-        def maybe(*args, **opts, &block)
-          extract_type_spec(*args, nullable: true) do |*predicates, type_spec:, type_rule:|
+        def maybe(type_spec, *args, **opts, &block)
+          extract_type_spec(type_spec, *args, nullable: true) do |*predicates, type_spec:, type_rule:|
             append_macro(Macros::Maybe) do |macro|
               macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
             end
+          end
+        end
+
+        # Set type specification and predicates for a maybe value
+        #
+        # @example
+        #   required(:name).maybe(:string)
+        #
+        # @see Macros::Key#value
+        #
+        # @return [Macros::Key]
+        #
+        # @api public
+        def array(type_spec, *args, **opts, &block)
+          extract_type_spec(type_spec, *args) do |*predicates, type_spec:, type_rule:|
+            super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
           end
         end
 

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -91,7 +91,7 @@ module Dry
       alias_method :[], :call
 
       # @api public
-      def xor(other)
+      def xor(_other)
         raise NotImplementedError, "composing schemas using `xor` operator is not supported yet"
       end
       alias_method :^, :xor

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Dry::Schema::Result do
   before { Dry::Schema.load_extensions(:monads) }
 
-  let(:schema) { Dry::Schema.define { required(:name).filled(:str?, size?: 2..4) } }
+  let(:schema) { Dry::Schema.define { required(:name).filled(:string, size?: 2..4) } }
 
   let(:result) { schema.(input) }
 

--- a/spec/integration/custom_error_messages_spec.rb
+++ b/spec/integration/custom_error_messages_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Dry::Schema do
           config.messages.load_paths << SPEC_ROOT.join("fixtures/locales/en.yml")
         end
 
-        required(:email).value(:filled?)
+        required(:email).value(:string, :filled?)
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe Dry::Schema do
             config.messages.backend = :i18n
           end
 
-          required(:email).value(:filled?)
+          required(:email).value(:string, :filled?)
         end
       end
 
@@ -54,7 +54,7 @@ RSpec.describe Dry::Schema do
 
       subject(:schema) do
         Dry::Schema.define do
-          required(:email).value(:filled?)
+          required(:email).value(:string, :filled?)
         end
       end
 

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Validation hints" do
   context "with yaml messages" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:age).maybe(:int?, gt?: 18)
+        required(:age).maybe(:integer, gt?: 18)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe "Validation hints" do
       Dry::Schema.define do
         config.messages.backend = :i18n
 
-        required(:age).maybe(:int?, gt?: 18)
+        required(:age).maybe(:integer, gt?: 18)
       end
     end
 
@@ -42,8 +42,8 @@ RSpec.describe "Validation hints" do
   context "when type expectation is specified" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:email).filled
-        required(:name).filled(:str?, size?: 5..25)
+        required(:email).filled(:string)
+        required(:name).filled(:string, size?: 5..25)
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe "Validation hints" do
   context "when predicate failed and there is a corresponding hint generated" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:age).value(lt?: 23)
+        required(:age).value(:integer, lt?: 23)
       end
     end
 
@@ -70,10 +70,10 @@ RSpec.describe "Validation hints" do
   context "with a nested schema with same rule names" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:code).filled(:str?, eql?: "foo")
+        required(:code).filled(:string, eql?: "foo")
 
         required(:nested).hash do
-          required(:code).filled(:str?, eql?: "bar")
+          required(:code).filled(:string, eql?: "bar")
         end
       end
     end
@@ -104,7 +104,7 @@ RSpec.describe "Validation hints" do
   context "with an each rule" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:nums).each(:int?, gt?: 0)
+        required(:nums).each(:integer, gt?: 0)
       end
     end
 
@@ -121,7 +121,7 @@ RSpec.describe "Validation hints" do
   context "with a format? predicate" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:name).value(size?: 2, format?: /xy/)
+        required(:name).value(:string, size?: 2, format?: /xy/)
       end
     end
 
@@ -150,7 +150,7 @@ RSpec.describe "Validation hints" do
       Dry::Schema.define do
         configure { |c| c.messages.load_paths << SPEC_ROOT.join("fixtures/messages.yml") }
 
-        required(:pill).filled(eql?: "blue")
+        required(:pill).filled(:string, eql?: "blue")
       end
     end
 
@@ -161,7 +161,7 @@ RSpec.describe "Validation hints" do
     end
 
     it "provides a correct hint" do
-      expect(schema.(pill: nil).messages).to eql(
+      expect(schema.(pill: "").messages).to eql(
         pill: ["must be filled", "must be equal to blue"]
       )
     end
@@ -171,7 +171,7 @@ RSpec.describe "Validation hints" do
     subject(:schema) do
       Dry::Schema.define do
         required(:attributes).hash do
-          optional(:text) { int? | nil? }
+          optional(:text).value([:integer, :nil])
         end
       end
     end

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
           config.messages.load_paths = %w[en pl]
             .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
-          required(:email).value(:filled?)
+          required(:email).value(:string, :filled?)
         end
       end
 
@@ -32,7 +32,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
           config.messages.load_paths = %w[en pl]
             .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
-          required(:email).value(:filled?)
+          required(:email).value(:string, :filled?)
         end
       end
 
@@ -54,7 +54,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
           config.messages.load_paths = %w[en pl]
             .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
-          required(:email).value(:filled?)
+          required(:email).value(:string, :filled?)
         end
       end
 

--- a/spec/integration/messages/namespaced_spec.rb
+++ b/spec/integration/messages/namespaced_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Namespaced messages" do
         config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
         config.messages.namespace = :comment
 
-        required(:comment_body).filled
+        required(:comment_body).filled(:string)
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe "Namespaced messages" do
         config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
         config.messages.namespace = :post
 
-        required(:post_body).filled
+        required(:post_body).filled(:string)
         required(:comment).hash(::Test::CommentSchema)
       end
     end

--- a/spec/integration/optional_keys_spec.rb
+++ b/spec/integration/optional_keys_spec.rb
@@ -4,15 +4,13 @@ RSpec.describe Dry::Schema do
   describe "defining schema with optional keys and value rules" do
     subject(:schema) do
       Dry::Schema.define do
-        optional(:email).value(:filled?)
+        optional(:email).value(:string, :filled?)
 
         required(:address).hash do
-          required(:city).value(:filled?)
-          required(:street).value(:filled?)
+          required(:city).value(:string, :filled?)
+          required(:street).value(:string, :filled?)
 
-          optional(:phone_number) do
-            nil? | str?
-          end
+          optional(:phone_number).value([:nil, :string])
         end
       end
     end
@@ -32,7 +30,7 @@ RSpec.describe Dry::Schema do
     subject(:schema) do
       Dry::Schema.define do
         required(:name).filled(:string)
-        optional(:login)
+        optional(:login).filled(:any)
       end
     end
 
@@ -47,10 +45,8 @@ RSpec.describe Dry::Schema do
   describe "defining schema with optional key that can be an array with hashes" do
     subject(:schema) do
       Dry::Schema.define do
-        optional(:contacts).array do
-          hash do
-            required(:name).filled
-          end
+        optional(:contacts).array(:hash) do
+          required(:name).filled(:string)
         end
       end
     end
@@ -61,7 +57,7 @@ RSpec.describe Dry::Schema do
     end
 
     it "produces correct errors when array has an invalid element" do
-      expect(schema.(contacts: [{name: nil}]).errors)
+      expect(schema.(contacts: [{name: ""}]).errors)
         .to eql(contacts: {0 => {name: ["must be filled"]}})
     end
   end

--- a/spec/integration/params/defining_base_form_spec.rb
+++ b/spec/integration/params/defining_base_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Defining base schema class" do
   let(:parent) do
     Dry::Schema.Params do
       required(:email).filled(:string)
-      required(:age).filter(:filled?).value(:integer)
+      required(:age).filter(:any, :filled?).value(:integer)
     end
   end
 

--- a/spec/integration/params/multiple_parents_schema_spec.rb
+++ b/spec/integration/params/multiple_parents_schema_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Defining a schema with multiple parents" do
 
   let(:parent2) do
     Dry::Schema.Params do
-      required(:age).filter(:filled?).value(:integer)
+      required(:age).filter(:any, :filled?).value(:integer)
 
       after(:rule_applier) do |result|
         result.to_h[:bar] = "bar"

--- a/spec/integration/params/predicates/array_spec.rb
+++ b/spec/integration/params/predicates/array_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Predicates: Array" do
   context "with required" do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo).value(array[:integer]).each(:int?)
+        required(:foo).value(array[:integer]).each(:integer)
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe "Predicates: Array" do
   context "with optional" do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo).value(array[:integer]).each(:int?)
+        optional(:foo).value(array[:integer]).each(:integer)
       end
     end
 
@@ -157,7 +157,7 @@ RSpec.describe "Predicates: Array" do
     context "with required" do
       subject(:schema) do
         Dry::Schema.Params do
-          required(:foo).value(array[:integer]).each(:int?)
+          required(:foo).value(array[:integer]).each(:integer)
         end
       end
 
@@ -205,7 +205,7 @@ RSpec.describe "Predicates: Array" do
     context "with optional" do
       subject(:schema) do
         Dry::Schema.Params do
-          optional(:foo).value(array[:integer]).each(:int?)
+          optional(:foo).value(array[:integer]).each(:integer)
         end
       end
 
@@ -302,7 +302,7 @@ RSpec.describe "Predicates: Array" do
   context "with block-based syntax" do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo) { array? { each(:int?) } }
+        required(:foo).value(:array) { each(:integer) }
       end
     end
 

--- a/spec/integration/params/predicates/bytesize/fixed_spec.rb
+++ b/spec/integration/params/predicates/bytesize/fixed_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Predicates: Size" do
         context "with filled" do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo).filled(bytesize?: 3)
+              required(:foo).filled(:string, bytesize?: 3)
             end
           end
 
@@ -167,7 +167,7 @@ RSpec.describe "Predicates: Size" do
             let(:input) { {} }
 
             it "is not successful" do
-              expect(result).to be_failing ["is missing", "must be 3 bytes long"]
+              expect(result).to be_failing ["is missing", "must be a string", "must be 3 bytes long"]
             end
           end
 
@@ -199,7 +199,7 @@ RSpec.describe "Predicates: Size" do
         context "with maybe" do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo).maybe(bytesize?: 3)
+              required(:foo).maybe(:string, bytesize?: 3)
             end
           end
 
@@ -215,7 +215,7 @@ RSpec.describe "Predicates: Size" do
             let(:input) { {} }
 
             it "is not successful" do
-              expect(result).to be_failing ["is missing", "must be 3 bytes long"]
+              expect(result).to be_failing ["is missing", "must be a string", "must be 3 bytes long"]
             end
           end
 
@@ -231,7 +231,7 @@ RSpec.describe "Predicates: Size" do
             let(:input) { {"foo" => ""} }
 
             it "is successful" do
-              expect(result).to be_failing ["must be 3 bytes long"]
+              expect(result).to be_successful
             end
           end
 
@@ -297,7 +297,7 @@ RSpec.describe "Predicates: Size" do
         context "with filled" do
           subject(:schema) do
             Dry::Schema.Params do
-              optional(:foo).filled(bytesize?: 3)
+              optional(:foo).filled(:string, bytesize?: 3)
             end
           end
 

--- a/spec/integration/params/predicates/bytesize/range_spec.rb
+++ b/spec/integration/params/predicates/bytesize/range_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Predicates: Bytesize" do
     context "with required" do
       subject(:schema) do
         Dry::Schema.Params do
-          required(:foo) { bytesize?(2..3) }
+          required(:foo).value(:string) { bytesize?(2..3) }
         end
       end
 
@@ -21,15 +21,15 @@ RSpec.describe "Predicates: Bytesize" do
         let(:input) { {} }
 
         it "is not successful" do
-          expect(result).to be_failing ["is missing", "must be within 2 - 3 bytes long"]
+          expect(result).to be_failing ["is missing", "must be a string", "must be within 2 - 3 bytes long"]
         end
       end
 
       context "with nil input" do
         let(:input) { {"foo" => nil} }
 
-        it "is raises error" do
-          expect { result }.to raise_error(NoMethodError)
+        it "is not successful" do
+          expect(result).to be_failing ["must be a string", "must be within 2 - 3 bytes long"]
         end
       end
 
@@ -54,7 +54,7 @@ RSpec.describe "Predicates: Bytesize" do
     context "with optional" do
       subject(:schema) do
         Dry::Schema.Params do
-          optional(:foo) { bytesize?(2..3) }
+          optional(:foo).value(:string) { bytesize?(2..3) }
         end
       end
 
@@ -78,7 +78,7 @@ RSpec.describe "Predicates: Bytesize" do
         let(:input) { {"foo" => nil} }
 
         it "is raises error" do
-          expect { result }.to raise_error(NoMethodError)
+          expect(result).to be_failing ["must be a string", "must be within 2 - 3 bytes long"]
         end
       end
 
@@ -105,7 +105,7 @@ RSpec.describe "Predicates: Bytesize" do
         context "with value" do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo).value(bytesize?: 2..3)
+              required(:foo).value(:string, bytesize?: 2..3)
             end
           end
 
@@ -121,15 +121,15 @@ RSpec.describe "Predicates: Bytesize" do
             let(:input) { {} }
 
             it "is not successful" do
-              expect(result).to be_failing ["is missing", "must be within 2 - 3 bytes long"]
+              expect(result).to be_failing ["is missing", "must be a string", "must be within 2 - 3 bytes long"]
             end
           end
 
           context "with nil input" do
             let(:input) { {"foo" => nil} }
 
-            it "is raises error" do
-              expect { result }.to raise_error(NoMethodError)
+            it "is not successful" do
+              expect(result).to be_failing ["must be a string", "must be within 2 - 3 bytes long"]
             end
           end
 
@@ -153,7 +153,7 @@ RSpec.describe "Predicates: Bytesize" do
         context "with filled" do
           subject(:schema) do
             Dry::Schema.Params do
-              required(:foo).filled(bytesize?: 2..3)
+              required(:foo).filled(:string, bytesize?: 2..3)
             end
           end
 
@@ -169,7 +169,7 @@ RSpec.describe "Predicates: Bytesize" do
             let(:input) { {} }
 
             it "is not successful" do
-              expect(result).to be_failing ["is missing", "must be within 2 - 3 bytes long"]
+              expect(result).to be_failing ["is missing", "must be a string", "must be within 2 - 3 bytes long"]
             end
           end
 
@@ -251,7 +251,7 @@ RSpec.describe "Predicates: Bytesize" do
         context "with value" do
           subject(:schema) do
             Dry::Schema.Params do
-              optional(:foo).value(bytesize?: 2..3)
+              optional(:foo).value(:string, bytesize?: 2..3)
             end
           end
 
@@ -274,8 +274,8 @@ RSpec.describe "Predicates: Bytesize" do
           context "with nil input" do
             let(:input) { {"foo" => nil} }
 
-            it "is raises error" do
-              expect { result }.to raise_error(NoMethodError)
+            it "is successful" do
+              expect(result).to be_failing ["must be a string", "must be within 2 - 3 bytes long"]
             end
           end
 

--- a/spec/integration/params/predicates/excludes_spec.rb
+++ b/spec/integration/params/predicates/excludes_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Predicates: Excludes" do
   context "with required" do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo).value(array[:integer]).each(:int?).value(excludes?: 1)
+        required(:foo).value(array[:integer]).each(:integer).value(excludes?: 1)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "Predicates: Excludes" do
   context "with optional" do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo).value(array[:integer]).each(:int?).value(excludes?: 1)
+        optional(:foo).value(array[:integer]).each(:integer).value(excludes?: 1)
       end
     end
 

--- a/spec/integration/params/predicates/format_spec.rb
+++ b/spec/integration/params/predicates/format_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "Predicates: Format" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).filled(:str?, format?: /bar/)
+            required(:foo).filled(:string, format?: /bar/)
           end
         end
 
@@ -344,7 +344,7 @@ RSpec.describe "Predicates: Format" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).filled(:str?, format?: /bar/)
+            optional(:foo).filled(:string, format?: /bar/)
           end
         end
 

--- a/spec/integration/params/predicates/gt_spec.rb
+++ b/spec/integration/params/predicates/gt_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Predicates: Gt" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).maybe(:integer).maybe(:int?, gt?: 23)
+            required(:foo).maybe(:integer).maybe(:integer, gt?: 23)
           end
         end
 
@@ -456,7 +456,7 @@ RSpec.describe "Predicates: Gt" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).maybe(:integer).maybe(:int?, gt?: 23)
+            optional(:foo).maybe(:integer).maybe(:integer, gt?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/gteq_spec.rb
+++ b/spec/integration/params/predicates/gteq_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).maybe(:integer).maybe(:int?, gteq?: 23)
+            required(:foo).maybe(:integer).maybe(:integer, gteq?: 23)
           end
         end
 
@@ -456,7 +456,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).maybe(:integer).maybe(:int?, gteq?: 23)
+            optional(:foo).maybe(:integer).maybe(:integer, gteq?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/includes_spec.rb
+++ b/spec/integration/params/predicates/includes_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Predicates: Includes" do
   context "with required" do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo).value(array[:integer]).each(:int?).value(includes?: 1)
+        required(:foo).value(array[:integer]).each(:integer).value(includes?: 1)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "Predicates: Includes" do
   context "with optional" do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo).value(array[:integer]).each(:int?).value(includes?: 1)
+        optional(:foo).value(array[:integer]).each(:integer).value(includes?: 1)
       end
     end
 

--- a/spec/integration/params/predicates/lt_spec.rb
+++ b/spec/integration/params/predicates/lt_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Predicates: Lt" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).maybe(:integer).maybe(:int?, lt?: 23)
+            required(:foo).maybe(:integer).maybe(:integer, lt?: 23)
           end
         end
 
@@ -456,7 +456,7 @@ RSpec.describe "Predicates: Lt" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).maybe(:integer).maybe(:int?, lt?: 23)
+            optional(:foo).maybe(:integer).maybe(:integer, lt?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/lteq_spec.rb
+++ b/spec/integration/params/predicates/lteq_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe "Predicates: Lteq" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).maybe(:integer).maybe(:int?, lteq?: 23)
+            optional(:foo).maybe(:integer).maybe(:integer, lteq?: 23)
           end
         end
 

--- a/spec/integration/params/predicates/odd_spec.rb
+++ b/spec/integration/params/predicates/odd_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe "Predicates: Odd" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).maybe(:integer).maybe(:int?, :odd?)
+            required(:foo).maybe(:integer).maybe(:integer, :odd?)
           end
         end
 

--- a/spec/integration/schema/defining_base_schema_spec.rb
+++ b/spec/integration/schema/defining_base_schema_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Defining base schema class" do
   subject(:schema) do
     Dry::Schema.define(parent: parent) do
-      required(:email).filled
+      required(:email).filled(:string)
       required(:age).filled
     end
   end

--- a/spec/integration/schema/json_spec.rb
+++ b/spec/integration/schema/json_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Dry::Schema, "defining a schema with json coercion" do
     Dry::Schema.JSON do
       required(:email).value(:string).filled
 
-      required(:age).maybe(:integer).maybe(:int?, gt?: 18)
+      required(:age).maybe(:integer).maybe(:integer, gt?: 18)
 
       required(:address).value(:hash).hash do
         required(:city).value(:string).filled
@@ -17,7 +17,7 @@ RSpec.describe Dry::Schema, "defining a schema with json coercion" do
         end
       end
 
-      optional(:phone_number).maybe(:int?, gt?: 0)
+      optional(:phone_number).maybe(:integer, gt?: 0)
     end
   end
 

--- a/spec/integration/schema/macros/filled_spec.rb
+++ b/spec/integration/schema/macros/filled_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Macros #filled" do
   describe "with no args" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:email).filled
+        required(:email).filled(:string)
       end
     end
 

--- a/spec/integration/schema/or_spec.rb
+++ b/spec/integration/schema/or_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Dry::Schema, "OR messages" do
   context "with a predicate and an each operation" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo) { str? | value(:array?).each(:int?) }
+        required(:foo) { str? | value(:array?).each(:integer) }
       end
     end
 

--- a/spec/integration/schema/predicates/array_spec.rb
+++ b/spec/integration/schema/predicates/array_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Predicates: Array" do
   context "with required" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo).value(:array?).each(:int?)
+        required(:foo).value(:array?).each(:integer)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe "Predicates: Array" do
   context "with optional" do
     subject(:schema) do
       Dry::Schema.define do
-        optional(:foo).value(:array?).each(:int?)
+        optional(:foo).value(:array?).each(:integer)
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe "Predicates: Array" do
   context "with block-based syntax" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:foo) { array? { each(:int?) } }
+        required(:foo) { array? { each(:integer) } }
       end
     end
 

--- a/spec/integration/schema/predicates/even_spec.rb
+++ b/spec/integration/schema/predicates/even_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Predicates: Even" do
       context "with value" do
         subject(:schema) do
           Dry::Schema.define do
-            required(:foo).value(:even?)
+            required(:foo).value(:integer, :even?)
           end
         end
 
@@ -174,7 +174,7 @@ RSpec.describe "Predicates: Even" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.define do
-            required(:foo).filled(:even?)
+            required(:foo).filled(:integer, :even?)
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe "Predicates: Even" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.define do
-            required(:foo).maybe(:even?)
+            required(:foo).maybe(:integer, :even?)
           end
         end
 
@@ -288,7 +288,7 @@ RSpec.describe "Predicates: Even" do
       context "with value" do
         subject(:schema) do
           Dry::Schema.define do
-            optional(:foo).value(:even?)
+            optional(:foo).value(:integer, :even?)
           end
         end
 
@@ -344,7 +344,7 @@ RSpec.describe "Predicates: Even" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.define do
-            optional(:foo).filled(:even?)
+            optional(:foo).filled(:integer, :even?)
           end
         end
 
@@ -400,7 +400,7 @@ RSpec.describe "Predicates: Even" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.define do
-            optional(:foo).maybe(:even?)
+            optional(:foo).maybe(:integer, :even?)
           end
         end
 

--- a/spec/integration/schema/predicates/gteq_spec.rb
+++ b/spec/integration/schema/predicates/gteq_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with value" do
         subject(:schema) do
           Dry::Schema.define do
-            required(:foo).value(gteq?: 23)
+            required(:foo).value(:integer, gteq?: 23)
           end
         end
 
@@ -198,7 +198,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.define do
-            required(:foo).filled(gteq?: 23)
+            required(:foo).filled(:integer, gteq?: 23)
           end
         end
 
@@ -262,7 +262,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.define do
-            required(:foo).maybe(gteq?: 23)
+            required(:foo).maybe(:integer, gteq?: 23)
           end
         end
 
@@ -328,7 +328,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with value" do
         subject(:schema) do
           Dry::Schema.define do
-            optional(:foo).value(gteq?: 23)
+            optional(:foo).value(:integer, gteq?: 23)
           end
         end
 
@@ -392,7 +392,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.define do
-            optional(:foo).filled(gteq?: 23)
+            optional(:foo).filled(:integer, gteq?: 23)
           end
         end
 
@@ -456,7 +456,7 @@ RSpec.describe "Predicates: Gteq" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.define do
-            optional(:foo).maybe(gteq?: 23)
+            optional(:foo).maybe(:integer, gteq?: 23)
           end
         end
 

--- a/spec/integration/schema/predicates/included_in/array_spec.rb
+++ b/spec/integration/schema/predicates/included_in/array_spec.rb
@@ -119,7 +119,7 @@ RSpec.context "Predicates: Included In" do
         context "with value" do
           subject(:schema) do
             Dry::Schema.define do
-              required(:foo).value(included_in?: [1, 3, 5])
+              required(:foo).value(:integer, included_in?: [1, 3, 5])
             end
           end
 
@@ -175,7 +175,7 @@ RSpec.context "Predicates: Included In" do
         context "with filled" do
           subject(:schema) do
             Dry::Schema.define do
-              required(:foo).filled(included_in?: [1, 3, 5])
+              required(:foo).filled(:integer, included_in?: [1, 3, 5])
             end
           end
 
@@ -231,7 +231,7 @@ RSpec.context "Predicates: Included In" do
         context "with maybe" do
           subject(:schema) do
             Dry::Schema.define do
-              required(:foo).maybe(included_in?: [1, 3, 5])
+              required(:foo).maybe(:integer, included_in?: [1, 3, 5])
             end
           end
 
@@ -289,7 +289,7 @@ RSpec.context "Predicates: Included In" do
         context "with value" do
           subject(:schema) do
             Dry::Schema.define do
-              optional(:foo).value(included_in?: [1, 3, 5])
+              optional(:foo).value(:integer, included_in?: [1, 3, 5])
             end
           end
 
@@ -345,7 +345,7 @@ RSpec.context "Predicates: Included In" do
         context "with filled" do
           subject(:schema) do
             Dry::Schema.define do
-              optional(:foo).filled(included_in?: [1, 3, 5])
+              optional(:foo).filled(:integer, included_in?: [1, 3, 5])
             end
           end
 
@@ -401,7 +401,7 @@ RSpec.context "Predicates: Included In" do
         context "with maybe" do
           subject(:schema) do
             Dry::Schema.define do
-              optional(:foo).maybe(included_in?: [1, 3, 5])
+              optional(:foo).maybe(:integer, included_in?: [1, 3, 5])
             end
           end
 

--- a/spec/integration/schema/type_spec.rb
+++ b/spec/integration/schema/type_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Dry::Schema, "types specs" do
   context "sum type spec with rules" do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:age).type([:nil, :integer]).maybe(:int?, gt?: 18)
+        required(:age).type([:nil, :integer]).maybe(:integer, gt?: 18)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,7 @@ RSpec.configure do |config|
   end
   config.disable_monkey_patching!
   config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = "spec/examples.txt"
 
   config.include PredicatesIntegration
   config.include Coercions

--- a/spec/unit/dry/schema/key_map_spec.rb
+++ b/spec/unit/dry/schema/key_map_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Dry::Schema::KeyMap do
         expect(result).to eql(
           ["Bohemian Rhapsody",
            [{"name" => "queen", "count" => 312}, {"name" => "classic", "count" => 423}]]
-          )
+        )
       end
     end
 


### PR DESCRIPTION
Resolves #272 

- [ ] Fix all of the specs
- [ ] Fix Macros::Array#value to correctly coerce hash types
- [ ] Should filter be usable without a type spec?