### PR TITLE
Allow composition of multiple ors

### DIFF
--- a/lib/dry/schema/message/or.rb
+++ b/lib/dry/schema/message/or.rb
@@ -17,8 +17,8 @@ module Dry
 
           if paths.uniq.size == 1
             SinglePath.new(left, right, messages)
-          elsif right.is_a?(Array)
-            if left.is_a?(Array) && paths.uniq.size > 1
+          elsif MultiPath.handler(right)
+            if MultiPath.handler(left) && paths.uniq.size > 1
               MultiPath.new(left, right)
             else
               right

--- a/lib/dry/schema/message/or/multi_path.rb
+++ b/lib/dry/schema/message/or/multi_path.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/core/equalizer"
-
 require "dry/schema/message/or/abstract"
 require "dry/schema/path"
 
@@ -14,23 +12,85 @@ module Dry
         # @api public
         class MultiPath < Abstract
           # @api private
-          attr_reader :root
+          class MessageArray
+            # @api private
+            def initialize(messages)
+              @messages = messages.flatten
+            end
+
+            # @api private
+            def _paths
+              @messages.map(&:_path)
+            end
+
+            # @api private
+            def to_or(root)
+              self.class.new(@messages.map { _1.to_or(root) })
+            end
+
+            # @api private
+            def to_h
+              MessageSet.new(@messages).to_h
+            end
+          end
 
           # @api private
-          def initialize(...)
-            super
-            flat_left = left.flatten
-            flat_right = right.flatten
-            @root = [*flat_left, *flat_right].map(&:_path).reduce(:&)
-            @left = flat_left.map { _1.to_or(root) }
-            @right = flat_right.map { _1.to_or(root) }
+          def self.handler(message)
+            handlers.find { |k,| message.is_a?(k) }&.last
+          end
+
+          # @api private
+          private_class_method def self.handlers
+            @handlers ||= {
+              self => -> { _1 },
+              Array => -> { MessageArray.new(_1) }
+            }.freeze
           end
 
           # @api public
           def to_h
-            @to_h ||= Path[[*root, :or]].to_h(
-              [MessageSet.new(left).to_h, MessageSet.new(right).to_h]
-            )
+            @to_h ||= Path[[*root, :or]].to_h(messages.map(&:to_h))
+          end
+
+          # @api private
+          def messages
+            @messages ||= _messages.flat_map { _1.to_or(root) }
+          end
+
+          # @api private
+          def root
+            @root ||= _messages.flat_map(&:_paths).reduce(:&)
+          end
+
+          # @api private
+          def path
+            root
+          end
+
+          # @api private
+          def _paths
+            @paths ||= [Path[root]]
+          end
+
+          # @api private
+          def to_or(root)
+            self.root == root ? messages : [self]
+          end
+
+          private
+
+          # @api private
+          def _messages
+            @_messages ||= [@left, @right].map do |message|
+              handler = self.class.handler(message)
+
+              unless handler
+                raise ArgumentError,
+                      "#{message.inspect} is of unknown type #{message.class.inspect}"
+              end
+
+              handler.(message)
+            end
           end
         end
       end

--- a/lib/dry/schema/message/or/multi_path.rb
+++ b/lib/dry/schema/message/or/multi_path.rb
@@ -81,7 +81,7 @@ module Dry
 
           # @api private
           def _messages
-            @_messages ||= [@left, @right].map do |message|
+            @_messages ||= [left, right].map do |message|
               handler = self.class.handler(message)
 
               unless handler

--- a/spec/integration/schema/or_spec.rb
+++ b/spec/integration/schema/or_spec.rb
@@ -111,4 +111,82 @@ RSpec.describe Dry::Schema, "OR messages" do
       expect(schema.(user: {}).errors.to_h).to eql(user: {or: [{name: ["is missing"]}, {nickname: ["is missing"]}]})
     end
   end
