### PR TITLE
Avoid YARD warnings: name param

### DIFF
--- a/lib/dry/schema/compiler.rb
+++ b/lib/dry/schema/compiler.rb
@@ -30,7 +30,7 @@ module Dry
       # used as nested schemas
       #
       # @param [Array] node
-      # @param [Hash] opts
+      # @param [Hash] _opts Unused
       #
       # @return [NamespacedRule]
       #

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -43,7 +43,7 @@ module Dry
 
       # Return a new result scoped to a specific path
       #
-      # @param [Symbol, Array, Path]
+      # @param path [Symbol, Array, Path]
       #
       # @return [Result]
       #


### PR DESCRIPTION
This PR avoids YARD warnings during documentation generation.