### PR TITLE
Fix key validator false negatives on empty collections

### DIFF
--- a/lib/dry/schema/key_validator.rb
+++ b/lib/dry/schema/key_validator.rb
@@ -51,9 +51,14 @@ module Dry
         hash.flat_map { |key, _|
           case (value = hash[key])
           when Hash
+            next key.to_s if value.empty?
+
             [key].product(key_paths(hash[key])).map { |keys| keys.join(DOT) }
           when Array
-            hashes_or_arrays = value.select { |e| e.is_a?(Array) || e.is_a?(Hash) }
+            hashes_or_arrays = value.select { |e| (e.is_a?(Array) || e.is_a?(Hash)) && !e.empty? }
+
+            next key.to_s if hashes_or_arrays.empty?
+
             hashes_or_arrays.flat_map.with_index { |el, idx|
               key_paths(el).map { |path| ["#{key}[#{idx}]", *path].join(DOT) }
             }

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe Dry::Schema, "unexpected keys" do
       foo: "unexpected",
       name: "Jane",
       ids: [1, 2, 3, 4],
-      address: {bar: "unexpected", city: "NYC", zipcode: "1234"},
+      qux: [],
+      quux: [{}],
+      hoge: {},
+      address: {bar: "unexpected", baz: [1], city: "NYC", zipcode: "1234"},
       roles: [
         {name: "admin", expires_at: Date.today},
         {name: "editor", foo: "unexpected", expires_at: Date.today}
@@ -35,7 +38,10 @@ RSpec.describe Dry::Schema, "unexpected keys" do
     expect(schema.(input).errors.to_h)
       .to eql(
         foo: ["is not allowed"],
-        address: {bar: ["is not allowed"]},
+        qux: ["is not allowed"],
+        quux: ["is not allowed"],
+        hoge: ["is not allowed"],
+        address: {bar: ["is not allowed"], baz: ["is not allowed"]},
         roles: {1 => {foo: ["is not allowed"]}}
       )
   end


### PR DESCRIPTION
### What was happening?

As described in #349 and #355, when using `validate_keys = true`, there are false negatives when the schema encounters unexpected keys where the value is an empty array or -hash, or an array with only primitives.

This was happening because the recursively defined `KeyValidator#key_paths` did not handle the cases where there was nothing to recurse over. (The correct behaviour would be to instantly return the key.)

The output of this method is what is subsequently checked against the key map, but with the relevant keys missing, the validation logic would overlook these unexpected keys.

### How does this fix it?

- When encountering an empty hash value, immediately add the key to the key paths.
- When encountering an array value, return the key immediately if the array 1) has no nested collections, 2) all nested collections are empty, or 3) contains only primitives.

### What is the impact?

This change affects only private APIs, but the obvious "side effect" is that the bug is fixed, and anyone whose application incidentally works because unexpected keys were ignored, might start seeing errors in their application after upgrading.

### Limitations

There was a related, but separate, issue highlighted in #355. For nested hashes, the error is tacked onto the innermost hash, rather than on the first key that is unexpected. After having a quick look I decided to not address that in this same PR, as the changes are quite involved, and probably deserve their own PR.