### PR TITLE
Fix regression introduced in 1.10.0

### DIFF
--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -53,9 +53,15 @@ module Dry
         #
         # @api public
         def value(*args, **opts, &block)
-          extract_type_spec(args) do |*predicates, type_spec:, type_rule:|
+          if (type_spec_from_opts = opts[:type_spec])
             append_macro(Macros::Value) do |macro|
-              macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
+              macro.call(*args, type_spec: type_spec_from_opts, **opts, &block)
+            end
+          else
+            extract_type_spec(args) do |*predicates, type_spec:, type_rule:|
+              append_macro(Macros::Value) do |macro|
+                macro.call(*predicates, type_spec: type_spec, type_rule: type_rule, **opts, &block)
+              end
             end
           end
         end

--- a/spec/integration/params/macros/array_spec.rb
+++ b/spec/integration/params/macros/array_spec.rb
@@ -60,4 +60,21 @@ RSpec.describe "Params / Macros / array" do
       end
     end
   end
+
+  context "with a sum type as member" do
+    it "applies coercion and rules" do
+      schema = Dry::Schema.Params {
+        required(:nums).array(Types::Params::Integer | Types::Params::Nil)
+      }
+
+      result = schema.(nums: ["3", nil, "1"])
+
+      expect(result).to be_success
+
+      result = schema.(nums: ["3", {}, "1"])
+
+      expect(result).to be_failure
+      expect(result.errors.to_h).to eql(nums: {1 => ["must be an integer or cannot be defined"]})
+    end
+  end
 end


### PR DESCRIPTION
In 8ee785811e2dc6f7a01eb08d5c5f280d6b82b852 `value` DSL method started extracting type specs as well which in case of `array(sum_type)` caused double-type-spec extraction that broke things.

This fix simply tweaks `value` so that it checks if there's no type_spec already provided in the opts.

Fixes #436