### PR TITLE
Fix types and key maps for composed schemas

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -374,9 +374,7 @@ module Dry
       #
       # @api private
       def types
-        [*parents.map(&:types), @types].reduce({}) do |acc, types|
-          merge_types(Dry::Logic::Operations::And, acc, types)
-        end
+        [*parents.map(&:types), @types].reduce(:merge)
       end
 
       # @api private

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -365,7 +365,8 @@ module Dry
       # @api private
       def filter_rules?
         if instance_variable_defined?("@filter_schema_dsl") && !filter_schema_dsl.macros.empty?
-          return true end
+          return true
+        end
 
         parents.any?(&:filter_rules?)
       end
@@ -379,7 +380,7 @@ module Dry
 
       # @api private
       def merge_types(op_class, lhs, rhs)
-        type_merger.(op_class, lhs, rhs)
+        types_merger.(op_class, lhs, rhs)
       end
 
       protected
@@ -509,8 +510,8 @@ module Dry
         (parent || Schema).config.dup
       end
 
-      def type_merger
-        @type_merger ||= TypesMerger.new(type_registry)
+      def types_merger
+        @types_merger ||= TypesMerger.new(type_registry)
       end
     end
   end

--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -316,7 +316,7 @@ module Dry
         type = resolve_type(spec)
         meta = {required: false, maybe: type.optional?}
 
-        types[name] = type.meta(meta)
+        @types[name] = type.meta(meta)
       end
 
       # Check if a custom type was set under provided key name
@@ -367,6 +367,22 @@ module Dry
         end
 
         parents.any?(&:filter_rules?)
+      end
+
+      # This DSL's type map merged with any parent type maps
+      #
+      # @api private
+      def types
+        [*parents.map(&:types), @types].reduce({}) do |acc, types|
+          merge_types(acc, types)
+        end
+      end
+
+      # @api private
+      def merge_types(lhs, rhs)
+        lhs.merge(rhs) do |_, old, new|
+          old | new
+        end
       end
 
       protected

--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -51,7 +51,7 @@ module Dry
                 EMPTY_HASH.dup
               end
 
-            schema_dsl.merge_types(acc, types)
+            schema_dsl.merge_types(op.class, acc, types)
           end
         end
 

--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -30,18 +30,29 @@ module Dry
 
         # @api private
         def process_operation(op)
-          schemas = op.rules.select { |rule| rule.is_a?(Processor) }
-
-          hash_schema = hash_type.schema(
-            schemas.map(&:schema_dsl).map(&:types).reduce(:merge)
-          )
-
-          type(hash_schema)
+          type(hash_type.schema(merge_operation_types(op)))
         end
 
         # @api private
         def hash_type
           schema_dsl.resolve_type(:hash)
+        end
+
+        # @api private
+        def merge_operation_types(op)
+          op.rules.reduce({}) do |acc, rule|
+            types =
+              case rule
+              when Dry::Logic::Operations::Abstract
+                merge_operation_types(rule)
+              when Processor
+                rule.types
+              else
+                EMPTY_HASH.dup
+              end
+
+            schema_dsl.merge_types(acc, types)
+          end
         end
 
         # @api private

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -186,6 +186,13 @@ module Dry
         rule_applier.rules
       end
 
+      # Return the types from the schema DSL
+      #
+      # @api private
+      def types
+        schema_dsl.types
+      end
+
       # Check if there are filter rules
       #
       # @api private

--- a/lib/dry/schema/types_merger.rb
+++ b/lib/dry/schema/types_merger.rb
@@ -11,85 +11,122 @@ module Dry
     class TypesMerger
       attr_reader :type_registry
 
