### PR TITLE
Add error message to respond_to? predicate

### DIFF
--- a/config/errors.yml
+++ b/config/errors.yml
@@ -87,6 +87,8 @@ en:
 
       type?: "must be %{type}"
 
+      respond_to?: "must respond to %{method}"
+
       size?:
         arg:
           default: "size must be %{size}"

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -17,6 +17,7 @@ module Dry
 
         undef :eql?
         undef :nil?
+        undef :respond_to?
 
         # @!attribute [r] chain
         #   Indicate if the macro should append its rules to the provided trace

--- a/spec/integration/schema/predicates/respond_to_spec.rb
+++ b/spec/integration/schema/predicates/respond_to_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Predicates: Respond To' do
-  xcontext 'with required' do
+  context 'with required' do
     subject(:schema) do
       Dry::Schema.define { required(:foo) { respond_to?(:bar) } }
     end
@@ -47,7 +47,7 @@ RSpec.describe 'Predicates: Respond To' do
     end
   end
 
-  xcontext 'with optional' do
+  context 'with optional' do
     subject(:schema) do
       Dry::Schema.define { optional(:foo) { respond_to?(:bar) } }
     end

--- a/spec/integration/schema/predicates/respond_to_spec.rb
+++ b/spec/integration/schema/predicates/respond_to_spec.rb
@@ -1,0 +1,377 @@
+# frozen_string_literal: true
+
+RSpec.fdescribe 'Predicates: Respond To' do
+  xcontext 'with required' do
+    subject(:schema) do
+      Dry::Schema.define { required(:foo) { respond_to?(:bar) } }
+    end
+
+    context 'with valid input' do
+      let(:input) { { foo: double(bar: 23) } }
+
+      it 'is successful' do
+        expect(result).to be_successful
+      end
+    end
+
+    context 'with missing input' do
+      let(:input) { {} }
+
+      it 'is not successful' do
+        expect(result).to be_failing ['is missing', 'must respond to bar']
+      end
+    end
+
+    context 'with nil input' do
+      let(:input) { { foo: nil } }
+
+      it 'is not successful' do
+        expect(result).to be_failing ['must respond to bar']
+      end
+    end
+
+    context 'with blank input' do
+      let(:input) { { foo: '' } }
+
+      it 'is not successful' do
+        expect(result).to be_failing ['must respond to bar']
+      end
+    end
+
+    context 'with invalid input' do
+      let(:input) { { foo: double(baz: 23) } }
+
+      it 'is not successful' do
+        expect(result).to be_failing ['must respond to bar']
+      end
+    end
+  end
+
+  xcontext 'with optional' do
+    subject(:schema) do
+      Dry::Schema.define { optional(:foo) { respond_to?(:bar) } }
+    end
+
+    context 'with valid input' do
+      let(:input) { { foo: double(bar: 23) } }
+
+      it 'is successful' do
+        expect(result).to be_successful
+      end
+    end
+
+    context 'with missing input' do
+      let(:input) { {} }
+
+      it 'is successful' do
+        expect(result).to be_successful
+      end
+    end
+
+    context 'with nil input' do
+      let(:input) { { foo: nil } }
+
+      it 'is not successful' do
+        expect(result).to be_failing ['must respond to bar']
+      end
+    end
+
+    context 'with blank input' do
+      let(:input) { { foo: '' } }
+
+      it 'is not successful' do
+        expect(result).to be_failing ['must respond to bar']
+      end
+    end
+
+    context 'with invalid input' do
+      let(:input) { { foo: double(baz: 23) } }
+
+      it 'is not successful' do
+        expect(result).to be_failing ['must respond to bar']
+      end
+    end
+  end
+
+  context 'as macro' do
+    context 'with required' do
+      context 'with value' do
+        subject(:schema) do
+          Dry::Schema.define { required(:foo).value(respond_to?: :bar) }
+        end
+
+        context 'with valid input' do
+          let(:input) { { foo: double(bar: 23) } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with missing input' do
+          let(:input) { {} }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['is missing', 'must respond to bar']
+          end
+        end
+
+        context 'with nil input' do
+          let(:input) { { foo: nil } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+
+        context 'with blank input' do
+          let(:input) { { foo: '' } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+
+        context 'with invalid input' do
+          let(:input) { { foo: double(baz: 23) } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+      end
+
+      fcontext 'with filled' do
+        subject(:schema) do
+          Dry::Schema.define { required(:foo).filled(respond_to?: :bar) }
+        end
+
+        context 'with valid input' do
+          let(:input) { { foo: double(bar: 23) } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with missing input' do
+          let(:input) { {} }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['is missing', 'must respond to bar']
+          end
+        end
+
+        context 'with nil input' do
+          let(:input) { { foo: nil } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must be filled', 'must respond to bar']
+          end
+        end
+
+        context 'with blank input' do
+          let(:input) { { foo: '' } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must be filled', 'must respond to bar']
+          end
+        end
+
+        context 'with invalid input' do
+          let(:input) { { foo: double(baz: 23) } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+      end
+
+      context 'with maybe' do
+        subject(:schema) do
+          Dry::Schema.define { required(:foo).maybe(respond_to?: :bar) }
+        end
+
+        context 'with valid input' do
+          let(:input) { { foo: double(bar: 23) } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with missing input' do
+          let(:input) { {} }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['is missing', 'must respond to bar']
+          end
+        end
+
+        context 'with nil input' do
+          let(:input) { { foo: nil } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with blank input' do
+          let(:input) { { foo: '' } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+
+        context 'with invalid input' do
+          let(:input) { { foo: double(baz: 23) } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+      end
+    end
+
+    context 'with optional' do
+      context 'with value' do
+        subject(:schema) do
+          Dry::Schema.define { optional(:foo).value(respond_to?: :bar) }
+        end
+
+        context 'with valid input' do
+          let(:input) { { foo: double(bar: 23) } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with missing input' do
+          let(:input) { {} }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with nil input' do
+          let(:input) { { foo: nil } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+
+        context 'with blank input' do
+          let(:input) { { foo: '' } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+
+        context 'with invalid input' do
+          let(:input) { { foo: double(baz: 23) } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+      end
+
+      context 'with filled' do
+        subject(:schema) do
+          Dry::Schema.define { optional(:foo).filled(respond_to?: :bar) }
+        end
+
+        context 'with valid input' do
+          let(:input) { { foo: double(bar: 23) } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with missing input' do
+          let(:input) { {} }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with nil input' do
+          let(:input) { { foo: nil } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must be filled', 'must respond to bar']
+          end
+        end
+
+        context 'with blank input' do
+          let(:input) { { foo: '' } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must be filled', 'must respond to bar']
+          end
+        end
+
+        context 'with invalid input' do
+          let(:input) { { foo: double(baz: 23) } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+      end
+
+      context 'with maybe' do
+        subject(:schema) do
+          Dry::Schema.define { optional(:foo).maybe(respond_to?: :bar) }
+        end
+
+        context 'with valid input' do
+          let(:input) { { foo: double(bar: 23) } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with missing input' do
+          let(:input) { {} }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with nil input' do
+          let(:input) { { foo: nil } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with blank input' do
+          let(:input) { { foo: '' } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+
+        context 'with invalid input' do
+          let(:input) { { foo: double(baz: 23) } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must respond to bar']
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/schema/predicates/respond_to_spec.rb
+++ b/spec/integration/schema/predicates/respond_to_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.fdescribe 'Predicates: Respond To' do
+RSpec.describe 'Predicates: Respond To' do
   xcontext 'with required' do
     subject(:schema) do
       Dry::Schema.define { required(:foo) { respond_to?(:bar) } }

--- a/spec/integration/schema/predicates/respond_to_spec.rb
+++ b/spec/integration/schema/predicates/respond_to_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'Predicates: Respond To' do
         end
       end
 
-      fcontext 'with filled' do
+      context 'with filled' do
         subject(:schema) do
           Dry::Schema.define { required(:foo).filled(respond_to?: :bar) }
         end


### PR DESCRIPTION
This was not reported on https://discourse.dry-rb.org/, though I think it can be treated as "typo", thus just straight PR:

When using Types.Interface, error is not produced in the `Dry::Schema::Result`

Ex.

```
Dry::Schema.Params { required(:a).filled(Types.Interface(:inv)) }.call(a: 1)
=> #<Dry::Schema::Result:0x1680>
```

The reason behind that is because errors message compiler can't find translation:
```
Dry::Schema::MissingMessageError (Message template for :a under "" was not found. Searched in:)
"en.dry_schema.errors.rules.a.respond_to?.arg.default"
"en.dry_schema.errors.rules.a.respond_to?"
"en.dry_schema.errors.respond_to?.failure"
"en.dry_schema.errors.respond_to?.value.a"
"en.dry_schema.errors.respond_to?.value.default.arg.default"
"en.dry_schema.errors.respond_to?.value.default"
"en.dry_schema.errors.respond_to?.arg.default"
"en.dry_schema.errors.respond_to?"
```

Expected:
```
Dry::Schema.Params { required(:a).filled(Types.Interface(:inv)) }.call(a: 1)
=> #<Dry::Schema::Result{:a=>1} errors={:a=>["must respond to inv"]}>
```

Adding a translation to `respond_to?` fixes the above issue