### PR TITLE
Merge `Dry::Schema::Step::Scoped` into `Dry::Schema::Step`

### DIFF
--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -84,14 +84,14 @@ module Dry
       #
       # @api public
       def call(input)
-        Result.new(input, input: input, message_compiler: message_compiler) do |result|
+        Result.new(input.dup, message_compiler: message_compiler) do |result|
           steps.call(result)
         end
       end
       alias_method :[], :call
 
       # @api public
-      def xor(other)
+      def xor(_other)
         raise NotImplementedError, "composing schemas using `xor` operator is not supported yet"
       end
       alias_method :^, :xor

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -73,7 +73,7 @@ module Dry
 
       # @api private
       def replace(hash)
-        @output = hash
+        output.replace(hash)
         self
       end
 

--- a/lib/dry/schema/result.rb
+++ b/lib/dry/schema/result.rb
@@ -25,8 +25,10 @@ module Dry
       # @return [Hash]
       alias_method :to_h, :output
 
+      # A list of failure ASTs produced by rule result objects
+      #
       # @api private
-      param :results, default: -> { EMPTY_ARRAY.dup }
+      option :result_ast, default: -> { EMPTY_ARRAY.dup }
 
       # @api private
       option :message_compiler
@@ -57,7 +59,7 @@ module Dry
         self.class.new(
           output,
           message_compiler: message_compiler,
-          results: results,
+          result_ast: result_ast,
           **opts,
           &block
         )
@@ -77,7 +79,6 @@ module Dry
 
       # @api private
       def concat(other)
-        results.concat(other)
         result_ast.concat(other.map(&:to_ast))
         self
       end
@@ -181,15 +182,6 @@ module Dry
       # @api private
       def add_error(node)
         result_ast << node
-      end
-
-      private
-
-      # A list of failure ASTs produced by rule result objects
-      #
-      # @api private
-      def result_ast
-        @result_ast ||= results.map(&:to_ast)
       end
     end
   end

--- a/lib/dry/schema/step.rb
+++ b/lib/dry/schema/step.rb
@@ -7,6 +7,9 @@ module Dry
   module Schema
     # @api private
     class Step
+      EMPTY_PATH = Path.new([]).freeze
+      private_constant :EMPTY_PATH
+
       # @api private
       attr_reader :name
 
@@ -17,53 +20,34 @@ module Dry
       attr_reader :executor
 
       # @api private
-      class Scoped
-        # @api private
-        attr_reader :path
-
-        # @api private
-        attr_reader :step
-
-        # @api private
-        def initialize(path, step)
-          @path = Path[path]
-          @step = step
-        end
-
-        # @api private
-        def scoped(new_path)
-          self.class.new(Path[[*new_path, *path]], step)
-        end
-
-        # @api private
-        def call(result)
-          result.at(path) do |scoped_result|
-            output = step.(scoped_result).to_h
-            target = Array(path)[0..-2].reduce(result) { |a, e| a[e] }
-
-            target.update(path.last => output)
-          end
-        end
-      end
+      attr_reader :path
 
       # @api private
-      def initialize(type:, name:, executor:)
+      def initialize(type:, name:, executor:, path: EMPTY_PATH)
         @type = type
         @name = name
         @executor = executor
+        @path = path
         validate_name(name)
       end
 
       # @api private
       def call(result)
-        output = executor.(result)
-        result.replace(output) if output.is_a?(Hash)
+        scoped_result = path.equal?(EMPTY_PATH) ? result : result.at(path)
+
+        output = executor.(scoped_result)
+        scoped_result.replace(output) if output.is_a?(Hash)
         output
       end
 
       # @api private
-      def scoped(path)
-        Scoped.new(path, self)
+      def scoped(parent_path)
+        self.class.new(
+          type: type,
+          name: name,
+          executor: executor,
+          path: Path.new([*parent_path, *path])
+        )
       end
 
       private

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Dry::Schema::Result do
 
   let(:schema) { Dry::Schema.define { required(:name).filled(size?: 2..4) } }
 
+  context "with frozen input" do
+    let(:input) { {name: "Jane"}.freeze }
+
+    it "does not raise errors" do
+      expect { result }.not_to raise_error
+    end
+  end
+
   context "with valid input" do
     let(:input) { {name: "Jane"} }
 


### PR DESCRIPTION
Second extract from https://github.com/dry-rb/dry-schema/pull/353

It makes things more streamlined. And preparational commit:
```
   Drop `Dry::Schema::Result#results`
    
    It's unused, we're working only with result_ast and if value coercer
    is not run on the Result (will be the case in the next commit) — it's
    frozen after `.new`, so `@result_ast ||=` fails with `FrozenError` if
    we try to get `#errors`, for example
    
    Also fix the typo `param` -> `option`
```

Unfortunately can't invent not-noisy benchmark, so tested by this:
```ruby
VALID_INPUT = {
  name: "John",
  age: 20,
  email: "john@doe.com"
}.freeze

INVALID_INPUT = {
  name: :John,
  age: "17",
  email: nil
}.freeze

MESSAGE_COMPILER = PersonSchema.(VALID_INPUT.dup).message_compiler.freeze

def result(input)
  Dry::Schema::Result.method(:new).super_method.call(input.dup, message_compiler: MESSAGE_COMPILER)
end

key_map = Dry::Schema::KeyMap.new([[:name, :age, :email]])
coercer =  Dry::Schema::KeyCoercer.new(key_map, &:to_sym)
step = Dry::Schema::Step.new(executor: coercer, type: :core, name: :key_coercer)

Benchmark.ips do |x|
  x.config(stats: :bootstrap, confidence: 95)

  x.report("valid input") { step.(result(VALID_INPUT)) }
  x.report("invalid input") { step.(result(INVALID_INPUT)) }
  x.compare!
end
```
Before:
```
Warming up --------------------------------------
         valid input    11.959k i/100ms
       invalid input    12.077k i/100ms
Calculating -------------------------------------
         valid input    113.668k (± 1.1%) i/s -    574.032k in   5.059266s
       invalid input    122.840k (± 1.2%) i/s -    615.927k in   5.027367s
                   with 95.0% confidence

Comparison:
       invalid input:   122840.2 i/s
         valid input:   113668.2 i/s - 1.08x  (± 0.02) slower
                   with 95.0% confidence
```
After:
```
Warming up --------------------------------------
         valid input    11.004k i/100ms
       invalid input    12.469k i/100ms
Calculating -------------------------------------
         valid input    117.272k (± 1.2%) i/s -    594.216k in   5.077576s
       invalid input    114.757k (± 1.1%) i/s -    573.574k in   5.007477s
                   with 95.0% confidence

Comparison:
         valid input:   117272.0 i/s
       invalid input:   114757.4 i/s - same-ish: difference falls within error
                   with 95.0% confidence
```

In theory both valid & invalid inputs should be the same, since we're not generating error messages, but  there is variation. The same with before/after comparison, results are comparable, but different runs show `115000 i/s ± 10%`.

dry-v specs are passing.