### PR TITLE
Support anyOf composition in JSON schema output

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -115,6 +115,18 @@ module Dry
         end
 
         # @api private
+        def visit_or(node, opts = EMPTY_HASH)
+          node.each do |child|
+            c = self.class.new(loose: loose?)
+            c.keys.update(subschema: {})
+            c.visit(child, opts.merge(key: :subschema))
+
+            any_of = (keys[opts[:key]][:anyOf] ||= [])
+            any_of << c.keys[:subschema]
+          end
+        end
+
+        # @api private
         def visit_implication(node, opts = EMPTY_HASH)
           node.each do |el|
             visit(el, **opts, required: false)

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
         optional(:address).hash do
           optional(:street).value(:string)
         end
+
+        required(:id) { str? | int? }
       end
     end
 
@@ -70,9 +72,15 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
               }
             },
             required: []
+          },
+          id: {
+            anyOf: [
+              {type: "string"},
+              {type: "integer"}
+            ]
           }
         },
-        required: %w[email roles]
+        required: %w[email roles id]
       )
     end
   end


### PR DESCRIPTION
Hi! It's been awhile 😄 This implements `visit_or` within Dry::Schema::JSONSchema::SchemaCompiler so that composition of predicates and schemata can be converted to JSON schemas.