### PR TITLE
Remove circular `require`

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -2,7 +2,6 @@
 
 require "dry/initializer"
 
-require "dry/schema"
 require "dry/schema/constants"
 require "dry/schema/path"
 require "dry/schema/config"

--- a/lib/dry/schema/rule_applier.rb
+++ b/lib/dry/schema/rule_applier.rb
@@ -2,7 +2,6 @@
 
 require "dry/initializer"
 
-require "dry/schema"
 require "dry/schema/constants"
 require "dry/schema/config"
 require "dry/schema/result"


### PR DESCRIPTION
Per #279, there are two circular `require` statements. This commits
resolves them by removing the loading of the top-level package in
package components.

Closes #279 