### PR TITLE
Simplify `Dry::Schema::Path`

### DIFF
--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -71,24 +71,13 @@ module Dry
       end
 
       # @api private
-      def index(key)
-        keys.index(key)
-      end
-
-      # @api private
       def include?(other)
         keys[0, other.keys.length].eql?(other.keys)
       end
 
       # @api private
       def <=>(other)
-        raise ArgumentError, "Can't compare paths from different branches" unless same_root?(other)
-
-        return 0 if keys.eql?(other.keys)
-
-        res = key_matches(other).compact.reject { |value| value.equal?(false) }
-
-        res.size < count ? 1 : -1
+        keys.length <=> other.keys.length if include?(other) || other.include?(self)
       end
 
       # @api private
@@ -96,11 +85,6 @@ module Dry
         self.class.new(
           keys.take_while.with_index { |key, index| other.keys[index].eql?(key) }
         )
-      end
-
-      # @api private
-      def key_matches(other, meth = :map)
-        public_send(meth) { |key| (idx = other.index(key)) && keys[idx].equal?(key) }
       end
 
       # @api private

--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -93,12 +93,8 @@ module Dry
 
       # @api private
       def &(other)
-        unless same_root?(other)
-          raise ArgumentError, "#{other.inspect} doesn't have the same root #{inspect}"
-        end
-
         self.class.new(
-          key_matches(other, :select).compact.reject { |value| value.equal?(false) }
+          keys.take_while.with_index { |key, index| other.keys[index].eql?(key) }
         )
       end
 

--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -75,25 +75,9 @@ module Dry
         keys.index(key)
       end
 
-      def without_index
-        self.class.new(to_a[0..-2])
-      end
-
       # @api private
       def include?(other)
-        if !same_root?(other)
-          false
-        elsif index?
-          if other.index?
-            last.equal?(other.last)
-          else
-            without_index.include?(other)
-          end
-        elsif other.index? && key_matches(other, :select).size < 2
-          false
-        else
-          self >= other && !other.key_matches(self).include?(nil)
-        end
+        keys[0, other.keys.length].eql?(other.keys)
       end
 
       # @api private
@@ -131,11 +115,6 @@ module Dry
       # @api private
       def same_root?(other)
         root.equal?(other.root)
-      end
-
-      # @api private
-      def index?
-        last.is_a?(Integer)
       end
     end
   end

--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -60,24 +60,9 @@ module Dry
 
       # @api private
       def to_h(value = EMPTY_ARRAY.dup)
-        curr_idx = 0
-        last_idx = keys.size - 1
-        hash = EMPTY_HASH.dup
-        node = hash
+        value = [value] unless value.is_a?(Array)
 
-        while curr_idx <= last_idx
-          node =
-            node[keys[curr_idx]] =
-              if curr_idx == last_idx
-                value.is_a?(Array) ? value : [value]
-              else
-                EMPTY_HASH.dup
-              end
-
-          curr_idx += 1
-        end
-
-        hash
+        keys.reverse_each.reduce(value) { |result, key| {key => result} }
       end
 
       # @api private

--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -32,10 +32,10 @@ module Dry
           new(spec.split(DOT).map(&:to_sym))
         when Hash
           new(keys_from_hash(spec))
-        when Path
+        when self
           spec
         else
-          raise ArgumentError, "+spec+ must be either a Symbol, Array, Hash or a Path"
+          raise ArgumentError, "+spec+ must be either a Symbol, Array, Hash or a #{name}"
         end
       end
 

--- a/spec/integration/result/error_predicate_spec.rb
+++ b/spec/integration/result/error_predicate_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Dry::Schema::Result, "#error?" do
 
       it "raises error" do
         expect { result.error?(Object.new) }
-          .to raise_error(ArgumentError, "+spec+ must be either a Symbol, Array, Hash or a Path")
+          .to raise_error(ArgumentError, "+spec+ must be either a Symbol, Array, Hash or a Dry::Schema::Path")
       end
     end
 

--- a/spec/unit/dry/schema/path_spec.rb
+++ b/spec/unit/dry/schema/path_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe Dry::Schema::Path do
     end
   end
 
-  describe "#index" do
-    let(:segments) do
-      %i[foo bar 1 baz bar foo]
-    end
-
-    it "returns index for a given key" do
-      expect(path.index(:'1')).to be(2)
-      expect(path.index(:baz)).to be(3)
-    end
-  end
-
   describe "#include?" do
     let(:segments) do
       %i[foo bar 1 baz bar foo]

--- a/spec/unit/dry/schema/path_spec.rb
+++ b/spec/unit/dry/schema/path_spec.rb
@@ -91,10 +91,10 @@ RSpec.describe Dry::Schema::Path do
       expect(path & other).to eql(root)
     end
 
-    it "raises if other is not included in the source" do
+    it "returns empty path if other is not included in the source" do
       other = Dry::Schema::Path.new(%i[foo baz qux])
 
-      expect { path & other }.to raise_error(ArgumentError, /doesn't have the same root/)
+      expect(path & other).to eql(Dry::Schema::Path.new([]))
     end
   end
 end


### PR DESCRIPTION
First extract from https://github.com/dry-rb/dry-schema/pull/353.

master dry-v specs are passing locally, I don't see any changes in benchmarks.