### PR TITLE
Update config in configure blocks only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,7 @@ gemspec
 # if ENV["DRY_CONFIGURABLE_FROM_MAIN"].eql?("true")
 #   gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
 # end
-gem "dry-configurable",
-  github: "dry-rb/dry-configurable",
-  branch: "write-settings-in-configure-only"
-gem "dry-core", github: "dry-rb/dry-core"
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only"
 
 if ENV["DRY_LOGIC_FROM_MAIN"].eql?("true")
   gem "dry-logic", github: "dry-rb/dry-logic", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ gemspec
 # if ENV["DRY_CONFIGURABLE_FROM_MAIN"].eql?("true")
 #   gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
 # end
-gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only"
+gem "dry-configurable",
+  github: "dry-rb/dry-configurable",
+  branch: "write-settings-in-configure-only"
 gem "dry-core", github: "dry-rb/dry-core"
 
 if ENV["DRY_LOGIC_FROM_MAIN"].eql?("true")

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,11 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
-if ENV["DRY_CONFIGURABLE_FROM_MAIN"].eql?("true")
-  gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
-end
+# if ENV["DRY_CONFIGURABLE_FROM_MAIN"].eql?("true")
+#   gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
+# end
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only"
+gem "dry-core", github: "dry-rb/dry-core"
 
 if ENV["DRY_LOGIC_FROM_MAIN"].eql?("true")
   gem "dry-logic", github: "dry-rb/dry-logic", branch: "main"

--- a/lib/dry/schema.rb
+++ b/lib/dry/schema.rb
@@ -27,6 +27,11 @@ module Dry
       @config ||= Config.new
     end
 
+    # @api public
+    def self.configure(&block)
+      config.configure(&block)
+    end
+
     # Define a schema
     #
     # @example

--- a/lib/dry/schema/json.rb
+++ b/lib/dry/schema/json.rb
@@ -11,9 +11,11 @@ module Dry
     #
     # @api public
     class JSON < Processor
-      config.key_map_type = :stringified
-      config.type_registry_namespace = :json
-      config.filter_empty_string = false
+      configure do |config|
+        config.key_map_type = :stringified
+        config.type_registry_namespace = :json
+        config.filter_empty_string = false
+      end
     end
   end
 end

--- a/lib/dry/schema/params.rb
+++ b/lib/dry/schema/params.rb
@@ -11,9 +11,11 @@ module Dry
     #
     # @api public
     class Params < Processor
-      config.key_map_type = :stringified
-      config.type_registry_namespace = :params
-      config.filter_empty_string = true
+      configure do |config|
+        config.key_map_type = :stringified
+        config.type_registry_namespace = :params
+        config.filter_empty_string = true
+      end
     end
   end
 end

--- a/spec/integration/custom_error_messages_spec.rb
+++ b/spec/integration/custom_error_messages_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Dry::Schema do
   context "yaml" do
     subject(:schema) do
       Dry::Schema.define do
-        configure do
+        configure do |config|
           config.messages.load_paths << SPEC_ROOT.join("fixtures/locales/en.yml")
         end
 
@@ -36,7 +36,7 @@ RSpec.describe Dry::Schema do
     context "with custom messages set globally" do
       subject(:schema) do
         Dry::Schema.define do
-          configure do
+          configure do |config|
             config.messages.backend = :i18n
           end
 
@@ -49,7 +49,7 @@ RSpec.describe Dry::Schema do
 
     context "with global configuration" do
       before do
-        Dry::Schema.config.messages.backend = :i18n
+        Dry::Schema.configure { |c| c.messages.backend = :i18n }
       end
 
       subject(:schema) do

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Validation hints" do
   context "with i18n messages" do
     subject(:schema) do
       Dry::Schema.define do
-        config.messages.backend = :i18n
+        configure { |c| c.messages.backend = :i18n }
 
         required(:age).maybe(:int?, gt?: 18)
       end

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe Dry::Schema, "with localized messages" do
     context "without a namespace" do
       subject(:schema) do
         Dry::Schema.define do
