### PR TITLE
Allow nested filled and value macro usage

### DIFF
--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -58,12 +58,13 @@ module Dry
         # @return [Macros::Core]
         #
         # @api public
-        def value(...)
-          append_macro(Macros::Value) do |macro|
-            macro.call(...)
+        def value(*args, **opts, &block)
+          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+            append_macro(Macros::Value) do |macro|
+              macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
+            end
           end
         end
-        ruby2_keywords :value if respond_to?(:ruby2_keywords, true)
 
         # Prepends `:filled?` predicate
         #
@@ -76,12 +77,13 @@ module Dry
         # @return [Macros::Core]
         #
         # @api public
-        def filled(...)
-          append_macro(Macros::Filled) do |macro|
-            macro.call(...)
+        def filled(*args, **opts, &block)
+          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+            append_macro(Macros::Filled) do |macro|
+              macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
+            end
           end
         end
-        ruby2_keywords :filled if respond_to?(:ruby2_keywords, true)
 
         # Specify a nested hash without enforced `hash?` type-check
         #

--- a/lib/dry/schema/macros/each.rb
+++ b/lib/dry/schema/macros/each.rb
@@ -11,13 +11,15 @@ module Dry
       # @api private
       class Each < DSL
         # @api private
-        def value(*args, **opts)
+        def value(*args, **opts, &block)
           extract_type_spec(*args, set_type: false) do |*predicates, type_spec:, type_rule:|
             if type_spec && !type_spec.is_a?(Dry::Types::Type)
               type(schema_dsl.array[type_spec])
             end
 
-            super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts)
+            append_macro(Macros::Value) do |macro|
+              macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
+            end
           end
         end
 

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -32,49 +32,6 @@ module Dry
         end
         ruby2_keywords(:filter) if respond_to?(:ruby2_keywords, true)
 
-        # @overload value(type_spec, *predicates, **predicate_opts)
-        #   Set type specification and predicates
-        #
-        #   @param [Symbol,Types::Type,Array] type_spec
-        #   @param [Array<Symbol>] predicates
-        #   @param [Hash] predicate_opts
-        #
-        #   @example with a predicate
-        #     required(:name).value(:string, :filled?)
-        #
-        #   @example with a predicate with arguments
-        #     required(:name).value(:string, min_size?: 2)
-        #
-        #   @example with a block
-        #     required(:name).value(:string) { filled? & min_size?(2) }
-        #
-        # @return [Macros::Key]
-        #
-        # @see Macros::DSL#value
-        #
-        # @api public
-        def value(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
-            super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
-          end
-        end
-
-        # Set type specification and predicates for a filled value
-        #
-        # @example
-        #   required(:name).filled(:string)
-        #
-        # @see Macros::Key#value
-        #
-        # @return [Macros::Key]
-        #
-        # @api public
-        def filled(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
-            super(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
-          end
-        end
-
         # Set type specification and predicates for a maybe value
         #
         # @example

--- a/spec/unit/dry/schema/macros/value_spec.rb
+++ b/spec/unit/dry/schema/macros/value_spec.rb
@@ -56,4 +56,26 @@ RSpec.describe Dry::Schema::Macros::Value do
       )
     end
   end
+
+  context "nesting without keys" do
+    subject(:schema) do
+      Dry::Schema.define do
+        required(:foo).value(:array).each do
+          value(:array).each do
+            value(:string)
+          end
+        end
+      end
+    end
+
+    it "passes when valid" do
+      expect(schema.(foo: [["bar"]])).to be_success
+    end
+
+    it "fails when invalid" do
+      expect(schema.(foo: 1).errors).to eql(foo: ["must be an array"])
+      expect(schema.(foo: [1]).errors).to eql(foo: {0 => ["must be an array"]})
+      expect(schema.(foo: [[1]]).errors).to eql(foo: {0 => {0 => ["must be a string"]}})
+    end
+  end
 end


### PR DESCRIPTION
All of the macros have access to the macro DSL. With a few small tweaks,
it's possible to make the macros apply to the values themselves,
allowing things like nested arrays to be validated without having to use
predicate logic.