+      class ValueMerger
+        attr_reader :types_merger
+        attr_reader :op_class
+        attr_reader :old
+        attr_reader :new
+
+        def initialize(types_merger, op_class, old, new)
+          @types_merger = types_merger
+          @op_class = op_class
+          @old = old
+          @new = new
+        end
+
+        # @api private
+        def call
+          handlers.fetch(op_class).call
+        end
+
+        private
+
+        # @api private
+        def handlers
+          @handlers ||=
+            {
+              Dry::Logic::Operations::Or => method(:handle_or),
+              Dry::Logic::Operations::And => method(:handle_and),
+              Dry::Logic::Operations::Implication => method(:handle_implication)
+            }
+        end
+
+        # @api private
+        def handle_or
+          old | new
+        end
+
+        def handle_implication
+          handle_and
+        end
+
+        # @api private
+        def handle_and
+          return old if old == new
+
+          unwrapped_old, old_rule = unwrap_type(old)
+          unwrapped_new, new_rule = unwrap_type(new)
+
+          type = merge_underlying_types(unwrapped_old, unwrapped_new)
+
+          rule = [old_rule, new_rule].compact.reduce { op_class.new(_1, _2) }
+
+          type = Dry::Types::Constrained.new(type, rule: rule) if rule
+
+          type
+        end
+
+        # @api private
+        # rubocop:disable Metrics/PerceivedComplexity
+        def merge_underlying_types(unwrapped_old, unwrapped_new)
+          if unwrapped_old.is_a?(Dry::Types::Schema) &&
+             unwrapped_new.is_a?(Dry::Types::Schema)
+            types_merger.type_registry["hash"].schema(
+              types_merger.call(
+                op_class,
+                unwrapped_old.name_key_map,
+                unwrapped_new.name_key_map
+              )
+            )
+          elsif unwrapped_old.is_a?(Dry::Types::AnyClass) ||
+                (
+                  unwrapped_old.is_a?(Dry::Types::Hash) &&
+                    unwrapped_new.is_a?(Dry::Types::Schema)
+                )
+            unwrapped_new
+          elsif unwrapped_new.is_a?(Dry::Types::AnyClass) ||
+                (
+                  unwrapped_old.is_a?(Dry::Types::Schema) &&
+                    unwrapped_new.is_a?(Dry::Types::Hash)
+                )
+            unwrapped_old
+          elsif unwrapped_old.primitive == unwrapped_new.primitive
+            unwrapped_old
+          else
+            raise ArgumentError,
+                  "Can't merge types, unwrapped_old=#{unwrapped_old.inspect}, unwrapped_new=#{unwrapped_new.inspect}"
+          end
+        end
+
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        # @api private
+        def unwrap_type(type)
+          rules = []
+
+          while type.is_a?(Dry::Types::Decorator)
+            rules << type.rule if type.is_a?(Dry::Types::Constrained)
+
+            if type.meta[:maybe] & type.respond_to?(:right)
+              type = type.right
+            else
+              type = type.type
+            end
+          end
+
+          [type, rules.reduce(:&)]
+        end
+      end
+
       def initialize(type_registry = TypeRegistry.new)
         @type_registry = type_registry
       end
 
       # @api private
       def call(op_class, lhs, rhs)
-        fn = handlers.fetch(op_class)
-        lhs.merge(rhs) { |_k, lhs, rhs| fn.(op_class, lhs, rhs) }
-      end
-
-      private
-
-      # @api private
-      def handlers
-        @handlers ||= {
-          Dry::Logic::Operations::Or => method(:handle_or),
-          Dry::Logic::Operations::And => method(:handle_and),
-          Dry::Logic::Operations::Implication => method(:handle_and)
-        }
-      end
-
-      # @api private
-      def handle_or(_op_class, lhs, rhs)
-        lhs | rhs
-      end
-
-      # @api private
-      def handle_and(op_class, lhs, rhs)
-        return lhs if lhs == rhs
-
-        lhs, lhs_rule = unwrap_type(lhs)
-        rhs, rhs_rule = unwrap_type(rhs)
-
-        type = merge_underlying_types(op_class, lhs, rhs)
-
-        rule = [lhs_rule, rhs_rule].compact.reduce { op_class.new(_1, _2) }
-
-        type = Dry::Types::Constrained.new(type, rule: rule) if rule
-
-        type
-      end
-
-      # @api private
-      # rubocop:disable Metrics/PerceivedComplexity
-      def merge_underlying_types(op_class, lhs, rhs)
-        if lhs.is_a?(Dry::Types::Schema) && rhs.is_a?(Dry::Types::Schema)
-          type_registry["hash"].schema(
-            call(op_class, lhs.name_key_map, rhs.name_key_map)
-          )
-        elsif lhs.is_a?(Dry::Types::AnyClass) ||
-              (lhs.is_a?(Dry::Types::Hash) && rhs.is_a?(Dry::Types::Schema))
-          rhs
-        elsif rhs.is_a?(Dry::Types::AnyClass) ||
-              (lhs.is_a?(Dry::Types::Schema) && rhs.is_a?(Dry::Types::Hash))
-          lhs
-        elsif lhs.primitive == rhs.primitive
-          lhs
-        else
-          raise ArgumentError,
-                "Can't merge types, lhs=#{lhs.inspect}, rhs=#{rhs.inspect}"
+        lhs.merge(rhs) do |_k, old, new|
+          ValueMerger.new(self, op_class, old, new).call
         end
