### PR TITLE
fix: correct spelling error 'mininum' to 'minimum' in json-schema extension

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -47,7 +47,7 @@ module Dry
             pattern: "^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$"
           },
           gt?: {exclusiveMinimum: IDENTITY},
-          gteq?: {mininum: IDENTITY},
+          gteq?: {minimum: IDENTITY},
           lt?: {exclusiveMaximum: IDENTITY},
           lteq?: {maximum: IDENTITY},
           odd?: {type: "integer", not: {multipleOf: 2}},

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
   describe "special number predictes" do
     {
       {gt?: 5} => {type: "integer", exclusiveMinimum: 5},
-      {gteq?: 5} => {type: "integer", mininum: 5},
+      {gteq?: 5} => {type: "integer", minimum: 5},
       {lt?: 5} => {type: "integer", exclusiveMaximum: 5},
       {lteq?: 5} => {type: "integer", maximum: 5},
       odd?: {type: "integer", not: {multipleOf: 2}},


### PR DESCRIPTION
## Describe the bug

👋

Seems like a small typo might have creep:de into the `json_schema` extension when using the `gteq?` predicate as it currently returns "mini_n_um" instead of "mini_m_um" 😄 

## To Reproduce

```ruby
Dry::Schema.load_extensions(:json_schema)

UserSchema = Dry::Schema.JSON do
   required(:age).value(:integer, gteq?: 18)
end

require "json"

puts JSON.pretty_generate(UserSchema.json_schema)
```

Currently prints the following schema:

```json
{
  "$schema": "http://json-schema.org/draft-06/schema#",
  "type": "object",
  "properties": {
    "age": {
      "type": "integer",
      "mininum": 18
    }
  },
  "required": [
    "age"
  ]
}
```

## Expected behavior

To print the following schema:

```json
{
  "$schema": "http://json-schema.org/draft-06/schema#",
  "type": "object",
  "properties": {
    "age": {
      "type": "integer",
      "minimum": 18
    }
  },
  "required": [
    "age"
  ]
}
```

## Notes

Made a liberal interpretation of your contributing guidelines and assumed this qualifies as a "typo" and just went ahead and opened a pull request directly instead of creating an issue. Let me know if I should have done it the other way around 🙂 

Also, guess this could be something which affects downstream JSON schema validators (which uses the exported schema) since at least some of the validators will silently ignore the invalid "mini_n_um" constraint ([example](https://www.jsonschemavalidator.net/s/5YCuxssD)). Just something to be aware of I guess 🙂 