-          config.messages.backend = :i18n
-          config.messages.load_paths = %w[en pl ja]
-            .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+          configure do |config|
+            config.messages.backend = :i18n
+            config.messages.load_paths = %w[en pl ja]
+              .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+          end
 
           required(:email).value(:filled?)
         end
@@ -31,10 +33,12 @@ RSpec.describe Dry::Schema, "with localized messages" do
     context "with a namespace" do
       subject(:schema) do
         Dry::Schema.define do
-          config.messages.backend = :i18n
-          config.messages.namespace = :user
-          config.messages.load_paths = %w[en pl ja]
-            .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+          configure do |config|
+            config.messages.backend = :i18n
+            config.messages.namespace = :user
+            config.messages.load_paths = %w[en pl ja]
+              .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+          end
 
           required(:email).value(:filled?)
         end
@@ -52,11 +56,13 @@ RSpec.describe Dry::Schema, "with localized messages" do
     context "with a config.default_locale set" do
       subject(:schema) do
         Dry::Schema.define do
-          config.messages.backend = :i18n
-          config.messages.namespace = :user
-          config.messages.default_locale = :pl
-          config.messages.load_paths = %w[en pl ja]
-            .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+          configure do |config|
+            config.messages.backend = :i18n
+            config.messages.namespace = :user
+            config.messages.default_locale = :pl
+            config.messages.load_paths = %w[en pl ja]
+              .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+          end
 
           required(:email).value(:filled?)
         end
@@ -71,11 +77,13 @@ RSpec.describe Dry::Schema, "with localized messages" do
 
         it "returns localized error messages with defined whitespace character for 'full' option" do
           schema = Dry::Schema.define do
-            config.messages.backend = :i18n
-            config.messages.namespace = :user
-            config.messages.default_locale = :ja
-            config.messages.load_paths = %w[en pl ja]
-              .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+            configure do |config|
+              config.messages.backend = :i18n
+              config.messages.namespace = :user
+              config.messages.default_locale = :ja
+              config.messages.load_paths = %w[en pl ja]
+                .map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") }
+            end
 
             required(:email).value(:filled?)
           end

--- a/spec/integration/messages/i18n/with_locale_spec.rb
+++ b/spec/integration/messages/i18n/with_locale_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe "I18n validation messages / using I18n.with_locale" do
   context "with current locale" do
     subject(:schema) do
       Dry::Schema.Params do
-        config.messages.backend = :i18n
-        config.messages.namespace = :user
+        configure do |config|
+          config.messages.backend = :i18n
+          config.messages.namespace = :user
+        end
 
         required(:name).filled(:string)
       end
@@ -65,7 +67,7 @@ RSpec.describe "I18n validation messages / using I18n.with_locale" do
     context "without namespace" do
       subject(:schema) do
         Dry::Schema.Params do
-          config.messages.backend = :i18n
+          configure { |c| c.messages.backend = :i18n }
 
           required(:name).filled(:string)
         end
@@ -85,8 +87,10 @@ RSpec.describe "I18n validation messages / using I18n.with_locale" do
     context "with namespace" do
       subject(:schema) do
         Dry::Schema.Params do
-          config.messages.backend = :i18n
-          config.messages.namespace = :user
+          configure do |config|
+            config.messages.backend = :i18n
+            config.messages.namespace = :user
+          end
 
           required(:name).filled(:string)
         end

--- a/spec/integration/messages/namespaced_spec.rb
+++ b/spec/integration/messages/namespaced_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe "Namespaced messages" do
   context "namespace with nested schema" do
     let(:post_schema) do
       Dry::Schema.Params do
-        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
-        config.messages.namespace = :post
+        configure do |config|
+          config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
+          config.messages.namespace = :post
+        end
 
         required(:post_body).filled(:string)
         required(:comment).schema do
