### PR TITLE
Fix value coercion for composed schemas

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -288,13 +288,20 @@ module Dry
 
       # Return type schema used by the value coercer
       #
-      # @return [Dry::Types::Safe]
+      # @return [Dry::Types::Lax]
       #
       # @api private
       def type_schema
-        our_schema = type_registry["hash"].schema(types).lax
-        schemas = [*parents.map(&:type_schema), our_schema]
-        schemas.inject { |result, schema| result.schema(schema.to_a) }
+        strict_type_schema.lax
+      end
+
+      # Return type schema used when composing subschemas
+      #
+      # @return [Dry::Types::Schema]
+      #
+      # @api private
+      def strict_type_schema
+        type_registry["hash"].schema(types)
       end
 
       # Return a new DSL instance using the same processor type
@@ -316,7 +323,7 @@ module Dry
       # @api private
       def set_type(name, spec)
         type = resolve_type(spec)
-        meta = {required: false, maybe: type.optional?}
+        meta = {required: true, maybe: type.optional?}
 
         @types[name] = type.meta(meta)
       end

--- a/lib/dry/schema/macros/schema.rb
+++ b/lib/dry/schema/macros/schema.rb
@@ -62,11 +62,11 @@ module Dry
           schema = definition.call
           type_schema =
             if array_type?(parent_type)
-              build_array_type(parent_type, definition.type_schema)
+              build_array_type(parent_type, definition.strict_type_schema)
             elsif redefined_schema?(args)
               parent_type.schema(definition.types)
             else
-              definition.type_schema
+              definition.strict_type_schema
             end
           final_type = optional? ? type_schema.optional : type_schema
 

--- a/lib/dry/schema/macros/value.rb
+++ b/lib/dry/schema/macros/value.rb
@@ -30,9 +30,9 @@ module Dry
 
             updated_type =
               if array_type?(current_type)
-                build_array_type(current_type, schema.type_schema)
+                build_array_type(current_type, schema.strict_type_schema)
               else
-                schema.type_schema
+                schema.strict_type_schema
               end
 
             import_steps(schema)

--- a/lib/dry/schema/processor.rb
+++ b/lib/dry/schema/processor.rb
@@ -136,11 +136,20 @@ module Dry
 
       # Return the type schema
       #
-      # @return [Dry::Types::Safe]
+      # @return [Dry::Types::Lax]
       #
       # @api private
       def type_schema
         steps.type_schema
+      end
+
+      # Return type schema used when composing subschemas
+      #
+      # @return [Dry::Types::Schema]
+      #
+      # @api private
+      def strict_type_schema
+        schema_dsl.strict_type_schema
       end
 
       # Return the rule applier

--- a/lib/dry/schema/types_merger.rb
+++ b/lib/dry/schema/types_merger.rb
@@ -118,7 +118,7 @@ module Dry
             end
           end
 
-          [type, rules.reduce { |acc, rule| op_class.new(acc, rule) }]
+          [type, rules.reduce(:&)]
         end
       end
 

--- a/lib/dry/schema/types_merger.rb
+++ b/lib/dry/schema/types_merger.rb
@@ -108,13 +108,15 @@ module Dry
         def unwrap_type(type)
           rules = []
 
-          while type.is_a?(Dry::Types::Decorator)
-            rules << type.rule if type.is_a?(Dry::Types::Constrained)
+          loop do
+            rules << type.rule if type.respond_to?(:rule)
 
-            if type.meta[:maybe] & type.respond_to?(:right)
-              type = type.right
-            else
+            if type.optional?
+              type = type.left.primitive?(nil) ? type.right : type.left
+            elsif type.is_a?(Dry::Types::Decorator)
               type = type.type
+            else
+              break
             end
           end
 

--- a/lib/dry/schema/types_merger.rb
+++ b/lib/dry/schema/types_merger.rb
@@ -27,34 +27,34 @@ module Dry
 
         # @api private
         def call
-          handlers.fetch(op_class).call
+          if op_class <= Dry::Logic::Operations::Or
+            merge_or
+          elsif op_class <= Dry::Logic::Operations::And
+            merge_and
+          elsif op_class <= Dry::Logic::Operations::Implication
+            merge_implication
+          else
+            raise ArgumentError, <<~MESSAGE
+              Can't merge operations, op_class=#{op_class}
+            MESSAGE
+          end
         end
 
         private
 
         # @api private
