### PR TITLE
Handle arrays of hashes where Array constructor coerces non-Hash input

### DIFF
--- a/lib/dry/schema/key.rb
+++ b/lib/dry/schema/key.rb
@@ -151,7 +151,11 @@ module Dry
       # @api private
       def write(source, target)
         read(source) { |value|
-          target[coerced_name] = value.is_a?(::Array) ? value.map { |el| member.write(el) } : value
+          target[coerced_name] = if value.is_a?(::Array)
+                                   value.map { |el| el.is_a?(::Hash) ? member.write(el) : el }
+                                 else
+                                   value
+                                 end
         }
       end
 


### PR DESCRIPTION
We're already skipping non-Hash values in `Key::Hash`, do the same in `Key::Array`.

Fixes #351 