### PR TITLE
Improve error message for attr? predicate

### DIFF
--- a/config/errors.yml
+++ b/config/errors.yml
@@ -67,7 +67,7 @@ en:
 
       key?: "is missing"
 
-      attr?: "is missing"
+      attr?: "must respond to %{name}"
 
       lt?: "must be less than %{num}"
 

--- a/spec/integration/schema/predicates/attr_spec.rb
+++ b/spec/integration/schema/predicates/attr_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Attr" do
+  context "with required" do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:foo) { attr?(:to_i) }
+      end
+    end
+
+    context "with valid input" do
+      let(:input) { {foo: 42} }
+
+      it "is successful" do
+        expect(result).to be_successful
+      end
+    end
+
+    context "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect(result).to be_failing ["is missing", "must respond to to_i"]
+      end
+    end
+
+    context "with input that does not respond to method" do
+      let(:input) { {foo: Object.new} }
+
+      it "is not successful" do
+        expect(result).to be_failing ["must respond to to_i"]
+      end
+    end
+  end
+
+  context "with optional" do
+    subject(:schema) do
+      Dry::Schema.define do
+        optional(:foo) { attr?(:to_i) }
+      end
+    end
+
+    context "with valid input" do
+      let(:input) { {foo: 42} }
+
+      it "is successful" do
+        expect(result).to be_successful
+      end
+    end
+
+    context "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect(result).to be_successful
+      end
+    end
+
+    context "with input that does not respond to method" do
+      let(:input) { {foo: Object.new} }
+
+      it "is not successful" do
+        expect(result).to be_failing ["must respond to to_i"]
+      end
+    end
+  end
+
+  context "as macro" do
+    context "with required" do
+      context "with value" do
+        subject(:schema) do
+          Dry::Schema.define do
+            required(:foo).value(attr?: :to_i)
+          end
+        end
+
+        context "with valid input" do
+          let(:input) { {foo: 42} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["is missing", "must respond to to_i"]
+          end
+        end
+
+        context "with input that does not respond to method" do
+          let(:input) { {foo: Object.new} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to to_i"]
+          end
+        end
+      end
+
+      context "with filled" do
+        subject(:schema) do
+          Dry::Schema.define do
+            required(:foo).filled(attr?: :to_i)
+          end
+        end
+
+        context "with valid input" do
+          let(:input) { {foo: 42} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["is missing", "must respond to to_i"]
+          end
+        end
+
+        context "with input that does not respond to method" do
+          let(:input) { {foo: Object.new} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to to_i"]
+          end
+        end
+      end
+
+      context "with maybe" do
+        subject(:schema) do
+          Dry::Schema.define do
+            required(:foo).maybe(attr?: :to_i)
+          end
+        end
+
+        context "with valid input" do
+          let(:input) { {foo: 42} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["is missing", "must respond to to_i"]
+          end
+        end
+
+        context "with input that does not respond to method" do
+          let(:input) { {foo: Object.new} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to to_i"]
+          end
+        end
+      end
+    end
+
+    context "with optional" do
+      context "with value" do
+        subject(:schema) do
+          Dry::Schema.define do
+            optional(:foo).value(attr?: :to_i)
+          end
+        end
+
+        context "with valid input" do
+          let(:input) { {foo: 42} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with input that does not respond to method" do
+          let(:input) { {foo: Object.new} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to to_i"]
+          end
+        end
+      end
+
+      context "with filled" do
+        subject(:schema) do
+          Dry::Schema.define do
+            optional(:foo).filled(attr?: :to_i)
+          end
+        end
+
+        context "with valid input" do
+          let(:input) { {foo: 42} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with input that does not respond to method" do
+          let(:input) { {foo: Object.new} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to to_i"]
+          end
+        end
+      end
+
+      context "with maybe" do
+        subject(:schema) do
+          Dry::Schema.define do
+            optional(:foo).maybe(attr?: :to_i)
+          end
+        end
+
+        context "with valid input" do
+          let(:input) { {foo: 42} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect(result).to be_successful
+          end
+        end
+
+        context "with input that does not respond to method" do
+          let(:input) { {foo: Object.new} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to to_i"]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes the error message for the `attr?` predicate from:

```ruby
"is missing"
```
 to:
```ruby
"must respond to %{name}"
```