-        def handlers
-          @handlers ||=
-            {
-              Dry::Logic::Operations::Or => method(:handle_or),
-              Dry::Logic::Operations::And => method(:handle_and),
-              Dry::Logic::Operations::Implication => method(:handle_implication)
-            }
-        end
-
-        # @api private
-        def handle_or
+        def merge_or
           old | new
         end
 
         # @api private
-        def handle_ordered
+        def merge_ordered
           return old if old == new
 
           unwrapped_old, old_rule = unwrap_type(old)
           unwrapped_new, new_rule = unwrap_type(new)
 
-          type = merge_underlying_types(unwrapped_old, unwrapped_new)
+          type = merge_unwrapped_types(unwrapped_old, unwrapped_new)
 
           rule = [old_rule, new_rule].compact.reduce { op_class.new(_1, _2) }
 
@@ -63,32 +63,44 @@ module Dry
           type
         end
 
-        alias_method :handle_and, :handle_ordered
-        alias_method :handle_implication, :handle_ordered
+        alias_method :merge_and, :merge_ordered
+        alias_method :merge_implication, :merge_ordered
 
         # @api private
-        def merge_underlying_types(unwrapped_old, unwrapped_new)
+        def merge_unwrapped_types(unwrapped_old, unwrapped_new)
           case [unwrapped_old, unwrapped_new]
           in Dry::Types::Schema, Dry::Types::Schema
-            types_merger.type_registry["hash"].schema(
-              types_merger.call(
-                op_class,
-                unwrapped_old.name_key_map,
-                unwrapped_new.name_key_map
-              )
-            )
+            merge_schemas(unwrapped_old, unwrapped_new)
           in [Dry::Types::AnyClass, _] | [Dry::Types::Hash, Dry::Types::Schema]
             unwrapped_new
-          in [Dry::Types::Hash, Dry::Types::Schema] | [_, Dry::Types::AnyClass]
+          in [Dry::Types::Schema, Dry::Types::Hash] | [_, Dry::Types::AnyClass]
             unwrapped_old
           else
-            if unwrapped_old.primitive != unwrapped_new.primitive
-              raise ArgumentError, <<~MESSAGE
-                Can't merge types, unwrapped_old=#{unwrapped_old.inspect}, unwrapped_new=#{unwrapped_new.inspect}
-              MESSAGE
-            end
+            merge_equivalent_types(unwrapped_old, unwrapped_new)
+          end
+        end
 
+        # @api private
+        def merge_schemas(unwrapped_old, unwrapped_new)
+          types_merger.type_registry["hash"].schema(
+            types_merger.call(
+              op_class,
+              unwrapped_old.name_key_map,
+              unwrapped_new.name_key_map
+            )
+          )
+        end
+
+        # @api private
+        def merge_equivalent_types(unwrapped_old, unwrapped_new)
+          if unwrapped_old.primitive <= unwrapped_new.primitive
+            unwrapped_new
+          elsif unwrapped_new.primitive <= unwrapped_old.primitive
             unwrapped_old
+          else
+            raise ArgumentError, <<~MESSAGE
+              Can't merge types, unwrapped_old=#{unwrapped_old.inspect}, unwrapped_new=#{unwrapped_new.inspect}
+            MESSAGE
           end
         end
 
@@ -106,7 +118,7 @@ module Dry
             end
           end
 
-          [type, rules.reduce(:&)]
+          [type, rules.reduce { |acc, rule| op_class.new(acc, rule) }]
         end
       end
 

--- a/spec/unit/dry/schema/types_merger_spec.rb
+++ b/spec/unit/dry/schema/types_merger_spec.rb
@@ -7,19 +7,17 @@ require "dry/schema/types_merger"
 require "dry/schema/type_registry"
 
 RSpec.describe Dry::Schema::TypesMerger do
-  let(:t) { Dry.Types }
-
   subject(:types_merger) { Dry::Schema::TypesMerger.new }
 
   describe "#call" do
     context Dry::Logic::Operations::Or do
