### PR TITLE
Custom type fixes

### DIFF
--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -83,6 +83,24 @@ module Dry
           end
         end
 
+        # Set type specification and predicates for a maybe value
+        #
+        # @example
+        #   required(:name).maybe(:string)
+        #
+        # @see Macros::Key#value
+        #
+        # @return [Macros::Key]
+        #
+        # @api public
+        def maybe(*args, **opts, &block)
+          extract_type_spec(args, nullable: true) do |*predicates, type_spec:, type_rule:|
+            append_macro(Macros::Maybe) do |macro|
+              macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
+            end
+          end
+        end
+
         # Specify a nested hash without enforced `hash?` type-check
         #
         # This is a simpler building block than `hash` macro, use it

--- a/lib/dry/schema/macros/filled.rb
+++ b/lib/dry/schema/macros/filled.rb
@@ -13,12 +13,14 @@ module Dry
         def call(*predicates, **opts, &block)
           ensure_valid_predicates(predicates)
 
-          if opts[:type_spec] && !filter_empty_string?
-            value(predicates[0], :filled?, *predicates[1..predicates.size - 1], **opts, &block)
-          elsif opts[:type_rule]
-            value(:filled?).value(*predicates, **opts, &block)
-          else
-            value(:filled?, *predicates, **opts, &block)
+          append_macro(Macros::Value) do |macro|
+            if opts[:type_spec] && !filter_empty_string?
+              macro.call(predicates[0], :filled?, *predicates[1..predicates.size - 1], **opts, &block)
+            elsif opts[:type_rule]
+              macro.call(:filled?).value(*predicates, **opts, &block)
+            else
+              macro.call(:filled?, *predicates, **opts, &block)
+            end
           end
         end
 

--- a/lib/dry/schema/macros/filled.rb
+++ b/lib/dry/schema/macros/filled.rb
@@ -15,7 +15,8 @@ module Dry
 
           append_macro(Macros::Value) do |macro|
             if opts[:type_spec] && !filter_empty_string?
-              macro.call(predicates[0], :filled?, *predicates[1..predicates.size - 1], **opts, &block)
+              macro.call(predicates[0], :filled?, *predicates[1..predicates.size - 1], **opts,
+                         &block)
             elsif opts[:type_rule]
               macro.call(:filled?).value(*predicates, **opts, &block)
             else

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -32,24 +32,6 @@ module Dry
         end
         ruby2_keywords(:filter) if respond_to?(:ruby2_keywords, true)
 
-        # Set type specification and predicates for a maybe value
-        #
-        # @example
-        #   required(:name).maybe(:string)
-        #
-        # @see Macros::Key#value
-        #
-        # @return [Macros::Key]
-        #
-        # @api public
-        def maybe(*args, **opts, &block)
-          extract_type_spec(args, nullable: true) do |*predicates, type_spec:, type_rule:|
-            append_macro(Macros::Maybe) do |macro|
-              macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
-            end
-          end
-        end
-
         # Coerce macro to a rule
         #
         # @return [Dry::Logic::Rule]

--- a/lib/dry/schema/macros/maybe.rb
+++ b/lib/dry/schema/macros/maybe.rb
@@ -19,7 +19,9 @@ module Dry
             raise ::Dry::Schema::InvalidSchemaError, "Using maybe with nil? predicate is redundant"
           end
 
-          value(*args, **opts, &block)
+          append_macro(Macros::Value) do |macro|
+            macro.call(*args, **opts, &block)
+          end
 
           self
         end

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -173,6 +173,10 @@ RSpec.describe "Registering custom types" do
 
         let(:calendar_date) do
           Class.new(::Date) do
+            def to_json(*args)
+              strftime("--%m-%d").to_json(*args)
+            end
+
             def self.parse(date)
               mon, mday = Date._iso8601(date).values_at(:mon, :mday)
               raise ArgumentError, "invalid ISO8601 calendar day string, expected format \"--MM-DD\"" unless mon && mday
@@ -198,7 +202,7 @@ RSpec.describe "Registering custom types" do
         specify do
           expect(result).to be_success
           expect(result[:date]).to be_a(CalendarDate)
-          expect(result[:date].strftime("--%m-%d")).to eq("--02-09")
+          expect(result[:date].to_json).to eq('"--02-09"')
         end
       end
     end

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -81,11 +81,32 @@ RSpec.describe "Registering custom types" do
       end
 
       let(:params) do
-        { number: "19.3" }
+        {number: "19.3"}
       end
 
       it "coerces the type" do
         expect(result[:number]).to eql(BigDecimal('19.3'))
+      end
+    end
+
+    context "filled string" do
+      let(:klass) do
+        class Test::CustomTypeSchema < Dry::Schema::JSON
+          define do
+            required(:string).filled(
+              Types::Strict::String.constrained(format: /foo/) |
+              Types::Strict::String.constrained(format: /bar/)
+            )
+          end
+        end
+      end
+
+      let(:params) do
+        {string: "foo"}
+      end
+
+      it "coerces the type" do
+        expect(result[:string]).to eql("foo")
       end
     end
   end

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -70,6 +70,24 @@ RSpec.describe "Registering custom types" do
         expect(result[:age]).to eql("i am not that old")
       end
     end
+
+    context "maybe decimal" do
+      let(:klass) do
+        class Test::CustomTypeSchema < Dry::Schema::JSON
+          define do
+            required(:number).maybe(Types::JSON::Decimal | Types::Params::Nil)
+          end
+        end
+      end
+
+      let(:params) do
+        { number: "19.3" }
+      end
+
+      it "coerces the type" do
+        expect(result[:number]).to eql(BigDecimal('19.3'))
+      end
+    end
   end
 
   context "DSL-based definition" do

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Registering custom types" do
       end
 
       it "coerces the type" do
-        expect(result[:number]).to eql(BigDecimal('19.3'))
+        expect(result[:number]).to eql(BigDecimal("19.3"))
       end
     end
 

--- a/spec/integration/schema/macros/filled_spec.rb
+++ b/spec/integration/schema/macros/filled_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Macros #filled" do
       Dry::Schema.define do
         required(:foo).filled(:array).each do
           filled(:array).each do
-            filled(:string)
+            filled(Types::Strict::String)
           end
         end
       end


### PR DESCRIPTION
Appends the Value macro directly instead of calling .value and re-extracting the type spec.

For consistency, hoist maybe to the DSL as well so it can be used inside of blocks, just like filled.

Incorporates a variant of @ADStrovers repro spec from #423.

Resolves #419.
Resolves #423.