### PR TITLE
Or::SinglePath and Or::MultPath robustness fixes

### DIFF
--- a/lib/dry/schema/message/or/multi_path.rb
+++ b/lib/dry/schema/message/or/multi_path.rb
@@ -34,17 +34,17 @@ module Dry
             end
           end
 
-          # @api private
-          def self.handler(message)
-            handlers.find { |k,| message.is_a?(k) }&.last
-          end
+          MULTI_PATH_HANDLER = -> { _1 }
+          MESSAGE_ARRAY_HANDLER = -> { MessageArray.new(_1) }
 
           # @api private
-          private_class_method def self.handlers
-            @handlers ||= {
-              self => :itself.to_proc,
-              Array => MessageArray.method(:new)
-            }.freeze
+          def self.handler(message)
+            case message
+            when self
+              MULTI_PATH_HANDLER
+            when Array
+              MESSAGE_ARRAY_HANDLER
+            end
           end
 
           # @api public

--- a/lib/dry/schema/message/or/multi_path.rb
+++ b/lib/dry/schema/message/or/multi_path.rb
@@ -34,14 +34,13 @@ module Dry
             end
           end
 
-          MULTI_PATH_HANDLER = -> { _1 }
           MESSAGE_ARRAY_HANDLER = -> { MessageArray.new(_1) }
 
           # @api private
           def self.handler(message)
             case message
             when self
-              MULTI_PATH_HANDLER
+              IDENTITY
             when Array
               MESSAGE_ARRAY_HANDLER
             end

--- a/lib/dry/schema/message/or/single_path.rb
+++ b/lib/dry/schema/message/or/single_path.rb
@@ -21,10 +21,11 @@ module Dry
 
           # @api private
           def initialize(*args, messages)
-            super(*args)
+            super(*args.map { [_1].flatten })
             @messages = messages
-            @path = left.path
-            @_path = left._path
+            message = left.first
+            @path = message.path
+            @_path = message._path
           end
 
           # Dump a message into a string
@@ -38,7 +39,7 @@ module Dry
           #
           # @api public
           def dump
-            @dump ||= "#{left.dump} #{messages[:or]} #{right.dump}"
+            @dump ||= [*left, *right].map(&:dump).join(" #{messages[:or]} ")
           end
           alias_method :to_s, :dump
 
@@ -55,7 +56,16 @@ module Dry
 
           # @api private
           def to_a
-            @to_a ||= [left, right]
+            @to_a ||= [*left, *right]
+          end
+
+          # @api private
+          def to_or(root)
+            to_ored = [left, right].map do |msgs|
+              msgs.map { _1.to_or(root) }
+            end
+
+            self.class.new(*to_ored, messages)
           end
         end
       end


### PR DESCRIPTION
It's possible for left and right to be an array of messages when
creating an Or::SinglePath, and it's possible for an Or::MultiPath to
contain an Or::SinglePath. Adds the following fixes:

* Turn left and right into flattened arrays when constructing
  Or::SinglePaths, then extract one of the paths (they should all be
  the same). Update all methods to handle arrays of messages.
* Implement to_or on Or::SinglePath, as they may end up in
  Or::MultiPaths.
* Simplify Or::MultiPath.handler to just use a case statement. The
  hash-based dispatch was unnecessarily complex.