### PR TITLE
Avoid creation of array in Info::SchemaCompiler.visit_set

### DIFF
--- a/lib/dry/schema/extensions/info/schema_compiler.rb
+++ b/lib/dry/schema/extensions/info/schema_compiler.rb
@@ -50,7 +50,7 @@ module Dry
         def visit_set(node, opts = EMPTY_HASH)
           target = (key = opts[:key]) ? self.class.new : self
 
-          node.map { |child| target.visit(child, opts) }
+          node.each { |child| target.visit(child, opts) }
 
           return unless key
 


### PR DESCRIPTION
The goal of `visit_set` is visit the nodes using their target, but while it does it also creates an array is not used on the method.