-      it "joins types with |" do
+      it "applies all when keys collide" do
         expect(
           types_merger
             .call(
               Dry::Logic::Operations::Or,
-              {foo: t::Integer, bar: t::Integer},
-              {foo: t::String}
+              {foo: Types::Integer, bar: Types::Integer},
+              {foo: Types::String}
             )
             .transform_values(&:to_ast)
         ).to eq(
@@ -68,8 +66,8 @@ RSpec.describe Dry::Schema::TypesMerger do
           types_merger
             .call(
               Dry::Logic::Operations::And,
-              {foo: t::Integer.constrained(gteq: 1)},
-              {foo: t::Integer.constrained(lteq: 3)}
+              {foo: Types::Integer.constrained(gteq: 1)},
+              {foo: Types::Integer.constrained(lteq: 3)}
             )
             .transform_values(&:to_ast)
         ).to eq(
@@ -114,8 +112,8 @@ RSpec.describe Dry::Schema::TypesMerger do
           types_merger
             .call(
               Dry::Logic::Operations::And,
-              {foo: t::Hash.schema(bar: t::Integer)},
-              {foo: t::Hash.schema(baz: t::Integer)}
+              {foo: Types::Hash.schema(bar: Types::Integer)},
+              {foo: Types::Hash.schema(baz: Types::Integer)}
             )
             .transform_values(&:to_ast)
         ).to eq(
@@ -219,8 +217,8 @@ RSpec.describe Dry::Schema::TypesMerger do
           types_merger
             .call(
               Dry::Logic::Operations::And,
-              {foo: t::Any},
-              {foo: t::Integer}
+              {foo: Types::Any},
+              {foo: Types::Integer}
             )
             .transform_values(&:to_ast)
         ).to eq(
@@ -241,8 +239,8 @@ RSpec.describe Dry::Schema::TypesMerger do
           types_merger
             .call(
               Dry::Logic::Operations::And,
-              {foo: t::Hash},
-              {foo: t::Hash.schema(bar: t::Integer)}
+              {foo: Types::Hash},
+              {foo: Types::Hash.schema(bar: Types::Integer)}
             )
             .transform_values(&:to_ast)
         ).to eq(
@@ -300,8 +298,8 @@ RSpec.describe Dry::Schema::TypesMerger do
           types_merger
             .call(
               Dry::Logic::Operations::And,
-              {foo: t::Integer},
-              {foo: t::Any}
+              {foo: Types::Integer},
+              {foo: Types::Any}
             )
             .transform_values(&:to_ast)
         ).to eq(
@@ -322,8 +320,8 @@ RSpec.describe Dry::Schema::TypesMerger do
           types_merger
             .call(
               Dry::Logic::Operations::And,
-              {foo: t::Hash.schema(bar: t::Integer)},
-              {foo: t::Hash}
+              {foo: Types::Hash.schema(bar: Types::Integer)},
+              {foo: Types::Hash}
             )
             .transform_values(&:to_ast)
         ).to eq(

--- a/spec/unit/dry/schema/types_merger_spec.rb
+++ b/spec/unit/dry/schema/types_merger_spec.rb
@@ -60,95 +60,136 @@ RSpec.describe Dry::Schema::TypesMerger do
       end
     end
 
-    context Dry::Logic::Operations::And do
-      it "applies all when keys collide" do
-        expect(
-          types_merger
-            .call(
-              Dry::Logic::Operations::And,
-              {foo: Types::Integer.constrained(gteq: 1)},
-              {foo: Types::Integer.constrained(lteq: 3)}
-            )
-            .transform_values(&:to_ast)
-        ).to eq(
-          {
-            foo: [
-              :constrained,
-              [
-                [:nominal, [Integer, {}]],
+    [
+      [Dry::Logic::Operations::And, :and],
+      [Dry::Logic::Operations::Implication, :implication]
+    ].each do |op_class, op_node_type|
+      context op_class do
+        it "applies all when keys collide" do
+          expect(
+            types_merger
+              .call(
+                op_class,
+                {foo: Types::Integer.constrained(gteq: 1)},
+                {foo: Types::Integer.constrained(lteq: 3)}
+              )
+              .transform_values(&:to_ast)
+          ).to eq(
+            {
+              foo: [
+                :constrained,
                 [
-                  :and,
+                  [:nominal, [Integer, {}]],
                   [
+                    op_node_type,
                     [
-                      :and,
                       [
+                        :and,
                         [
-                          :predicate,
-                          [:type?, [[:type, Integer], [:input, Undefined]]]
-                        ],
-                        [:predicate, [:gteq?, [[:num, 1], [:input, Undefined]]]]
-                      ]
-                    ],
-                    [
-                      :and,
+                          [
+                            :predicate,
+                            [:type?, [[:type, Integer], [:input, Undefined]]]
+                          ],
+                          [
+                            :predicate,
+                            [:gteq?, [[:num, 1], [:input, Undefined]]]
+                          ]
+                        ]
+                      ],
                       [
+                        :and,
                         [
-                          :predicate,
-                          [:type?, [[:type, Integer], [:input, Undefined]]]
-                        ],
-                        [:predicate, [:lteq?, [[:num, 3], [:input, Undefined]]]]
+                          [
+                            :predicate,
+                            [:type?, [[:type, Integer], [:input, Undefined]]]
+                          ],
+                          [
+                            :predicate,
+                            [:lteq?, [[:num, 3], [:input, Undefined]]]
+                          ]
+                        ]
                       ]
                     ]
                   ]
                 ]
               ]
-            ]
-          }
-        )
-      end
+            }
+          )
+        end
 
