### PR TITLE
Fix sum type errors when using I18n backend

### DIFF
--- a/lib/dry/schema/message/or/single_path.rb
+++ b/lib/dry/schema/message/or/single_path.rb
@@ -38,7 +38,7 @@ module Dry
           #
           # @api public
           def dump
-            @dump ||= "#{left.dump} #{messages[:or][:text]} #{right.dump}"
+            @dump ||= "#{left.dump} #{messages[:or]} #{right.dump}"
           end
           alias_method :to_s, :dump
 

--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -131,7 +131,10 @@ module Dry
 
       # @api private
       def or_translator
-        @or_translator ||= proc { |k| messages.translate(k, **default_lookup_options) }
+        @or_translator ||= proc { |k|
+          message = messages.translate(k, **default_lookup_options)
+          message.is_a?(Hash) ? message[:text] : message
+        }
       end
 
       # @api private


### PR DESCRIPTION
Resolve issue with error handling of custom sum types. The error message code was hardcoded to expect the YAML backend, which was causing an error when the I18n backend was used.

Wasn’t sure if a spec should be included or where it should be added, but this covers the patch:

```ruby
# frozen_string_literal: true

RSpec.describe "Custom type errors" do
  let(:container_with_types) { Dry::Schema::TypeContainer.new }

  before do
    container_with_types.register(
      "params.string_or_integer",
      Types::Strict::String | Types::Strict::Decimal
    )

    stub_const "ContainerWithTypes", container_with_types
  end

  let(:klass) do
    class Test::CustomTypeSchema < Dry::Schema::Params
      define do
        config.types = ContainerWithTypes

        required(:age).filled(:string_or_integer)
      end
    end
  end

  let(:params) {
    {
      age: 4.5
    }
  }

  subject(:schema) { klass.new.call(params) }

  before do
    klass.definition.configure { |config| config.messages.backend = backend }
  end

  context 'with YAML backend' do
    let(:backend) { :yaml }

    it "provides a valid error message" do
      expect(subject.errors[:age])
        .to include 'must be a string or must be a decimal'
    end
  end

  context 'with I18n backend' do
    let(:backend) { :i18n }

    it "provides a valid error message" do
      expect(subject.errors[:age])
        .to include 'must be a string or must be a decimal'
    end
  end
end
```

Fixes #328.