-      end
-      # rubocop:enable Metrics/PerceivedComplexity
-
-      # @api private
-      def unwrap_type(type)
-        rules = []
-
-        while type.is_a?(Dry::Types::Decorator)
-          rules << type.rule if type.is_a?(Dry::Types::Constrained)
-
-          if type.meta[:maybe] & type.respond_to?(:right)
-            type = type.right
-          else
-            type = type.type
-          end
-        end
-
-        [type, rules.reduce(:&)]
       end
     end
   end

--- a/lib/dry/schema/types_merger.rb
+++ b/lib/dry/schema/types_merger.rb
@@ -2,6 +2,10 @@
 
 module Dry
   module Schema
+    # Combines multiple logical operations into a single type, taking into
+    # account the type of logical operation (or, and, implication) and the
+    # underlying types (schemas, nominals, etc.)
+    #
     # @api private
     class TypesMerger
       attr_reader :type_registry

--- a/lib/dry/schema/types_merger.rb
+++ b/lib/dry/schema/types_merger.rb
@@ -1,22 +1,19 @@
 # frozen_string_literal: true
 
-require "dry/logic"
-require "dry/types"
-
-require "dry/schema/type_registry"
-
 module Dry
   module Schema
     # @api private
     class TypesMerger
       attr_reader :type_registry
 
+      # @api private
       class ValueMerger
         attr_reader :types_merger
         attr_reader :op_class
         attr_reader :old
         attr_reader :new
 
+        # @api private
         def initialize(types_merger, op_class, old, new)
           @types_merger = types_merger
           @op_class = op_class
@@ -93,8 +90,9 @@ module Dry
           elsif unwrapped_old.primitive == unwrapped_new.primitive
             unwrapped_old
           else
-            raise ArgumentError,
-                  "Can't merge types, unwrapped_old=#{unwrapped_old.inspect}, unwrapped_new=#{unwrapped_new.inspect}"
+            raise ArgumentError, <<~MESSAGE
+              Can't merge types, unwrapped_old=#{unwrapped_old.inspect}, unwrapped_new=#{unwrapped_new.inspect}
+            MESSAGE
           end
         end
 