@@ -29,8 +31,10 @@ RSpec.describe "Namespaced messages" do
   context "in nested, re-used schemas" do
     let!(:comment_schema) do
       Test::CommentSchema = Dry::Schema.Params do
-        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
-        config.messages.namespace = :comment
+        configure do |config|
+          config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
+          config.messages.namespace = :comment
+        end
 
         required(:comment_body).filled
       end
@@ -38,8 +42,10 @@ RSpec.describe "Namespaced messages" do
 
     let(:post_schema) do
       Test::PostSchema = Dry::Schema.Params do
-        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
-        config.messages.namespace = :post
+        configure do |config|
+          config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
+          config.messages.namespace = :post
+        end
 
         required(:post_body).filled
         required(:comment).hash(::Test::CommentSchema)
@@ -59,8 +65,10 @@ RSpec.describe "Namespaced messages" do
   context "with OR types" do
     let(:post_schema) do
       Dry::Schema.Params do
-        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
-        config.messages.namespace = :post
+        configure do |config|
+          config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/namespaced.yml"
+          config.messages.namespace = :post
+        end
 
         required(:some_ids).maybe(Types::Array.of(Types::Params::Integer | Types::Params::String))
       end

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Registering custom types" do
       let(:klass) do
         class Test::CustomTypeSchema < Dry::Schema::Params
           define do
-            config.types = ContainerWithoutTypes
+            configure { |c| c.types = ContainerWithoutTypes }
 
             required(:email).filled(:string)
             required(:age).filled(:trimmed_string)
@@ -54,7 +54,7 @@ RSpec.describe "Registering custom types" do
       let(:klass) do
         class Test::CustomTypeSchema < Dry::Schema::Params
           define do
-            config.types = ContainerWithTypes
+            configure { |c| c.types = ContainerWithTypes }
 
             required(:email).filled(:string)
             required(:age).filled(:trimmed_string)
@@ -115,7 +115,7 @@ RSpec.describe "Registering custom types" do
     context "custom type is not registered" do
       subject(:schema) do
         Dry::Schema.Params do
-          config.types = ContainerWithoutTypes
+          configure { |c| c.types = ContainerWithoutTypes }
 
           required(:email).filled(:string)
           required(:age).filled(:trimmed_string)
@@ -130,7 +130,7 @@ RSpec.describe "Registering custom types" do
     context "custom type is registered" do
       subject(:schema) do
         Dry::Schema.Params do
-          config.types = ContainerWithTypes
+          configure { |c| c.types = ContainerWithTypes }
 
           required(:email).filled(:string)
           required(:age).filled(:trimmed_string)
@@ -148,7 +148,7 @@ RSpec.describe "Registering custom types" do
       context "nested schema" do
         subject(:schema) do
           Dry::Schema.Params do
-            config.types = ContainerWithTypes
+            configure { |c| c.types = ContainerWithTypes }
 
             required(:user).hash do
               required(:age).filled(:trimmed_string)
@@ -166,7 +166,7 @@ RSpec.describe "Registering custom types" do
       context "custom constructor" do
         subject(:schema) do
           Dry::Schema.Params do
-            config.types = ContainerWithTypes
+            configure { |c| c.types = ContainerWithTypes }
             optional(:date).maybe(:calendar_day)
           end
         end
@@ -221,7 +221,7 @@ RSpec.describe "Registering custom types" do
     let(:klass) do
       class Test::CustomTypeSchema < Dry::Schema::Params
         define do
-          config.types = ContainerWithTypes
+          configure { |c| c.types = ContainerWithTypes }
 
           required(:age).filled(:string_or_integer)
         end
@@ -235,7 +235,7 @@ RSpec.describe "Registering custom types" do
     }
 
     before do
-      klass.definition.configure { |config| config.messages.backend = backend }
+      klass.definition.configure { |c| c.messages.backend = backend }
     end
 
     context "with YAML backend" do

--- a/spec/integration/schema/defining_base_schema_spec.rb
+++ b/spec/integration/schema/defining_base_schema_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Defining base schema class" do
   context "when child schema defines config" do
     subject(:schema) do
       Dry::Schema.define(parent: parent) do
