### PR TITLE
Fix loose JSON schemas for nested hashes

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -88,7 +88,7 @@ module Dry
 
         # @api private
         def visit_set(node, opts = EMPTY_HASH)
-          target = (key = opts[:key]) ? self.class.new : self
+          target = (key = opts[:key]) ? self.class.new(loose: loose?) : self
 
           node.map { |child| target.visit(child, opts) }
 

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -168,10 +168,12 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
     unsupported_cases.each do |predicate|
       subject(:schema) do
         Dry::Schema.JSON do
-          if predicate.is_a?(Hash)
-            required(:key).filled(**predicate)
-          else
-            required(:key).filled(predicate)
+          required(:nested).hash do
+            if predicate.is_a?(Hash)
+              required(:key).filled(**predicate)
+            else
+              required(:key).filled(predicate)
+            end
           end
         end
       end


### PR DESCRIPTION
The `:loose` option to the `#json_schema` method was not being applied
to subschemas. It was reverting to it's default of `false`. This passes
the option down such that all subschemas are affected by the option.