### PR TITLE
Change required metadata back to true

### DIFF
--- a/lib/dry/schema/dsl.rb
+++ b/lib/dry/schema/dsl.rb
@@ -307,7 +307,7 @@ module Dry
       # @api private
       def set_type(name, spec)
         type = resolve_type(spec)
-        meta = {required: true, maybe: type.optional?}
+        meta = {required: false, maybe: type.optional?}
 
         @types[name] = type.meta(meta)
       end

--- a/spec/integration/issues_spec.rb
+++ b/spec/integration/issues_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe "GitHub issues" do
+  describe "dry-rb/dry-validation#718" do
+    let(:schema) do
+      Dry::Schema.Params do
+        optional(:results).maybe(:hash) do
+          optional(:tours).value(:array).each do
+            hash do
+              required(:last_stop_ends_at).filled(:date_time)
+              required(:stops).value(:array).each do
+                hash do
+                  optional(:id).filled(:integer)
+                  required(:starts_at).filled(:date_time)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    specify do
+      params = {
+        results: {
+          tours: [
+            {
+              last_stop_ends_at: "2020-05-13T09:45:42+00:00",
+              stops: [{starts_at: "2020-05-13T08:00:00+00:00"}]
+            }
+          ]
+        }
+      }
+
+      result = schema.call(params)
+      expect(result).to be_success
+      expect(result.to_h).to eq(
+        {
+          results: {
+            tours: [{
+              last_stop_ends_at: DateTime.new(2020, 5, 13, 9, 45, 42),
+              stops: [{
+                starts_at: DateTime.new(2020, 5, 13, 8)
+              }]
+            }]
+          }
+        }
+      )
+    end
+  end
+
+  describe "dry-rb/dry-schema#423" do
+    let(:type_container) do
+      Dry::Schema::TypeContainer.new
+    end
+
+    subject(:schema) do
+      type_container = self.type_container
+      Dry::Schema.Params do
+        config.types = type_container
+        optional(:date).maybe(:calendar_day)
+      end
+    end
+
+    let(:calendar_date) do
+      Class.new(::Date) do
+        def to_json(*args)
+          strftime("--%m-%d").to_json(*args)
+        end
+
+        def self.parse(date)
+          mon, mday = Date._iso8601(date).values_at(:mon, :mday)
+          raise ArgumentError, "invalid ISO8601 calendar day string, expected format \"--MM-DD\"" unless mon && mday
+
+          new(2000, mon, mday)
+        end
+      end
+    end
+
+    before do
+      stub_const("CalendarDate", calendar_date)
+
+      type_container.register(
+        :calendar_day,
+        Types::Strict(CalendarDate).constructor(CalendarDate.method(:parse))
+      )
+    end
+
+    let(:params) do
+      {"date" => "--02-09"}
+    end
+
+    specify do
+      result = schema.call(params)
+      expect(result).to be_success
+      expect(result[:date]).to be_a(CalendarDate)
+      expect(result[:date].to_json).to eq('"--02-09"')
+    end
+  end
+end

--- a/spec/integration/schema/custom_types_spec.rb
+++ b/spec/integration/schema/custom_types_spec.rb
@@ -162,49 +162,6 @@ RSpec.describe "Registering custom types" do
           expect(result[:user][:age]).to eql("i am not that old")
         end
       end
-
-      context "custom constructor" do
-        subject(:schema) do
-          Dry::Schema.Params do
-            config.types = ContainerWithTypes
-            optional(:date).maybe(:calendar_day)
-          end
-        end
-
-        let(:calendar_date) do
-          Class.new(::Date) do
-            def to_json(*args)
-              strftime("--%m-%d").to_json(*args)
-            end
-
-            def self.parse(date)
-              mon, mday = Date._iso8601(date).values_at(:mon, :mday)
-              raise ArgumentError, "invalid ISO8601 calendar day string, expected format \"--MM-DD\"" unless mon && mday
-
-              new(2000, mon, mday)
-            end
-          end
-        end
-
-        before do
-          stub_const("CalendarDate", calendar_date)
-
-          container_with_types.register(
-            :calendar_day,
-            Types::Strict(CalendarDate).constructor(CalendarDate.method(:parse))
-          )
-        end
-
-        let(:params) do
-          {"date" => "--02-09"}
-        end
-
-        specify do
-          expect(result).to be_success
-          expect(result[:date]).to be_a(CalendarDate)
-          expect(result[:date].to_json).to eq('"--02-09"')
-        end
-      end
     end
   end
 


### PR DESCRIPTION
This had some unintended effects as far as value coercion goes. At some point, this was causing issues with TypesMerger, but now it appears that it does not! Great!

Resolves dry-rb/dry-validation#718
Resolves dry-rb/dry-schema#438