--- a/lib/dry/schema/types_merger.rb
+++ b/lib/dry/schema/types_merger.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "dry/logic"
+require "dry/types"
+
+require "dry/schema/type_registry"
+
+module Dry
+  module Schema
+    # @api private
+    class TypesMerger
+      attr_reader :type_registry
+
+      def initialize(type_registry = TypeRegistry.new)
+        @type_registry = type_registry
+      end
+
+      # @api private
+      def call(op_class, lhs, rhs)
+        fn = handlers.fetch(op_class)
+        lhs.merge(rhs) { |_k, lhs, rhs| fn.(op_class, lhs, rhs) }
+      end
+
+      private
+
+      # @api private
+      def handlers
+        @handlers ||= {
+          Dry::Logic::Operations::Or => method(:handle_or),
+          Dry::Logic::Operations::And => method(:handle_and),
+          Dry::Logic::Operations::Implication => method(:handle_and)
+        }
+      end
+
+      # @api private
+      def handle_or(_op_class, lhs, rhs)
+        lhs | rhs
+      end
+
+      # @api private
+      def handle_and(op_class, lhs, rhs)
+        return lhs if lhs == rhs
+
+        lhs, lhs_rule = unwrap_type(lhs)
+        rhs, rhs_rule = unwrap_type(rhs)
+
+        type = merge_underlying_types(op_class, lhs, rhs)
+
+        rule = [lhs_rule, rhs_rule].compact.reduce { op_class.new(_1, _2) }
+
+        type = Dry::Types::Constrained.new(type, rule: rule) if rule
+
+        type
+      end
+
+      # @api private
+      # rubocop:disable Metrics/PerceivedComplexity
+      def merge_underlying_types(op_class, lhs, rhs)
+        if lhs.is_a?(Dry::Types::Schema) && rhs.is_a?(Dry::Types::Schema)
+          type_registry["hash"].schema(
+            call(op_class, lhs.name_key_map, rhs.name_key_map)
+          )
+        elsif lhs.is_a?(Dry::Types::AnyClass) ||
+              (lhs.is_a?(Dry::Types::Hash) && rhs.is_a?(Dry::Types::Schema))
+          rhs
+        elsif rhs.is_a?(Dry::Types::AnyClass) ||
+              (lhs.is_a?(Dry::Types::Schema) && rhs.is_a?(Dry::Types::Hash))
+          lhs
+        elsif lhs.primitive == rhs.primitive
+          lhs
+        else
+          raise ArgumentError,
+                "Can't merge types, lhs=#{lhs.inspect}, rhs=#{rhs.inspect}"
+        end
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      # @api private
+      def unwrap_type(type)
+        rules = []
+
+        while type.is_a?(Dry::Types::Decorator)
+          rules << type.rule if type.is_a?(Dry::Types::Constrained)
+
+          if type.meta[:maybe] & type.respond_to?(:right)
+            type = type.right
+          else
+            type = type.type
+          end
+        end
+
+        [type, rules.reduce(:&)]
+      end
+    end
+  end
+end

--- a/spec/integration/type_inheritance_spec.rb
+++ b/spec/integration/type_inheritance_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "inheriting from a parent and extending its rules" do
+  let(:parent) do
+    Dry::Schema.define do
+      required(:foo).filled(:hash?)
+    end
+  end
+
+  subject(:child) do
+    Dry::Schema.define(parent: [parent]) do
+      required(:foo).hash do
+        required(:qux).hash do
+          required(:bar).filled(:string)
+        end
+      end
+    end
+  end
+
+  it "correctly eliminates nested unknown keys" do
+    expect(
+      child.call({foo: {qux: {bar: "baz", hello: "there"}}}).to_h
+    ).to eq({foo: {qux: {bar: "baz"}}})
+  end
+end

--- a/spec/integration/type_inheritance_spec.rb
+++ b/spec/integration/type_inheritance_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "inheriting from a parent and extending its rules" do
         required(:foo).hash do
           required(:bar).hash do
             required(:baz).filled(:hash)
-            # required(:qux).filled(:hash)
+            required(:qux).filled(:hash)
           end
           required(:last).hash do
             required(:not).filled(:array).value(array[:string])

--- a/spec/integration/type_inheritance_spec.rb
+++ b/spec/integration/type_inheritance_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "inheriting from a parent and extending its rules" do
   context "one parent" do
     let(:parent) do
       Dry::Schema.define do
-        required(:foo).filled(:hash?)
+        required(:foo).filled(:hash)
       end
     end
 
@@ -60,8 +60,8 @@ RSpec.describe "inheriting from a parent and extending its rules" do
                 required(:amaze).value(array[:string], size?: 1)
               end
               required(:friend).hash do
