### PR TITLE
Prevent error message YAML files from being parsed multiple times

### DIFF
--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -72,6 +72,11 @@ module Dry
       end
 
       # @api private
+      def self.source_cache
+        @source_cache ||= Concurrent::Map.new
+      end
+
+      # @api private
       def initialize(data: EMPTY_HASH, config: nil)
         super()
         @data = data
@@ -179,7 +184,9 @@ module Dry
 
       # @api private
       def load_translations(path)
-        data = self.class.flat_hash(YAML.load_file(path))
+        data = self.class.source_cache.fetch_or_store(path) do
+          self.class.flat_hash(YAML.load_file(path)).freeze
+        end
 
         return data unless custom_top_namespace?(path)
 


### PR DESCRIPTION
Fixes #352

Adds `source_cache` to `Dry::Schema::Messages::YAML`.

Since this data is now being shared by Schemas, I opted to freeze it.

I'm leaning towards not adding test coverage for this specifically, since it's changing the implementation of a feature that is already under test.