### PR TITLE
Make the yaml cache fully thread-safe

### DIFF
--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -164,7 +164,6 @@ module Dry
 
         # @api private
         def evaluation_context(key, options)
-          p key
           cache.fetch_or_store(get(key, options).fetch(:text)) do |input|
             tokens = input.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym).to_set
             text = input.gsub("%", "#")

--- a/lib/dry/schema/messages/yaml.rb
+++ b/lib/dry/schema/messages/yaml.rb
@@ -70,7 +70,9 @@ module Dry
 
         # @api private
         def self.cache
-          @cache ||= Concurrent::Map.new { |h, k| h[k] = Concurrent::Map.new }
+          @cache ||= Concurrent::Map.new do |h, k|
+            h.compute_if_absent(k) { Concurrent::Map.new }
+          end
         end
 
         # @api private
@@ -162,6 +164,7 @@ module Dry
 
         # @api private
         def evaluation_context(key, options)
+          p key
           cache.fetch_or_store(get(key, options).fetch(:text)) do |input|
             tokens = input.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym).to_set
             text = input.gsub("%", "#")


### PR DESCRIPTION
```ruby
Concurrent::Map.new { |h, k| h[k] = Concurrent::Map.new }
```

is prone to a race condition, thus the cache won't be fully thread safe if definitions are parsed in multiple threads.

This PR fixes that.

Ref: https://github.com/ruby-concurrency/concurrent-ruby/issues/970