-      it "merges schema types on collision" do
-        expect(
-          types_merger
-            .call(
-              Dry::Logic::Operations::And,
-              {foo: Types::Hash.schema(bar: Types::Integer)},
-              {foo: Types::Hash.schema(baz: Types::Integer)}
-            )
-            .transform_values(&:to_ast)
-        ).to eq(
-          {
-            foo: [
-              :constrained,
-              [
+        it "merges schema types on collision" do
+          expect(
+            types_merger
+              .call(
+                op_class,
+                {foo: Types::Hash.schema(bar: Types::Integer)},
+                {foo: Types::Hash.schema(baz: Types::Integer)}
+              )
+              .transform_values(&:to_ast)
+          ).to eq(
+            {
+              foo: [
+                :constrained,
                 [
-                  :constrained,
                   [
+                    :constrained,
                     [
-                      :schema,
                       [
+                        :schema,
                         [
                           [
-                            :key,
                             [
-                              :bar,
-                              true,
+                              :key,
                               [
-                                :key,
+                                :bar,
+                                true,
                                 [
-                                  :bar,
-                                  true,
+                                  :key,
                                   [
-                                    :constrained,
+                                    :bar,
+                                    true,
                                     [
-                                      [:nominal, [Integer, {}]],
+                                      :constrained,
                                       [
-                                        :predicate,
+                                        [:nominal, [Integer, {}]],
                                         [
-                                          :type?,
+                                          :predicate,
                                           [
-                                            [:type, Integer],
-                                            [:input, Undefined]
+                                            :type?,
+                                            [
+                                              [:type, Integer],
+                                              [:input, Undefined]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ],
+                            [
+                              :key,
+                              [
+                                :baz,
+                                true,
+                                [
+                                  :key,
+                                  [
+                                    :baz,
+                                    true,
+                                    [
+                                      :constrained,
+                                      [
+                                        [:nominal, [Integer, {}]],
+                                        [
+                                          :predicate,
+                                          [
+                                            :type?,
+                                            [
+                                              [:type, Integer],
+                                              [:input, Undefined]
+                                            ]
                                           ]
                                         ]
                                       ]
@@ -158,220 +199,378 @@ RSpec.describe Dry::Schema::TypesMerger do
                               ]
                             ]
                           ],
+                          {},
+                          {}
+                        ]
+                      ],
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ]
+                    ]
+                  ],
+                  [
+                    op_node_type,
+                    [
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ],
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            }
+          )
+        end
+
+        it "merges schema types on collision with multiple constraints" do
+          expect(
+            types_merger
+              .call(
+                op_class,
+                {foo: Types::Hash.schema(bar: Types::Integer.optional)},
+                {
+                  foo: Types::Hash.schema(baz: Types::Integer.optional).optional
+                }
+              )
+              .transform_values(&:to_ast)
+          ).to eq(
+            {
+              foo: [
+                :constrained,
+                [
+                  [
+                    :constrained,
+                    [
+                      [
+                        :schema,
+                        [
                           [
-                            :key,
                             [
-                              :baz,
-                              true,
+                              :key,
                               [
-                                :key,
+                                :bar,
+                                true,
                                 [
-                                  :baz,
-                                  true,
+                                  :key,
                                   [
-                                    :constrained,
+                                    :bar,
+                                    true,
                                     [
-                                      [:nominal, [Integer, {}]],
+                                      :sum,
                                       [
-                                        :predicate,
                                         [
-                                          :type?,
+                                          :constrained,
                                           [
-                                            [:type, Integer],
-                                            [:input, Undefined]
+                                            [:nominal, [NilClass, {}]],
+                                            [
+                                              :predicate,
+                                              [
+                                                :type?,
+                                                [
+                                                  [:type, NilClass],
+                                                  [:input, Undefined]
+                                                ]
+                                              ]
+                                            ]
                                           ]
-                                        ]
+                                        ],
+                                        [
+                                          :constrained,
+                                          [
+                                            [:nominal, [Integer, {}]],
+                                            [
+                                              :predicate,
+                                              [
+                                                :type?,
+                                                [
+                                                  [:type, Integer],
+                                                  [:input, Undefined]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ],
+                                        {}
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ],
+                            [
+                              :key,
+                              [
+                                :baz,
+                                true,
+                                [
+                                  :key,
+                                  [
+                                    :baz,
+                                    true,
+                                    [
+                                      :sum,
+                                      [
+                                        [
+                                          :constrained,
+                                          [
+                                            [:nominal, [NilClass, {}]],
+                                            [
+                                              :predicate,
+                                              [
+                                                :type?,
+                                                [
+                                                  [:type, NilClass],
+                                                  [:input, Undefined]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ],
+                                        [
+                                          :constrained,
+                                          [
+                                            [:nominal, [Integer, {}]],
+                                            [
+                                              :predicate,
+                                              [
+                                                :type?,
+                                                [
+                                                  [:type, Integer],
+                                                  [:input, Undefined]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ],
+                                        {}
                                       ]
                                     ]
                                   ]
                                 ]
                               ]
                             ]
-                          ]
-                        ],
-                        {},
-                        {}
+                          ],
+                          {},
+                          {}
+                        ]
+                      ],
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
                       ]
-                    ],
-                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
-                  ]
-                ],
-                [
-                  :and,
+                    ]
+                  ],
                   [
-                    [
-                      :predicate,
-                      [:type?, [[:type, Hash], [:input, Undefined]]]
-                    ],
-                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
-                  ]
-                ]
-              ]
-            ]
-          }
-        )
-      end
-
-      it "uses the rhs if the lhs is an Any" do
-        expect(
-          types_merger
-            .call(
-              Dry::Logic::Operations::And,
-              {foo: Types::Any},
-              {foo: Types::Integer}
-            )
-            .transform_values(&:to_ast)
-        ).to eq(
-          {
-            foo: [
-              :constrained,
-              [
-                [:nominal, [Integer, {}]],
-                [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]]
-              ]
-            ]
-          }
-        )
-      end
-
-      it "uses the rhs if the rhs is a subclass of lhs" do
-        expect(
-          types_merger
-            .call(
-              Dry::Logic::Operations::And,
-              {foo: Types::Hash},
-              {foo: Types::Hash.schema(bar: Types::Integer)}
-            )
-            .transform_values(&:to_ast)
-        ).to eq(
-          {
-            foo: [
-              :constrained,
-              [
-                [
-                  :schema,
-                  [
+                    op_node_type,
                     [
                       [
-                        :key,
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ],
+                      [
+                        :and,
                         [
-                          :bar,
-                          true,
                           [
-                            :constrained,
+                            :or,
                             [
-                              [:nominal, [Integer, {}]],
                               [
                                 :predicate,
                                 [
                                   :type?,
-                                  [[:type, Integer], [:input, Undefined]]
+                                  [[:type, NilClass], [:input, Undefined]]
+                                ]
+                              ],
+                              [
+                                :predicate,
+                                [:type?, [[:type, Hash], [:input, Undefined]]]
+                              ]
+                            ]
+                          ],
+                          [
+                            :predicate,
+                            [:type?, [[:type, Hash], [:input, Undefined]]]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            }
+          )
+        end
+
+        it "uses the rhs if the lhs is an Any" do
+          expect(
+            types_merger
+              .call(op_class, {foo: Types::Any}, {foo: Types::Integer})
+              .transform_values(&:to_ast)
+          ).to eq(
+            {
+              foo: [
+                :constrained,
+                [
+                  [:nominal, [Integer, {}]],
+                  [
+                    :predicate,
+                    [:type?, [[:type, Integer], [:input, Undefined]]]
+                  ]
+                ]
+              ]
+            }
+          )
+        end
+
+        it "uses the rhs if the rhs is a subclass of lhs" do
+          expect(
+            types_merger
+              .call(
+                op_class,
+                {foo: Types::Hash},
+                {foo: Types::Hash.schema(bar: Types::Integer)}
+              )
+              .transform_values(&:to_ast)
+          ).to eq(
+            {
+              foo: [
+                :constrained,
+                [
+                  [
+                    :schema,
+                    [
+                      [
+                        [
+                          :key,
+                          [
+                            :bar,
+                            true,
+                            [
+                              :constrained,
+                              [
+                                [:nominal, [Integer, {}]],
+                                [
+                                  :predicate,
+                                  [
+                                    :type?,
+                                    [[:type, Integer], [:input, Undefined]]
+                                  ]
                                 ]
                               ]
                             ]
                           ]
                         ]
-                      ]
-                    ],
-                    {},
-                    {}
-                  ]
-                ],
-                [
-                  :and,
+                      ],
+                      {},
+                      {}
+                    ]
+                  ],
                   [
+                    op_node_type,
                     [
-                      :predicate,
-                      [:type?, [[:type, Hash], [:input, Undefined]]]
-                    ],
-                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ],
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ]
+                    ]
                   ]
                 ]
               ]
-            ]
-          }
-        )
-      end
+            }
+          )
+        end
 
-      it "uses the lhs if the rhs is an Any" do
-        expect(
-          types_merger
-            .call(
-              Dry::Logic::Operations::And,
-              {foo: Types::Integer},
-              {foo: Types::Any}
-            )
-            .transform_values(&:to_ast)
-        ).to eq(
-          {
-            foo: [
-              :constrained,
-              [
-                [:nominal, [Integer, {}]],
-                [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]]
-              ]
-            ]
-          }
-        )
-      end
-
-      it "uses the lhs if the lhs is a subclass of rhs" do
-        expect(
-          types_merger
-            .call(
-              Dry::Logic::Operations::And,
-              {foo: Types::Hash.schema(bar: Types::Integer)},
-              {foo: Types::Hash}
-            )
-            .transform_values(&:to_ast)
-        ).to eq(
-          {
-            foo: [
-              :constrained,
-              [
+        it "uses the lhs if the rhs is an Any" do
+          expect(
+            types_merger
+              .call(op_class, {foo: Types::Integer}, {foo: Types::Any})
+              .transform_values(&:to_ast)
+          ).to eq(
+            {
+              foo: [
+                :constrained,
                 [
-                  :schema,
+                  [:nominal, [Integer, {}]],
                   [
+                    :predicate,
+                    [:type?, [[:type, Integer], [:input, Undefined]]]
+                  ]
+                ]
+              ]
+            }
+          )
+        end
+
+        it "uses the lhs if the lhs is a subclass of rhs" do
+          expect(
+            types_merger
+              .call(
+                op_class,
+                {foo: Types::Hash.schema(bar: Types::Integer)},
+                {foo: Types::Hash}
+              )
+              .transform_values(&:to_ast)
+          ).to eq(
+            {
+              foo: [
+                :constrained,
+                [
+                  [
+                    :schema,
                     [
                       [
-                        :key,
                         [
-                          :bar,
-                          true,
+                          :key,
                           [
-                            :constrained,
+                            :bar,
+                            true,
                             [
-                              [:nominal, [Integer, {}]],
+                              :constrained,
                               [
-                                :predicate,
+                                [:nominal, [Integer, {}]],
                                 [
-                                  :type?,
-                                  [[:type, Integer], [:input, Undefined]]
+                                  :predicate,
+                                  [
+                                    :type?,
+                                    [[:type, Integer], [:input, Undefined]]
+                                  ]
                                 ]
                               ]
                             ]
                           ]
                         ]
-                      ]
-                    ],
-                    {},
-                    {}
-                  ]
-                ],
-                [
-                  :and,
+                      ],
+                      {},
+                      {}
+                    ]
+                  ],
                   [
+                    op_node_type,
                     [
-                      :predicate,
-                      [:type?, [[:type, Hash], [:input, Undefined]]]
-                    ],
-                    [:predicate, [:type?, [[:type, Hash], [:input, Undefined]]]]
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ],
+                      [
+                        :predicate,
+                        [:type?, [[:type, Hash], [:input, Undefined]]]
+                      ]
+                    ]
                   ]
                 ]
               ]
-            ]
-          }
-        )
+            }
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Adds DSL#strict_type_schema. This is used when composing schemas within
macros. Making them strict improves composition of schemas, especially
when using the | operator. Before, all of the composed schemas were lax,
and if a subschema would pass a lax check, then values would be
eliminated from the coerced output that are necessary for later schema
validation to succeed.

Also fixes up metadata when creating the types map for a schema to not
always set required to false. This was also causing incorrect elision of
required keys when composing schemas.