### PR TITLE
Make path matching in key validator more strict

### DIFF
--- a/lib/dry/schema/key_validator.rb
+++ b/lib/dry/schema/key_validator.rb
@@ -41,13 +41,19 @@ module Dry
         if path[INDEX_REGEX]
           key = path.gsub(INDEX_REGEX, BRACKETS)
 
-          if key_paths.none? { _1.include?(key) }
+          if key_paths.none? { paths_match?(key, _1) }
             arr = path.gsub(INDEX_REGEX) { ".#{_1[1]}" }
             arr.split(DOT).map { DIGIT_REGEX.match?(_1) ? Integer(_1, 10) : _1.to_sym }
           end
-        elsif key_paths.none? { _1.include?(path) }
+        elsif key_paths.none? { paths_match?(path, _1) }
           path
         end
+      end
+
+      # @api private
+      def paths_match?(input_path, key_path)
+        residue = key_path.sub(input_path, "")
+        residue.empty? || residue.start_with?(DOT, BRACKETS)
       end
 
       # @api private

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe Dry::Schema, "unexpected keys" do
       roles: [
         {name: "admin", expires_at: Date.today},
         {name: "editor", foo: "unexpected", expires_at: Date.today}
-      ]
+      ],
+      am: "John",
+      city: "LA"
     }
 
     expect(schema.(input).errors.to_h)
@@ -42,7 +44,9 @@ RSpec.describe Dry::Schema, "unexpected keys" do
         quux: ["is not allowed"],
         hoge: ["is not allowed"],
         address: {bar: ["is not allowed"], baz: ["is not allowed"]},
-        roles: {1 => {foo: ["is not allowed"]}}
+        roles: {1 => {foo: ["is not allowed"]}},
+        am: ["is not allowed"],
+        city: ["is not allowed"]
       )
   end
 


### PR DESCRIPTION
Fixes #385

Loose matching was added to allow partial key paths to pass the `validate_keys` validation when used with `maybe` hashes  (#309, #312). This change maintains that behaviour, but prevents paths with partial keys from passing.

Originally, went with a regex solution but it turned out to be pretty sluggish when benchmarked. This version doesn't seem to have any noticeable impact on performance, at least for simple cases I tested.