-                required(:wow).filled(eql?: "c")
-                required(:such).filled(eql?: "cool")
+                required(:wow).filled(:string, eql?: "c")
+                required(:such).filled(:string, eql?: "cool")
                 required(:amaze).value(array[:string], size?: 1)
               end
             end

--- a/spec/integration/type_inheritance_spec.rb
+++ b/spec/integration/type_inheritance_spec.rb
@@ -1,25 +1,101 @@
 # frozen_string_literal: true
 
 RSpec.describe "inheriting from a parent and extending its rules" do
-  let(:parent) do
-    Dry::Schema.define do
-      required(:foo).filled(:hash?)
+  context "one parent" do
+    let(:parent) do
+      Dry::Schema.define do
+        required(:foo).filled(:hash?)
+      end
     end
-  end
 
-  subject(:child) do
-    Dry::Schema.define(parent: [parent]) do
-      required(:foo).hash do
-        required(:qux).hash do
-          required(:bar).filled(:string)
+    let(:child) do
+      Dry::Schema.define(parent: [parent]) do
+        required(:foo).hash do
+          required(:bar).hash do
+            required(:baz).filled(:string)
+          end
         end
       end
     end
+
+    it "correctly eliminates nested unknown keys" do
+      expect(
+        child.call({foo: {bar: {baz: "baz", hello: "there"}}}).to_h
+      ).to eq({foo: {bar: {baz: "baz"}}})
+    end
   end
 
-  it "correctly eliminates nested unknown keys" do
-    expect(
-      child.call({foo: {qux: {bar: "baz", hello: "there"}}}).to_h
-    ).to eq({foo: {qux: {bar: "baz"}}})
+  context "two parents" do
+    let(:parent_2) do
+      Dry::Schema.JSON do
+        required(:foo).hash do
+          required(:bar).hash do
+            required(:baz).filled(:hash)
+            # required(:qux).filled(:hash)
+          end
+          required(:last).hash do
+            required(:not).filled(:array).value(array[:string])
+            required(:least).filled(:string)
+          end
+        end
+      end
+    end
+
+    let(:parent_1) do
+      Dry::Schema.JSON do
+        required(:foo).filled.hash do
+          required(:bar).hash do
+            required(:baz).hash do
+              required(:hey).filled(:hash)
+            end
+            required(:qux).hash do
+              required(:hello).hash do
+                required(:wow).value(:string, eql?: "a")
+                required(:such).value(:string, eql?: "cool")
+                required(:amaze).value(array[:string], size?: 1)
+              end
+              required(:my).hash do
+                required(:wow).value(:string, eql?: "b")
+                required(:such).value(:string, eql?: "cool")
+                required(:amaze).value(array[:string], size?: 1)
+              end
+              required(:friend).hash do
+                required(:wow).filled(eql?: "c")
+                required(:such).filled(eql?: "cool")
+                required(:amaze).value(array[:string], size?: 1)
+              end
+            end
+          end
+          required(:last).filled.hash do
+            required(:not).value(:array, eql?: ["rad"])
+            required(:least).value(:string, eql?: "done")
+          end
+        end
+      end
+    end
+
+    let(:child) do
+      Dry::Schema.JSON(parent: [parent_2, parent_1])
+    end
+
+    it "correctly joins nested hashes" do
+      attrs = {
+        foo: {
+          bar: {
+            baz: {hey: {some: "hash"}},
+            qux: {
+              hello: {wow: "a", such: "cool", amaze: ["yup"]},
+              my: {wow: "b", such: "cool", amaze: ["yep"]},
+              friend: {wow: "c", such: "cool", amaze: ["yip"]}
+            }
+          },
+          last: {not: ["rad"], least: "done"}
+        }
+      }
+
+      result = child.call(attrs)
+      expect(result).to be_success
+      expect(result.to_h).to eq(attrs)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require_relative "support/rspec_options"
 
 Warning.ignore(%r{gems/i18n})
 Warning.ignore(/byebug/)
