### PR TITLE
Handle non-Hash to Hash transformation in `before(:key_coercer)`

### DIFF
--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -100,6 +100,8 @@ module Dry
       def same_root?(other)
         root.equal?(other.root)
       end
+
+      EMPTY = new(EMPTY_ARRAY).freeze
     end
   end
 end

--- a/lib/dry/schema/step.rb
+++ b/lib/dry/schema/step.rb
@@ -7,9 +7,6 @@ module Dry
   module Schema
     # @api private
     class Step
-      EMPTY_PATH = Path.new([]).freeze
-      private_constant :EMPTY_PATH
-
       # @api private
       attr_reader :name
 
@@ -23,7 +20,7 @@ module Dry
       attr_reader :path
 
       # @api private
-      def initialize(type:, name:, executor:, path: EMPTY_PATH)
+      def initialize(type:, name:, executor:, path: Path::EMPTY)
         @type = type
         @name = name
         @executor = executor
@@ -33,7 +30,7 @@ module Dry
 
       # @api private
       def call(result)
-        scoped_result = path.equal?(EMPTY_PATH) ? result : result.at(path)
+        scoped_result = path.equal?(Path::EMPTY) ? result : result.at(path)
 
         output = executor.(scoped_result)
         scoped_result.replace(output) if output.is_a?(Hash)

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dry::Schema::Result do
     describe "#inspect" do
       it "returns a string representation" do
         expect(result.inspect).to eql(<<-STR.strip)
-          #<Dry::Schema::Result{:name=>"Jane"} errors={}>
+          #<Dry::Schema::Result{:name=>"Jane"} errors={} path=[]>
         STR
       end
     end
@@ -61,8 +61,30 @@ RSpec.describe Dry::Schema::Result do
     describe "#inspect" do
       it "returns a string representation" do
         expect(result.inspect).to eql(<<-STR.strip)
-          #<Dry::Schema::Result{:name=>""} errors={:name=>["must be filled"]}>
+          #<Dry::Schema::Result{:name=>""} errors={:name=>["must be filled"]} path=[]>
         STR
+      end
+    end
+
+    context "when scoped" do
+      let(:schema) do
+        Dry::Schema.define do
+          required(:account).schema do
+            required(:name).schema do
+              required(:first).filled(:string)
+            end
+          end
+        end
+      end
+
+      let(:input) { {account: {name: {first: "ojab"}}} }
+
+      describe "#inspect" do
+        it "returns a string representation" do
+          expect(result.at([:account, :name]).inspect).to eql(<<-STR.strip)
+            #<Dry::Schema::Result{:first=>"ojab"} errors={} path=[:account, :name]>
+          STR
+        end
       end
     end
 

--- a/spec/integration/schema/steps_spec.rb
+++ b/spec/integration/schema/steps_spec.rb
@@ -170,6 +170,30 @@ RSpec.describe Dry::Schema, "callbacks" do
     end
   end
 
+  context "when input is not a Hash" do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:email).schema do
+          required(:address).schema do
+            required(:local_part).filled(:string)
+
+            before(:key_coercer) { |result| YAML.safe_load(result.output, permitted_classes: [Symbol]) }
+          end
+
+          before(:key_coercer) { |result| YAML.safe_load(result.output, permitted_classes: [Symbol]) }
+        end
+
+        before(:key_coercer) { |result| YAML.safe_load(result.output, permitted_classes: [Symbol]) }
+      end
+    end
+
+    specify do
+      input = YAML.dump(email: YAML.dump(address: YAML.dump(local_part: "ojab")))
+
+      expect(schema.(input).to_h).to eql(email: {address: {local_part: "ojab"}})
+    end
+  end
+
   context "invalid step name" do
     it "raises error" do
       expect {


### PR DESCRIPTION
Extract from #353.
Fixes #350

Instead of passing only part of the output to the scoped results we're passing whole output and path as a scope, this was result can replace scoped value without any assumptions on the initial and replacement types.

Performance for the common case (steps execution only on the outer schema) is not affected, running `benchmarks/params_valid_vs_invalid.rb` (10 times each because of the noise)
Before:
```
       valid input 8:    32011.2 i/s
       valid input 0:    31832.2 i/s - same-ish: difference falls within error
       valid input 7:    31779.7 i/s - same-ish: difference falls within error
       valid input 1:    31690.8 i/s - same-ish: difference falls within error
       valid input 2:    31623.7 i/s - same-ish: difference falls within error
       valid input 4:    31438.5 i/s - same-ish: difference falls within error
       valid input 6:    31369.0 i/s - same-ish: difference falls within error
       valid input 5:    31180.7 i/s - same-ish: difference falls within error
       valid input 3:    31118.2 i/s - same-ish: difference falls within error
       valid input 9:    30681.5 i/s - same-ish: difference falls within error
     invalid input 9:    20153.8 i/s - 1.59x  (± 0.00) slower
     invalid input 8:    20103.2 i/s - 1.59x  (± 0.00) slower
     invalid input 7:    20067.7 i/s - 1.60x  (± 0.00) slower
     invalid input 1:    19941.1 i/s - 1.61x  (± 0.00) slower
     invalid input 2:    19937.2 i/s - 1.61x  (± 0.00) slower
     invalid input 3:    19563.4 i/s - 1.64x  (± 0.00) slower
     invalid input 0:    19548.0 i/s - 1.64x  (± 0.00) slower
     invalid input 6:    19313.2 i/s - 1.66x  (± 0.00) slower
     invalid input 5:    18576.3 i/s - 1.72x  (± 0.00) slower
     invalid input 4:    17281.0 i/s - 1.85x  (± 0.00) slower
```
After:
```
Comparison:
       valid input 0:    32465.3 i/s
       valid input 2:    32141.4 i/s - same-ish: difference falls within error
       valid input 3:    31842.5 i/s - same-ish: difference falls within error
       valid input 5:    31600.6 i/s - same-ish: difference falls within error
       valid input 6:    31525.6 i/s - same-ish: difference falls within error
       valid input 4:    31306.8 i/s - same-ish: difference falls within error
       valid input 7:    31173.7 i/s - same-ish: difference falls within error
       valid input 8:    31123.6 i/s - same-ish: difference falls within error
       valid input 9:    30858.5 i/s - same-ish: difference falls within error
       valid input 1:    30832.5 i/s - same-ish: difference falls within error
     invalid input 5:    20427.4 i/s - 1.59x  (± 0.00) slower
     invalid input 4:    20413.8 i/s - 1.59x  (± 0.00) slower
     invalid input 6:    20385.7 i/s - 1.59x  (± 0.00) slower
     invalid input 7:    20368.8 i/s - 1.59x  (± 0.00) slower
     invalid input 9:    20276.1 i/s - 1.60x  (± 0.00) slower
     invalid input 8:    20184.7 i/s - 1.61x  (± 0.00) slower
     invalid input 1:    20084.0 i/s - 1.62x  (± 0.00) slower
     invalid input 2:    20078.9 i/s - 1.62x  (± 0.00) slower
     invalid input 3:    19898.7 i/s - 1.63x  (± 0.00) slower
     invalid input 0:    19893.5 i/s - 1.63x  (± 0.00) slower
```

dry-v specs are passing, didn't measured performance of the nested steps.