### PR TITLE
Use explicit conversion of config to hash

### DIFF
--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -53,7 +53,7 @@ module Dry
         # @api public
         def define(&block)
           @definition ||= DSL.new(
-            processor_type: self, parent: superclass.definition, **config, &block
+            processor_type: self, parent: superclass.definition, **config.to_h, &block
           )
           self
         end


### PR DESCRIPTION
The support for implicit conversion has been removed (https://github.com/dry-rb/dry-configurable/pull/114) and will be included in the upcoming dry-configurable 0.13.0 release.

This change is also compatible with all existing releases of dry-configurable, since they all feature a `Config#to_h` method.