+
+  context "with three schemas" do
+    name_schema = Dry::Schema.define do
+      required(:name).filled(:string)
+    end
+
+    nickname_schema = Dry::Schema.define do
+      required(:nickname).filled(:string)
+    end
+
+    alias_schema = Dry::Schema.define do
+      required(:alias).filled(:string)
+    end
+
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:user) { name_schema | nickname_schema | alias_schema }
+      end
+    end
+
+    it "returns success for valid input" do
+      expect(schema.(user: {name: "John"})).to be_success
+      expect(schema.(user: {nickname: "John"})).to be_success
+      expect(schema.(user: {alias: "Slick"})).to be_success
+    end
+
+    it "provides error messages for invalid input where all sides failed" do
+      expect(schema.(user: {}).errors.to_h).to eql(
+        {
+          user: {or: [{name: ["is missing"]},
+                      {nickname: ["is missing"]},
+                      {alias: ["is missing"]}]}
+        }
+      )
+    end
+  end
+
+  context "with four schemas" do
+    name_schema = Dry::Schema.define do
+      required(:name).filled(:string)
+    end
+
+    nickname_schema = Dry::Schema.define do
+      required(:nickname).filled(:string)
+    end
+
+    alias_schema = Dry::Schema.define do
+      required(:alias).filled(:string)
+    end
+
+    favorite_food_schema = Dry::Schema.define do
+      required(:favorite_food).filled(:string)
+    end
+
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:user) { name_schema | nickname_schema | alias_schema | favorite_food_schema }
+      end
+    end
+
+    it "returns success for valid input" do
+      expect(schema.(user: {name: "John"})).to be_success
+      expect(schema.(user: {nickname: "John"})).to be_success
+      expect(schema.(user: {alias: "Slick"})).to be_success
+      expect(schema.(user: {favorite_food: "pizza"})).to be_success
+    end
+
+    it "provides error messages for invalid input where all sides failed" do
+      expect(schema.(user: {}).errors.to_h).to eql(
+        {
+          user: {or: [{name: ["is missing"]},
+                      {nickname: ["is missing"]},
+                      {alias: ["is missing"]},
+                      {favorite_food: ["is missing"]}]}
+        }
+      )
+    end
+  end
 end

--- a/spec/unit/dry/schema/message/or/multi_path_spec.rb
+++ b/spec/unit/dry/schema/message/or/multi_path_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "dry/schema/message"
+require "dry/schema/message/or/multi_path"
+
+RSpec.describe Dry::Schema::Message::Or::MultiPath do
+  def message(*path)
+    Dry::Schema::Message.new(
+      path: path,
+      text: "is missing",
+      predicate: :key?,
+      input: {}
+    )
+  end
+
+  describe "#to_h" do
+    it "works with two arrays of messages" do
+      result = described_class.new(
+        [message(:foo, :bar)],
+        [message(:foo, :baz)]
+      ).to_h
+
+      expect(result).to eq(
+        {
+          foo: {or: [{bar: ["is missing"]},
+                     {baz: ["is missing"]}]}
+        }
+      )
+    end
+
+    it "works with an array of messages and a MultiPath" do
+      result = described_class.new(
+        [message(:foo, :bar)],
+        described_class.new(
+          [message(:foo, :baz)],
+          [message(:foo, :qux)]
+        )
+      ).to_h
+
+      expect(result).to eq(
+        {
+          foo: {or: [{bar: ["is missing"]},
+                     {baz: ["is missing"]},
+                     {qux: ["is missing"]}]}
+        }
+      )
+    end
+
+    it "works with a MultiPath and an array of messages" do
+      result = described_class.new(
+        described_class.new(
+          [message(:foo, :baz)],
+          [message(:foo, :qux)]
+        ),
+        [message(:foo, :bar)]
+      ).to_h
+
+      expect(result).to eq(
+        {
+          foo: {or: [{baz: ["is missing"]},
+                     {qux: ["is missing"]},
+                     {bar: ["is missing"]}]}
+        }
+      )
+    end
+
+    it "works with a MultiPath with a different root and an array of messages" do
+      result = described_class.new(
+        described_class.new(
+          [message(:hello, :baz)],
+          [message(:hello, :qux)]
+        ),
+        [message(:foo, :bar)]
+      ).to_h
+
+      expect(result).to eq(
+        {
+          or: [{hello: {or: [{baz: ["is missing"]},
+                             {qux: ["is missing"]}]}},
+               {foo: {bar: ["is missing"]}}]
+        }
+      )
+    end
+
+    it "does not work with an unknown message type" do
+      expect { described_class.new(1, 2).to_h }
+        .to raise_error(ArgumentError, /1 is of unknown type Integer/)
+    end
+  end
+end


### PR DESCRIPTION
Add support for composing multiple schemata with `|`. Recognizes when
children are MultiPaths, and correctly merges branches if the roots are
the same.

Resolves #307.