### PR TITLE
Forward #translate method to underlying backend

### DIFF
--- a/lib/dry/schema/messages/namespaced.rb
+++ b/lib/dry/schema/messages/namespaced.rb
@@ -80,6 +80,11 @@ module Dry
         def interpolate(key, options, **data)
           messages.interpolate(key, options, **data)
         end
+
+        # @api private
+        def translate(key, **args)
+          messages.translate(key, **args)
+        end
       end
     end
   end

--- a/spec/integration/messages/namespaced_spec.rb
+++ b/spec/integration/messages/namespaced_spec.rb
@@ -55,4 +55,21 @@ RSpec.describe "Namespaced messages" do
         .to eql(["COMMENT can't be blank"])
     end
   end
+
+  context "with OR types" do
+    let(:post_schema) do
+      Dry::Schema.Params do
+        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
+        config.messages.namespace = :post
+
+        required(:some_ids).maybe(Types::Array.of(Types::Params::Integer | Types::Params::String))
+      end
+    end
+
+    it "uses namespaced messages" do
+      result = post_schema.call(some_ids: [[]])
+
+      expect(result.errors[:some_ids]).to eql({0 => ["must be an integer or must be a string"]})
+    end
+  end
 end


### PR DESCRIPTION
# Description

Discovered this when received `[[]]` as input in our API. Schema in our API defined in same way as in specs in this PR.
There is issue related to this PR from another guy in dry-validation repo dry-rb/dry-validation#692 

# How to reproduce

## without fix

```
bundle exec rspec spec/integration/messages/namespaced_spec.rb:69
Run options: include {:locations=>{"./spec/integration/messages/namespaced_spec.rb"=>[69]}}

Randomized with seed 21602
F

Failures:

  1) Namespaced messages with OR messages uses namespaced messages
     Failure/Error: t["#{config.top_namespace}.#{key}", locale: locale]
     
     NameError:
       undefined local variable or method `t' for #<Dry::Schema::Messages::Namespaced:0x00007fb357a88fb0>
     # ./lib/dry/schema/messages/abstract.rb:72:in `translate'
     # ./lib/dry/schema/message_compiler.rb:126:in `block in or_translator'
     # ./lib/dry/schema/message/or/single_path.rb:41:in `dump'
     # ./lib/dry/schema/message/or/single_path.rb:53:in `to_h'
     # ./lib/dry/schema/message_set.rb:108:in `map'
     # ./lib/dry/schema/message_set.rb:108:in `messages_map'
     # ./lib/dry/schema/extensions/hints/message_set_methods.rb:37:in `to_h'
     # ./lib/dry/schema/message_set.rb:72:in `[]'
     # ./spec/integration/messages/namespaced_spec.rb:72:in `block (3 levels) in <top (required)>'
```

## with fix

Specs pass