-        config.messages.backend = :yaml
+        configure { |c| c.messages.backend = :yaml }
       end
     end
 

--- a/spec/integration/schema/steps_spec.rb
+++ b/spec/integration/schema/steps_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Dry::Schema, "callbacks" do
     describe "core step key maps" do
       it "copies key map from the parent and includes new keys from child" do
         parent = Dry::Schema.Params do
-          config.validate_keys = true
+          configure { |c| c.validate_keys = true }
 
           required(:name).filled(:string)
         end

--- a/spec/integration/schema/type_spec.rb
+++ b/spec/integration/schema/type_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe Dry::Schema, "types specs" do
           types.register("trimmed_string", trimmed_string)
 
           Dry::Schema.define do
-            config.types = types
+            configure { |c| c.types = types }
 
             required(:name).maybe(:trimmed_string)
           end

--- a/spec/integration/schema/unexpected_keys_spec.rb
+++ b/spec/integration/schema/unexpected_keys_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Dry::Schema, "unexpected keys" do
   subject(:schema) do
     Dry::Schema.define do
-      config.validate_keys = true
+      configure { |c| c.validate_keys = true }
 
       required(:name).filled(:string)
       required(:ids).filled(:array).each(:integer)
@@ -67,9 +67,11 @@ RSpec.describe Dry::Schema, "unexpected keys" do
 
   it "supports meta tags" do
     schema = Dry::Schema.define do
-      config.validate_keys = true
-      config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/pl.yml"
-      config.messages.default_locale = :pl
+      configure do |config|
+        config.validate_keys = true
+        config.messages.load_paths << "#{SPEC_ROOT}/fixtures/locales/pl.yml"
+        config.messages.default_locale = :pl
+      end
 
       required(:title).filled
     end
@@ -82,7 +84,7 @@ RSpec.describe Dry::Schema, "unexpected keys" do
   context "with an array validation" do
     subject(:schema) do
       Dry::Schema.define do
-        config.validate_keys = true
+        configure { |c| c.validate_keys = true }
 
         required(:name).filled(:string)
         optional(:tags).array(:string)
@@ -100,7 +102,7 @@ RSpec.describe Dry::Schema, "unexpected keys" do
 
     it "doesn't add the unexpected key error message when the type is wrong" do
       schema = Dry::Schema.define do
-        config.validate_keys = true
+        configure { |c| c.validate_keys = true }
 
         required(:pets).array(:hash) do
           required(:name).filled(:string)
@@ -117,7 +119,7 @@ RSpec.describe Dry::Schema, "unexpected keys" do
     context "with a nested maybe hash validator" do
       subject(:schema) do
         Dry::Schema.define do
-          config.validate_keys = true
+          configure { |c| c.validate_keys = true }
 
           required(:locations).array(:hash) do
             required(:feedback_location).maybe(:hash) do
@@ -136,7 +138,7 @@ RSpec.describe Dry::Schema, "unexpected keys" do
     context "with a non-nested maybe hash validator" do
       subject(:schema) do
         Dry::Schema.define do
-          config.validate_keys = true
+          configure { |c| c.validate_keys = true }
 
           required(:feedback_location).maybe(:hash) do
             required(:lat).filled(:float)
@@ -154,7 +156,7 @@ RSpec.describe Dry::Schema, "unexpected keys" do
   context "with an inherited params" do
     it "copies key map from the parent and includes new keys from child" do
       parent = Dry::Schema.Params do
-        config.validate_keys = true
+        configure { |c| c.validate_keys = true }
 
         required(:name).filled(:string)
       end

--- a/spec/unit/dry/schema/config_spec.rb
+++ b/spec/unit/dry/schema/config_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dry::Schema::Config do
     end
 
     it "returns overridden value" do
-      config.messages.backend = :i18n
+      config.configure { |c| c.messages.backend = :i18n }
 
       expect(config.messages.backend).to be(:i18n)
     end
