### PR TITLE
Allow customization of whitespace character between words per locale

### DIFF
--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -29,6 +29,14 @@ module Dry
 
       EMPTY_OPTS = VisitorOpts.new
       EMPTY_MESSAGE_SET = MessageSet.new(EMPTY_ARRAY).freeze
+      FULL_MESSAGE_WHITESPACE = Hash.new(' ').merge(
+            ja: '',
+            zh: '',
+            bn: '',
+            th: '',
+            lo: '',
+            my: '',
+          )
 
       param :messages
 
@@ -203,7 +211,7 @@ module Dry
         return text if !text || !full
 
         rule = options[:path]
-        "#{messages.rule(rule, options) || rule} #{text}"
+        [messages.rule(rule, options) || rule, text].join(FULL_MESSAGE_WHITESPACE[template.options[:locale]])
       end
 
       # @api private

--- a/spec/fixtures/locales/ja.yml
+++ b/spec/fixtures/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  dry_schema:
+    rules:
+      email: "Eメール"
+    errors:
+      rules:
+        email:
+          filled?: "は必須入力です"

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
       subject(:schema) do
         Dry::Schema.define do
           config.messages.backend = :i18n
-          config.messages.load_paths = %w[en pl]
+          config.messages.load_paths = %w[en pl ja]
             .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
           required(:email).value(:filled?)
@@ -21,6 +21,10 @@ RSpec.describe Dry::Schema, "with localized messages" do
             email: ["Proszę podać adres email"]
           )
         end
+
+        it "returns localized error message with defined whitespace character when full option is set to true" do
+            expect(schema.(email: "").messages(locale: :ja, full: true)).to eql(email: ["Eメールは必須入力です"])
+        end
       end
     end
 
@@ -29,7 +33,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
         Dry::Schema.define do
           config.messages.backend = :i18n
           config.messages.namespace = :user
-          config.messages.load_paths = %w[en pl]
+          config.messages.load_paths = %w[en pl ja]
             .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
           required(:email).value(:filled?)
@@ -51,7 +55,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
           config.messages.backend = :i18n
           config.messages.namespace = :user
           config.messages.default_locale = :pl
-          config.messages.load_paths = %w[en pl]
+          config.messages.load_paths = %w[en pl ja]
             .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
 
           required(:email).value(:filled?)
@@ -63,6 +67,20 @@ RSpec.describe Dry::Schema, "with localized messages" do
           expect(schema.(email: "").errors(locale: :en)).to eql(email: ["Please provide your email"])
 
           expect(schema.(email: "").errors).to eql(email: ["Hej user! Dawaj ten email no!"])
+        end
+
+        it "returns localized error messages" do
+          schema = Dry::Schema.define do
+            config.messages.backend = :i18n
+            config.messages.namespace = :user
+            config.messages.default_locale = :ja
+            config.messages.load_paths = %w[en pl ja]
+                                             .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+
+            required(:email).value(:filled?)
+          end
+
+          expect(schema.(email: "").messages(full: true)).to eql(email: ["Eメールは必須入力です"])
         end
       end
     end

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
           expect(schema.(email: "").errors).to eql(email: ["Hej user! Dawaj ten email no!"])
         end
 
-        it "returns localized error messages with defined whitespace character when full option is set to true" do
+        it "returns localized error messages with defined whitespace character for 'full' option" do
           schema = Dry::Schema.define do
             config.messages.backend = :i18n
             config.messages.namespace = :user

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Dry::Schema, "with localized messages" do
           expect(schema.(email: "").errors).to eql(email: ["Hej user! Dawaj ten email no!"])
         end
 
-        it "returns localized error messages" do
+        it "returns localized error messages with defined whitespace character when full option is set to true" do
           schema = Dry::Schema.define do
             config.messages.backend = :i18n
             config.messages.namespace = :user


### PR DESCRIPTION
Resolves dry-rb/dry-schema#161

This allows to define the whitespace char between words in localized full error messages.