### PR TITLE
Fix key validation when working with arrays

### DIFF
--- a/lib/dry/schema/key_validator.rb
+++ b/lib/dry/schema/key_validator.rb
@@ -53,6 +53,7 @@ module Dry
           when Hash
             [key].product(key_paths(hash[key])).map { |keys| keys.join(DOT) }
           when Array
+            return [] unless value.all? Hash
             value.flat_map.with_index { |el, idx|
               key_paths(el).map { |path| ["#{key}[#{idx}]", *path].join(DOT) }
             }

--- a/lib/dry/schema/key_validator.rb
+++ b/lib/dry/schema/key_validator.rb
@@ -53,7 +53,7 @@ module Dry
           when Hash
             [key].product(key_paths(hash[key])).map { |keys| keys.join(DOT) }
           when Array
-            return [] unless value.all? Hash
+            return [] unless value.all? { |obj| obj.is_a? Hash }
             value.flat_map.with_index { |el, idx|
               key_paths(el).map { |path| ["#{key}[#{idx}]", *path].join(DOT) }
             }

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Dry::Schema, "unexpected keys" do
         config.validate_keys = true
 
         required(:name).filled(:string)
-        optional(:tags).array(:str?)
+        optional(:tags).array(:string)
       end
     end
 

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -37,4 +37,25 @@ RSpec.describe Dry::Schema, "unexpected keys" do
         roles: {1 => {foo: ["is not allowed"]}}
       )
   end
+
+  context "with an array validation" do
+    subject(:schema) do
+      Dry::Schema.define do
+        config.validate_keys = true
+
+        required(:name).filled(:string)
+        optional(:tags).array(:str?)
+      end
+    end
+
+    it "adds error messages" do
+      input = { name: "", tags: ["red", 123] }
+      expect(schema.(input).errors.to_h)
+        .to eql(
+          name: ["must be filled"],
+          tags: {1=>["must be a string"]}
+        )
+    end
+
+  end
 end


### PR DESCRIPTION
Fixes #283.

When both requiring an array attribute and validating keys, dry-schema would throw a NoMethodError when validating keys.

This adds a check to guard against validating keys inside Arrays that just contain non-hash values.