### PR TITLE
Use main branch for dry-* gems in :test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ end
 gem "dry-types", github: "dry-rb/dry-types", branch: "main"
 
 group :test do
-  gem "dry-monads", require: false, github: "dry-rb/dry-monads"
-  gem "dry-struct", require: false, github: "dry-rb/dry-struct"
+  gem "dry-monads", require: false, github: "dry-rb/dry-monads", branch: "main"
+  gem "dry-struct", require: false, github: "dry-rb/dry-struct", branch: "main"
   gem "i18n", "1.8.2", require: false
   gem "transproc"
   gem "json-schema"


### PR DESCRIPTION
This was causing a failure locally when running `bundle install` because Bundler was attempting to use `master`.