### PR TITLE
 Fix bug: non-nested maybe hashes have errors on `validate_keys = true`

### DIFF
--- a/lib/dry/schema/key_validator.rb
+++ b/lib/dry/schema/key_validator.rb
@@ -32,7 +32,7 @@ module Dry
                 arr = path.gsub(INDEX_REGEX) { |m| ".#{m[1]}" }
                 arr.split(DOT).map { |s| DIGIT_REGEX.match?(s) ? s.to_i : s.to_sym }
               end
-            elsif !key_paths.include?(path)
+            elsif key_paths.none? { |key_path| key_path.include?(path) }
               path
             end
 

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -92,5 +92,22 @@ RSpec.describe Dry::Schema, "unexpected keys" do
         expect(schema.(locations: [{ feedback_location: nil}]).errors.to_h).to eq({})
       end
     end
+
+    context "with a non-nested maybe hash validator" do
+      subject(:schema) do
+        Dry::Schema.define do
+          config.validate_keys = true
+
+          required(:feedback_location).maybe(:hash) do
+            required(:lat).filled(:float)
+            required(:lon).filled(:float)
+          end
+        end
+      end
+
+      it "doesn't add error messages when there are no unexpected keys" do
+        expect(schema.(feedback_location: nil).errors.to_h).to eq({})
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description
There is an issue whereby if we're validating keys on `maybe` hashes in non-nested strucutures the schema comes back with `is not allowed`:

```ruby
schema = Dry::Schema.Params do
  config.validate_keys = true

  required(:feedback_location).maybe(:hash) do
    required(:lat).filled(:float)
    required(:lon).filled(:float)
  end
end

schema.call({ feedback_location: nil }).errors
=> #<Dry::Schema::MessageSet messages=[#<Dry::Schema::Message text="is not allowed" path="feedback_location" predicate=nil input={:feedback_location=>nil}>] options={:failures=>true}>
```

This mitigates the error for checking the partial path similarly to what has been done for the nested structures here:
https://github.com/dry-rb/dry-schema/pull/309

### Context

Closes: https://github.com/dry-rb/dry-schema/issues/311

/cc @solnic