### PR TITLE
Autoload schema constants

### DIFF
--- a/lib/dry/schema.rb
+++ b/lib/dry/schema.rb
@@ -2,11 +2,7 @@
 
 require "dry/core/extensions"
 
-require "dry/schema/config"
 require "dry/schema/constants"
-require "dry/schema/dsl"
-require "dry/schema/params"
-require "dry/schema/json"
 
 module Dry
   # Main interface
@@ -14,6 +10,11 @@ module Dry
   # @api public
   module Schema
     extend Dry::Core::Extensions
+
+    autoload(:DSL, "dry/schema/dsl")
+    autoload(:Params, "dry/schema/params")
+    autoload(:JSON, "dry/schema/json")
+    autoload(:Config, "dry/schema/config")
 
     # Configuration
     #

--- a/lib/dry/schema/path.rb
+++ b/lib/dry/schema/path.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
+
 require "dry/schema/constants"
 
 module Dry


### PR DESCRIPTION
👋  I noticed an app I was working on was taking some time to load `dry-schema`:

![Screen Shot 2022-05-10 at 1 35 25 PM](https://user-images.githubusercontent.com/5162312/167692672-51697a3c-cb3f-436a-b3c1-9508793adaf2.png)

This PR adds autoloading to schema constants so that on load, less files are required and apps using this gem can boot faster. Using a simple benchmark

```
require "benchmark"

x = Benchmark.realtime do
  require "dry/schema"
end

puts "Loaded in #{x * 1000}ms"
```

We can observe the time it takes to load the gem. Autoload changes this number from `~90ms` to `2ms`.

The downside to this, is we loose the ability to eager-load autoloaded constants into memory. Rails accounts for this by using [Zeitwerk](https://github.com/fxn/zeitwerk) to load autoloaded constants early, which helps in environments like production where we want to do as much loading as possible upfront. Since dry-rb doesn't use Zeitwerk, I'm not sure how we can address this. Any ideas?