-Warning.process { |w| raise w }
+# Warning.process { |w| raise w }
 
 begin
   require "pry-byebug"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require_relative "support/rspec_options"
 
 Warning.ignore(%r{gems/i18n})
 Warning.ignore(/byebug/)
-# Warning.process { |w| raise w }
+Warning.process { |w| raise w }
 
 begin
   require "pry-byebug"

--- a/spec/unit/dry/schema/types_merger_spec.rb
+++ b/spec/unit/dry/schema/types_merger_spec.rb
@@ -1,0 +1,380 @@
+# frozen_string_literal: true
+
+require "dry/types"
+require "dry/logic"
+
+require "dry/schema/types_merger"
+require "dry/schema/type_registry"
+
+RSpec.describe Dry::Schema::TypesMerger do
+  let(:t) { Dry.Types }
+
+  subject(:types_merger) { Dry::Schema::TypesMerger.new }
+
+  describe "#call" do
+    context Dry::Logic::Operations::Or do
+      it "joins types with |" do
+        expect(
+          types_merger
+            .call(
+              Dry::Logic::Operations::Or,
+              {foo: t::Integer, bar: t::Integer},
+              {foo: t::String}
+            )
+            .transform_values(&:to_ast)
+        ).to eq(
+          {
+            foo: [
+              :sum,
+              [
+                [
+                  :constrained,
+                  [
+                    [:nominal, [Integer, {}]],
+                    [
+                      :predicate,
+                      [:type?, [[:type, Integer], [:input, Undefined]]]
+                    ]
+                  ]
+                ],
+                [
+                  :constrained,
+                  [
+                    [:nominal, [String, {}]],
+                    [
+                      :predicate,
+                      [:type?, [[:type, String], [:input, Undefined]]]
+                    ]
+                  ]
+                ],
+                {}
+              ]
+            ],
+            bar: [
+              :constrained,
+              [
+                [:nominal, [Integer, {}]],
+                [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]]
+              ]
+            ]
+          }
+        )
+      end
+    end
+
+    context Dry::Logic::Operations::And do
+      it "applies all when keys collide" do
+        expect(
+          types_merger
+            .call(
+              Dry::Logic::Operations::And,
+              {foo: t::Integer.constrained(gteq: 1)},
+              {foo: t::Integer.constrained(lteq: 3)}
+            )
+            .transform_values(&:to_ast)
+        ).to eq(
+          {
+            foo: [
+              :constrained,
+              [
+                [:nominal, [Integer, {}]],
+                [
+                  :and,
+                  [
+                    [
+                      :and,
+                      [
+                        [
+                          :predicate,
+                          [:type?, [[:type, Integer], [:input, Undefined]]]
+                        ],
+                        [:predicate, [:gteq?, [[:num, 1], [:input, Undefined]]]]
+                      ]
+                    ],
+                    [
+                      :and,
+                      [
+                        [
+                          :predicate,
+                          [:type?, [[:type, Integer], [:input, Undefined]]]
+                        ],
+                        [:predicate, [:lteq?, [[:num, 3], [:input, Undefined]]]]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          }
+        )
+      end
+
+      it "merges schema types on collision" do
+        expect(
+          types_merger
+            .call(
+              Dry::Logic::Operations::And,
+              {foo: t::Hash.schema(bar: t::Integer)},
+              {foo: t::Hash.schema(baz: t::Integer)}
+            )
+            .transform_values(&:to_ast)
+        ).to eq(
+          {
+            foo: [
+              :constrained,
+              [
+                [
+                  :constrained,
+                  [
+                    [
+                      :schema,
+                      [
+                        [
+                          [
+                            :key,
+                            [
+                              :bar,
+                              true,
+                              [
+                                :key,
+                                [
+                                  :bar,
+                                  true,
+                                  [
+                                    :constrained,
+                                    [
+                                      [:nominal, [Integer, {}]],
+                                      [
+                                        :predicate,
+                                        [
+                                          :type?,
+                                          [
+                                            [:type, Integer],
+                                            [:input, Undefined]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ],
+                          [
+                            :key,
+                            [
+                              :baz,
+                              true,
+                              [
+                                :key,
+                                [
+                                  :baz,
+                                  true,
+                                  [
+                                    :constrained,
+                                    [
+                                      [:nominal, [Integer, {}]],
+                                      [
+                                        :predicate,
+                                        [
+                                          :type?,
+                                          [
+                                            [:type, Integer],
+                                            [:input, Undefined]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ],
+                        {},
+                        {}
+                      ]
+                    ],
+                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
+                  ]
+                ],
+                [
+                  :and,
+                  [
+                    [
+                      :predicate,
+                      [:type?, [[:type, Hash], [:input, Undefined]]]
+                    ],
+                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
+                  ]
+                ]
+              ]
+            ]
+          }
+        )
+      end
+
+      it "uses the rhs if the lhs is an Any" do
+        expect(
+          types_merger
+            .call(
+              Dry::Logic::Operations::And,
+              {foo: t::Any},
+              {foo: t::Integer}
+            )
+            .transform_values(&:to_ast)
+        ).to eq(
+          {
+            foo: [
+              :constrained,
+              [
+                [:nominal, [Integer, {}]],
+                [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]]
+              ]
+            ]
+          }
+        )
+      end
+
+      it "uses the rhs if the rhs is a subclass of lhs" do
+        expect(
+          types_merger
+            .call(
+              Dry::Logic::Operations::And,
+              {foo: t::Hash},
+              {foo: t::Hash.schema(bar: t::Integer)}
+            )
+            .transform_values(&:to_ast)
+        ).to eq(
+          {
+            foo: [
+              :constrained,
+              [
+                [
+                  :schema,
+                  [
+                    [
+                      [
+                        :key,
+                        [
+                          :bar,
+                          true,
+                          [
+                            :constrained,
+                            [
+                              [:nominal, [Integer, {}]],
+                              [
+                                :predicate,
+                                [
+                                  :type?,
+                                  [[:type, Integer], [:input, Undefined]]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ],
+                    {},
+                    {}
+                  ]
+                ],
+                [
+                  :and,
+                  [
+                    [
+                      :predicate,
+                      [:type?, [[:type, Hash], [:input, Undefined]]]
+                    ],
+                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
+                  ]
+                ]
+              ]
+            ]
+          }
+        )
+      end
+
+      it "uses the lhs if the rhs is an Any" do
+        expect(
+          types_merger
+            .call(
+              Dry::Logic::Operations::And,
+              {foo: t::Integer},
+              {foo: t::Any}
+            )
+            .transform_values(&:to_ast)
+        ).to eq(
+          {
+            foo: [
+              :constrained,
+              [
+                [:nominal, [Integer, {}]],
+                [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]]
+              ]
+            ]
+          }
+        )
+      end
+
+      it "uses the lhs if the lhs is a subclass of rhs" do
+        expect(
+          types_merger
+            .call(
+              Dry::Logic::Operations::And,
+              {foo: t::Hash.schema(bar: t::Integer)},
+              {foo: t::Hash}
+            )
+            .transform_values(&:to_ast)
+        ).to eq(
+          {
+            foo: [
+              :constrained,
+              [
+                [
+                  :schema,
+                  [
+                    [
+                      [
+                        :key,
+                        [
+                          :bar,
+                          true,
+                          [
+                            :constrained,
+                            [
+                              [:nominal, [Integer, {}]],
+                              [
+                                :predicate,
+                                [
+                                  :type?,
+                                  [[:type, Integer], [:input, Undefined]]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ],
+                    {},
+                    {}
+                  ]
+                ],
+                [
+                  :and,
+                  [
+                    [
+                      :predicate,
+                      [:type?, [[:type, Hash], [:input, Undefined]]]
+                    ],
+                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
+                  ]
+                ]
+              ]
+            ]
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two issues addressed here:
* The DSL types hash did not merge in parent types. Override the types
  accessors with one that merges in parent types.
* Operation processing within Macros::Schema did not recursively merge
  any nested operations.

These fixes allow for different key sets to be processed correctly.