### PR TITLE
Allow unexpected keys to cause result failure

### DIFF
--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -121,7 +121,7 @@ module Dry
       #
       # @api public
       def success?
-        results.empty?
+        result_ast.empty?
       end
 
       # Check if the result is not successful

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe Dry::Schema, "unexpected keys" do
       )
   end
 
+  it "is treated as a failure when passed unexpected keys" do
+    input = {
+      foo: "unexpected",
+      name: "Jane",
+      ids: [1, 2, 3, 4],
+      address: {bar: "unexpected", city: "NYC", zipcode: "1234"},
+      roles: [
+        {name: "admin", expires_at: Date.today},
+        {name: "editor", foo: "unexpected", expires_at: Date.today}
+      ]
+    }
+
+    expect(schema.(input)).to be_failure
+  end
+
   context "with an array validation" do
     subject(:schema) do
       Dry::Schema.define do


### PR DESCRIPTION
The success of a schema result depended on `results` being empty. This used to be correct as any steps which failed would add to `results`.

However, since the addition of the `key_validator` this is no longer true. The `key_validator` adds errors directly to the `result_ast` (which is then used to generate error messages) but doesn't change the contents of `results`.

In order for unexpected keys to cause `.success?` to return `false` we simply need to check whether `result_ast` is empty, rather than `results`.

Fixes #297