@@ -40,7 +40,7 @@ RSpec.describe Dry::Schema::Config do
 
     it "returns false when configs differ" do
       other = config.dup
-      other.messages.backend = :i18n
+      other.configure { |c| c.messages.backend = :i18n }
 
       expect(config).to_not eql(other)
     end

--- a/spec/unit/dry/schema/dsl_spec.rb
+++ b/spec/unit/dry/schema/dsl_spec.rb
@@ -40,27 +40,29 @@ RSpec.describe Dry::Schema::DSL do
     let(:replacement_namespace) { :replacement_test_namespace }
 
     it "uses a dup of the parent's config when a parent is present" do
-      config = Dry::Schema::Config.new.tap { |c| c.messages.namespace = namespace }
+      config = Dry::Schema::Config.new
+      config.configure { |c| c.messages.namespace = namespace }
       parent = Dry::Schema::DSL.new(config: config)
       dsl = Dry::Schema::DSL.new(parent: parent)
 
       expect(dsl.config.messages.namespace).to eq(namespace)
 
-      parent.config.messages.namespace = replacement_namespace
+      parent.configure { |c| c.messages.namespace = replacement_namespace }
       expect(dsl.config.messages.namespace).not_to eq(replacement_namespace)
     end
 
     it "uses a dup of the global config when no parent is present" do
-      Dry::Schema.config.messages.namespace = namespace
+      Dry::Schema.configure { |c| c.messages.namespace = namespace }
       expect(dsl.config.messages.namespace).to eq(namespace)
 
-      Dry::Schema.config.messages.namespace = replacement_namespace
+      Dry::Schema.configure { |c| c.messages.namespace = replacement_namespace }
       expect(dsl.config.messages.namespace).not_to eq(replacement_namespace)
     end
 
     it "raises an ArgumentError if the parent configs differ" do
       parent = [namespace, namespace, replacement_namespace, namespace].map do |namespace|
-        config = Dry::Schema::Config.new.tap { |c| c.messages.namespace = namespace }
+        config = Dry::Schema::Config.new
+        config.configure { |c| c.messages.namespace = namespace }
         Dry::Schema::DSL.new(config: config)
       end
 
@@ -70,7 +72,8 @@ RSpec.describe Dry::Schema::DSL do
 
     it "does not raise an error if the parent configs are the same" do
       parent = Array.new(4) do
-        config = Dry::Schema::Config.new.tap { |c| c.messages.namespace = namespace }
+        config = Dry::Schema::Config.new
+        config.configure { |c| c.messages.namespace = namespace }
         Dry::Schema::DSL.new(config: config)
       end
 

--- a/spec/unit/dry/schema/params_spec.rb
+++ b/spec/unit/dry/schema/params_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Dry::Schema::Params do
     let(:parent_class) do
       class Test::UserSchema < Dry::Schema::Params
         define do
-          config.messages.backend = :i18n
+          configure { |c| c.messages.backend = :i18n }
 
           required(:name).filled(:string)
         end

--- a/spec/unit/dry/schema/schema_spec.rb
+++ b/spec/unit/dry/schema/schema_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dry::Schema do
 
     context "with i18n setting" do
       let(:schema) do
-        Dry::Schema.define { configure { config.messages.backend = :i18n } }
+        Dry::Schema.define { configure { |c| c.messages.backend = :i18n } }
       end
 
       it "returns default i18n messages" do
@@ -28,7 +28,7 @@ RSpec.describe Dry::Schema do
 
     context "with an invalid setting" do
       let(:schema) do
-        Dry::Schema.define { configure { config.messages.backend = :oops } }
+        Dry::Schema.define { configure { |c| c.messages.backend = :oops } }
       end
 
       it "returns default i18n messages" do


### PR DESCRIPTION
Update all usages of dry-configurable-provided `config` so that any changes are made inside `configure` blocks.

This prepares for the changes in https://github.com/dry-rb/dry-configurable/pull/140.