### PR TITLE
Correct expands to example for using `.hash``

### DIFF
--- a/docsite/source/basics/macros.html.md
+++ b/docsite/source/basics/macros.html.md
@@ -56,7 +56,7 @@ Use it when a value is expected to be a hash:
 
 ```ruby
 Dry::Schema.Params do
-  # expands to: `required(:tags) { hash? & filled? & schema { required(:name).filled(:string) } } }`
+  # expands to: `required(:tags) { hash? & schema { required(:name).filled(:string) } } }`
   required(:tags).hash do
     required(:name).filled(:string)
   end


### PR DESCRIPTION
Using hash does not require `filled?` https://github.com/dry-rb/dry-schema/blob/master/lib/dry/schema/macros/hash.rb#L30
For example this `schema.call tags: {}` is successful