### PR TITLE
Custom sum types fail in main

### DIFF
--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -70,6 +70,24 @@ RSpec.describe "Registering custom types" do
         expect(result[:age]).to eql("i am not that old")
       end
     end
+
+    context "maybe decimal" do
+      let(:klass) do
+        class Test::CustomTypeSchema < Dry::Schema::JSON
+          define do
+            required(:number).maybe(Types::JSON::Decimal | Types::Params::Nil)
+          end
+        end
+      end
+
+      let(:params) do
+        { number: "19.3" }
+      end
+
+      it "coerces the type" do
+        expect(result[:number]).to eql(BigDecimal('19.3'))
+      end
+    end
   end
 
   context "DSL-based definition" do


### PR DESCRIPTION
The spec in this PR works in 1.9.3 but fails in our main branch with the following backtrace
```
  1) Registering custom types class-based definition maybe decimal coerces the type
     Failure/Error: types.registered?(key) ? types[key] : types[name.to_s]
     
     Dry::Container::KeyError:
       key not found: "decimal?"
       Did you mean?  "decimal"
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/dry-container-0.10.1/lib/dry/container/resolver.rb:31:in `block in call'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/dry-container-0.10.1/lib/dry/container/resolver.rb:27:in `fetch'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/dry-container-0.10.1/lib/dry/container/resolver.rb:27:in `call'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/dry-container-0.10.1/lib/dry/container/mixin.rb:171:in `resolve'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/dry-container-0.10.1/lib/dry/container/mixin.rb:184:in `[]'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/bundler/gems/dry-types-8713a790a94f/lib/dry/types.rb:97:in `block in []'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:203:in `block in fetch_or_store'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:182:in `fetch'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:202:in `fetch_or_store'
     # /Users/gordon/.rvm/gems/ruby-3.1.2@dry-schema/bundler/gems/dry-types-8713a790a94f/lib/dry/types.rb:88:in `[]'
     # ./lib/dry/schema/type_registry.rb:40:in `[]'
```
I had a quick look and it seems it's related to changes around here https://github.com/dry-rb/dry-schema/blob/main/lib/dry/schema/macros/dsl.rb#L61-L67