### PR TITLE
dry-configurable v0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     env:
       COVERAGE: ${{matrix.coverage}}
       COVERAGE_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
+      DRY_CONFIGURABLE_FROM_MASTER: true
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/lib/dry/schema/config.rb
+++ b/lib/dry/schema/config.rb
@@ -25,7 +25,7 @@ module Dry
       # @return [Schema::PredicateRegistry]
       #
       # @api public
-      setting(:predicates, Schema::PredicateRegistry.new)
+      setting(:predicates, default: Schema::PredicateRegistry.new)
 
       # @!method types
       #
@@ -34,7 +34,7 @@ module Dry
       # @return [Hash]
       #
       # @api public
-      setting(:types, Dry::Types)
+      setting(:types, default: Dry::Types)
 
       # @!method messages
       #
@@ -44,11 +44,11 @@ module Dry
       #
       # @api public
       setting(:messages) do
-        setting(:backend, :yaml)
+        setting(:backend, default: :yaml)
         setting(:namespace)
-        setting(:load_paths, Set[DEFAULT_MESSAGES_PATH], &:dup)
-        setting(:top_namespace, DEFAULT_MESSAGES_ROOT)
-        setting(:default_locale, nil)
+        setting(:load_paths, default: Set[DEFAULT_MESSAGES_PATH], &:dup)
+        setting(:top_namespace, default: DEFAULT_MESSAGES_ROOT)
+        setting(:default_locale, default: nil)
       end
 
       # @!method validate_keys
@@ -58,7 +58,7 @@ module Dry
       # @return [Boolean]
       #
       # @api public
-      setting(:validate_keys, false)
+      setting(:validate_keys, default: false)
 
       # @api private
       def respond_to_missing?(meth, include_private = false)

--- a/lib/dry/schema/messages/abstract.rb
+++ b/lib/dry/schema/messages/abstract.rb
@@ -18,13 +18,13 @@ module Dry
         include Dry::Configurable
         include Dry::Equalizer(:config)
 
-        setting :default_locale, nil
-        setting :load_paths, Set[DEFAULT_MESSAGES_PATH]
-        setting :top_namespace, DEFAULT_MESSAGES_ROOT
-        setting :root, "errors"
-        setting :lookup_options, %i[root predicate path val_type arg_type].freeze
+        setting :default_locale, default: nil
+        setting :load_paths, default: Set[DEFAULT_MESSAGES_PATH]
+        setting :top_namespace, default: DEFAULT_MESSAGES_ROOT
+        setting :root, default: "errors"
+        setting :lookup_options, default: %i[root predicate path val_type arg_type].freeze
 
-        setting :lookup_paths, [
+        setting :lookup_paths, default: [
           "%<root>s.rules.%<path>s.%<predicate>s.arg.%<arg_type>s",
           "%<root>s.rules.%<path>s.%<predicate>s",
           "%<root>s.%<predicate>s.%<message_type>s",
@@ -35,13 +35,13 @@ module Dry
           "%<root>s.%<predicate>s"
         ].freeze
 
-        setting :rule_lookup_paths, ["rules.%<name>s"].freeze
+        setting :rule_lookup_paths, default: ["rules.%<name>s"].freeze
 
-        setting :arg_types, Hash.new { |*| "default" }.update(
+        setting :arg_types, default: Hash.new { |*| "default" }.update(
           Range => "range"
         )
 
-        setting :val_types, Hash.new { |*| "default" }.update(
+        setting :val_types, default: Hash.new { |*| "default" }.update(
           Range => "range",
           String => "string"
         )

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -53,7 +53,7 @@ module Dry
         # @api public
         def define(&block)
           @definition ||= DSL.new(
-            processor_type: self, parent: superclass.definition, **config, &block
+            processor_type: self, parent: superclass.definition, **config.to_h, &block
           )
           self
         end

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -28,8 +28,8 @@ module Dry
       include Dry::Logic::Operators
 
       setting :key_map_type
-      setting :type_registry_namespace, :strict
-      setting :filter_empty_string, false
+      setting :type_registry_namespace, default: :strict
+      setting :filter_empty_string, default: false
 
       option :steps, default: -> { ProcessorSteps.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,9 @@ require_relative "support/rspec_options"
 Warning.ignore(%r{gems/i18n})
 Warning.process { |w| raise w }
 
-begin
-  require "pry-byebug"
-rescue LoadError; end
+# begin
+#   require "pry-byebug"
+# rescue LoadError; end
 SPEC_ROOT = Pathname(__dir__)
 
 Dir[SPEC_ROOT.join("shared/**/*.rb")].each(&method(:require))


### PR DESCRIPTION
Update `dry-configurable` syntax: `:default` argument for `.setting`.

https://github.com/dry-rb/dry-configurable/blob/master/CHANGELOG.md#unreleased