### PR TITLE
Fix for filled + constrained constructor type

### DIFF
--- a/lib/dry/schema/macros/array.rb
+++ b/lib/dry/schema/macros/array.rb
@@ -15,7 +15,7 @@ module Dry
         def value(*args, **opts, &block)
           type(:array)
 
-          extract_type_spec(*args, set_type: false) do |*predicates, type_spec:, type_rule:|
+          extract_type_spec(args, set_type: false) do |*predicates, type_spec:, type_rule:|
             type(schema_dsl.array[type_spec]) if type_spec
 
             is_hash_block = type_spec.equal?(:hash)

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -57,7 +57,7 @@ module Dry
         #
         # @api public
         def value(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+          extract_type_spec(args) do |*predicates, type_spec:, type_rule:|
             append_macro(Macros::Value) do |macro|
               macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
             end
@@ -76,7 +76,7 @@ module Dry
         #
         # @api public
         def filled(*args, **opts, &block)
-          extract_type_spec(*args) do |*predicates, type_spec:, type_rule:|
+          extract_type_spec(args) do |*predicates, type_spec:, type_rule:|
             append_macro(Macros::Filled) do |macro|
               macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
             end
@@ -201,7 +201,7 @@ module Dry
 
         # @api private
         # rubocop: disable Metrics/PerceivedComplexity
-        def extract_type_spec(*args, nullable: false, set_type: true)
+        def extract_type_spec(args, nullable: false, set_type: true)
           type_spec = args[0] unless schema_or_predicate?(args[0])
 
           predicates = Array(type_spec ? args[1..] : args)

--- a/lib/dry/schema/macros/each.rb
+++ b/lib/dry/schema/macros/each.rb
@@ -11,7 +11,7 @@ module Dry
       class Each < DSL
         # @api private
         def value(*args, **opts, &block)
-          extract_type_spec(*args, set_type: false) do |*predicates, type_spec:, type_rule:|
+          extract_type_spec(args, set_type: false) do |*predicates, type_spec:, type_rule:|
             if type_spec && !type_spec.is_a?(Dry::Types::Type)
               type(schema_dsl.array[type_spec])
             end

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -43,7 +43,7 @@ module Dry
         #
         # @api public
         def maybe(*args, **opts, &block)
-          extract_type_spec(*args, nullable: true) do |*predicates, type_spec:, type_rule:|
+          extract_type_spec(args, nullable: true) do |*predicates, type_spec:, type_rule:|
             append_macro(Macros::Maybe) do |macro|
               macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
             end


### PR DESCRIPTION
Since extract_type_spec was receiving *args, the splat could possibly
include something interpreted as a keyword arg (at least on Ruby 2.7.x).
Make extract_type_spec take an unambiguous array.