### PR TITLE
Run outer schema processor steps before inner ones

### DIFF
--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -77,7 +77,11 @@ module Dry
 
       # @api private
       def <=>(other)
-        keys.length <=> other.keys.length if include?(other) || other.include?(self)
+        return keys.length <=> other.keys.length if include?(other) || other.include?(self)
+
+        first_uncommon_index = (self & other).keys.length
+
+        keys[first_uncommon_index] <=> other.keys[first_uncommon_index]
       end
 
       # @api private

--- a/lib/dry/schema/processor_steps.rb
+++ b/lib/dry/schema/processor_steps.rb
@@ -87,6 +87,7 @@ module Dry
       def after(name, &block)
         after_steps[name] ||= EMPTY_ARRAY.dup
         after_steps[name] << Step.new(type: :after, name: name, executor: block)
+        after_steps[name].sort_by!(&:path)
         self
       end
 
@@ -100,6 +101,7 @@ module Dry
       def before(name, &block)
         before_steps[name] ||= EMPTY_ARRAY.dup
         before_steps[name] << Step.new(type: :before, name: name, executor: block)
+        before_steps[name].sort_by!(&:path)
         self
       end
 
@@ -120,18 +122,20 @@ module Dry
       # @api private
       def merge_callbacks(left, right)
         left.merge(right) do |_key, oldval, newval|
-          oldval + newval
+          (oldval + newval).sort_by(&:path)
         end
       end
 
       # @api private
       def import_callbacks(path, other)
         other.before_steps.each do |name, steps|
-          (before_steps[name] ||= []).concat(steps.map { |step| step.scoped(path) })
+          before_steps[name] ||= []
+          before_steps[name].concat(steps.map { |step| step.scoped(path) }).sort_by!(&:path)
         end
 
         other.after_steps.each do |name, steps|
-          (after_steps[name] ||= []).concat(steps.map { |step| step.scoped(path) })
+          after_steps[name] ||= []
+          after_steps[name].concat(steps.map { |step| step.scoped(path) }).sort_by!(&:path)
         end
       end
     end

--- a/spec/integration/schema/steps_spec.rb
+++ b/spec/integration/schema/steps_spec.rb
@@ -84,6 +84,92 @@ RSpec.describe Dry::Schema, "callbacks" do
     end
   end
 
+  context "with callbacks in main schema and nested schemas" do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:account).schema do
+          required(:name).filled(:string)
+
+          before(:key_coercer) do |result|
+            result.to_h.transform_keys(&:downcase)
+          end
+        end
+
+        required(:email).schema do
+          required(:address).schema do
+            required(:local_part).filled(:string)
+            required(:domain).filled(:string)
+
+            before(:key_coercer) do |result|
+              result.to_h.transform_keys { |key| key.to_s.squeeze.to_sym }
+            end
+          end
+
+          before(:key_coercer) do |result|
+            result.to_h.transform_keys(&:succ)
+          end
+        end
+
+        before(:key_coercer) do |result|
+          result.to_h.transform_keys(&:to_sym)
+        end
+      end
+    end
+
+    specify do
+      input = {
+        "account" => {
+          NaMe: "ojab"
+        },
+        "email" => {
+          addresr: {
+            loocall_part: "not_ojab",
+            dooooooomain: "example.org"
+          }
+        }
+      }
+      expect(schema.(input).to_h).to eql(
+        account: {name: "ojab"}, email: {address: {local_part: "not_ojab", domain: "example.org"}}
+      )
+    end
+  end
+
+  context "when schema with callbacks is reused" do
+    let(:first_schema) do
+      local_nested_schema = nested_schema
+      Dry::Schema.define do
+        required(:a).filled(local_nested_schema)
+      end
+    end
+
+    let(:second_schema) do
+      local_nested_schema = nested_schema
+
+      Dry::Schema.define do
+        required(:b).schema do
+          required(:c).filled(local_nested_schema)
+
+          before(:key_coercer) do |result|
+            result.to_h.transform_keys { |_key| :c }
+          end
+        end
+      end
+    end
+
+    let(:nested_schema) do
+      Dry::Schema.define do
+        required(:name).filled(:string)
+
+        before(:key_coercer) { |result| result.to_h.transform_keys(&:to_sym) }
+      end
+    end
+
+    it "correctly handles reused schemas" do
+      expect(first_schema.(a: {"name" => "ojab"}).to_h).to eql(a: {name: "ojab"})
+      expect(second_schema.(b: {foo: {"name" => "ojab"}}).to_h).to eql(b: {c: {name: "ojab"}})
+    end
+  end
+
   context "invalid step name" do
     it "raises error" do
       expect {

--- a/spec/unit/dry/schema/path_spec.rb
+++ b/spec/unit/dry/schema/path_spec.rb
@@ -86,4 +86,20 @@ RSpec.describe Dry::Schema::Path do
       expect(path & other).to eql(Dry::Schema::Path.new([]))
     end
   end
+
+  describe "#<=>" do
+    let(:paths) do
+      [
+        %i[a b d],
+        %i[b],
+        %i[a b c],
+        [],
+        %i[a b]
+      ].map { |path| Dry::Schema::Path[path] }
+    end
+
+    it "sorts alphabetically, shortest paths first" do
+      expect(paths.sort.map { |path| path.keys.join(".") }).to eq(["", "a.b", "a.b.c", "a.b.d", "b"])
+    end
+  end
 end


### PR DESCRIPTION
Extract from https://github.com/dry-rb/dry-schema/pull/353.

Pretty straightforward, just sorting steps by shortest path first on schema creation. 
We need to compare paths with different roots for this, so allow it.