### PR TITLE
Back to eql? and respond_to?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,9 @@ if ENV["DRY_CONFIGURABLE_FROM_MAIN"].eql?("true")
   gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
 end
 
-# if ENV["DRY_LOGIC_FROM_MAIN"].eql?("true")
-gem "dry-logic", github: "dry-rb/dry-logic", branch: "main"
-# end
+if ENV["DRY_LOGIC_FROM_MAIN"].eql?("true")
+  gem "dry-logic", github: "dry-rb/dry-logic", branch: "main"
+end
 
 group :test do
   gem "dry-monads"

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,9 @@ if ENV["DRY_CONFIGURABLE_FROM_MAIN"].eql?("true")
   gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "main"
 end
 
-if ENV["DRY_LOGIC_FROM_MAIN"].eql?("true")
-  gem "dry-logic", github: "dry-rb/dry-logic", branch: "main"
-end
+# if ENV["DRY_LOGIC_FROM_MAIN"].eql?("true")
+gem "dry-logic", github: "dry-rb/dry-logic", branch: "main"
+# end
 
 group :test do
   gem "dry-monads"

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem "dry-logic", github: "dry-rb/dry-logic", branch: "main"
 # end
 
 group :test do
-  gem "dry-monads", require: false, github: "dry-rb/dry-monads", branch: "main"
-  gem "dry-struct", require: false, github: "dry-rb/dry-struct", branch: "main"
+  gem "dry-monads"
+  gem "dry-struct"
   gem "i18n", "1.8.2", require: false
   gem "json-schema"
   gem "transproc"

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -20,8 +20,6 @@ en:
 
       eql?: "must be equal to %{left}"
 
-      is_eql?: "must be equal to %{left}"
-
       not_eql?: "must not be equal to %{left}"
 
       filled?: "must be filled"
@@ -90,8 +88,6 @@ en:
       type?: "must be %{type}"
 
       respond_to?: "must respond to %{method}"
-
-      interface?: "must respond to %{method}"
 
       size?:
         arg:

--- a/docsite/source/basics/built-in-predicates.html.md
+++ b/docsite/source/basics/built-in-predicates.html.md
@@ -38,7 +38,7 @@ Checks that a key's value is equal to the given value.
 describe 'eql?' do
   let(:schema) do
     Dry::Schema.Params do
-      required(:sample).value(is_eql?: 1234)
+      required(:sample).value(eql?: 1234)
     end
   end
 

--- a/dry-schema.gemspec
+++ b/dry-schema.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-configurable", "~> 1.0", ">= 1.0.1"
   spec.add_runtime_dependency "dry-core", "~> 1.0", "< 2"
   spec.add_runtime_dependency "dry-initializer", "~> 3.0"
-  spec.add_runtime_dependency "dry-logic", ">= 1.4", "< 2"
+  spec.add_runtime_dependency "dry-logic", ">= 1.5", "< 2"
   spec.add_runtime_dependency "dry-types", ">= 1.7", "< 2"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
 

--- a/lib/dry/schema/predicate.rb
+++ b/lib/dry/schema/predicate.rb
@@ -71,7 +71,7 @@ module Dry
 
       # @api private
       def ensure_valid
-        if compiler.predicates[name].arity - 1 != args.size && !name.eql?(:eql?)
+        if compiler.predicates[name].arity - 1 != args.size
           raise ArgumentError, "#{name} predicate arity is invalid"
         end
       end

--- a/lib/dry/schema/predicate.rb
+++ b/lib/dry/schema/predicate.rb
@@ -47,6 +47,9 @@ module Dry
       attr_reader :args
 
       # @api private
+      attr_reader :arity
+
+      # @api private
       attr_reader :block
 
       # @api private
@@ -55,6 +58,8 @@ module Dry
         @name = name
         @args = args
         @block = block
+        # Cater for optional second argument like in case of `eql?` or `respond_to?`
+        @arity = compiler.predicates[name].arity.abs
       end
 
       # Negate a predicate
@@ -71,7 +76,7 @@ module Dry
 
       # @api private
       def ensure_valid
-        if compiler.predicates[name].arity - 1 != args.size
+        if arity - 1 != args.size
           raise ArgumentError, "#{name} predicate arity is invalid"
         end
       end

--- a/lib/dry/schema/predicate_registry.rb
+++ b/lib/dry/schema/predicate_registry.rb
@@ -9,11 +9,13 @@ module Dry
       # @api private
       def arg_list(name, *values)
         predicate = self[name]
+        # Cater for optional second argument like in case of `eql?` or `respond_to?`
+        arity = predicate.arity.abs
 
         predicate
           .parameters
           .map(&:last)
-          .zip(values + Array.new(predicate.arity - values.size, Undefined))
+          .zip(values + Array.new(arity - values.size, Undefined))
       end
     end
   end

--- a/lib/dry/schema/type_container.rb
+++ b/lib/dry/schema/type_container.rb
@@ -15,7 +15,7 @@ module Dry
     class TypeContainer
       include Dry::Core::Container::Mixin
 
-      def initialize(types_container = ::Dry::Types.container)
+      def initialize(types_container = Dry::Types.container)
         super()
 
         merge(types_container)

--- a/spec/fixtures/messages.yml
+++ b/spec/fixtures/messages.yml
@@ -1,6 +1,6 @@
 en:
   dry_schema:
     errors:
-      is_eql?:
+      eql?:
         failure: '%{right} is not equal to blue'
         hint: 'must be equal to blue'

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe "Validation hints" do
   context "with a nested schema with same rule names" do
     subject(:schema) do
       Dry::Schema.define do
-        required(:code).filled(:str?, is_eql?: "foo")
+        required(:code).filled(:str?, eql?: "foo")
 
         required(:nested).hash do
-          required(:code).filled(:str?, is_eql?: "bar")
+          required(:code).filled(:str?, eql?: "bar")
         end
       end
     end
@@ -150,7 +150,7 @@ RSpec.describe "Validation hints" do
       Dry::Schema.define do
         configure { |c| c.messages.load_paths << SPEC_ROOT.join("fixtures/messages.yml") }
 
-        required(:pill).filled(is_eql?: "blue")
+        required(:pill).filled(eql?: "blue")
       end
     end
 

--- a/spec/integration/message_compiler_spec.rb
+++ b/spec/integration/message_compiler_spec.rb
@@ -406,10 +406,10 @@ RSpec.describe Dry::Schema::MessageCompiler do
       end
     end
 
-    describe ":is_eql?" do
+    describe ":eql?" do
       it "returns valid message" do
         msg = message_compiler.visit(
-          [:failure, [:str, [:key, [:str, p(:is_eql?, "Bar", "Foo")]]]]
+          [:failure, [:str, [:key, [:str, p(:eql?, "Bar", "Foo")]]]]
         )
 
         expect(msg).to eql("must be equal to Bar")

--- a/spec/integration/params/predicates/eql_spec.rb
+++ b/spec/integration/params/predicates/eql_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Predicates: IsEql" do
   context "with required" do
     subject(:schema) do
       Dry::Schema.Params do
-        required(:foo).value(:string) { is_eql?("23") }
+        required(:foo).value(:string) { eql?("23") }
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe "Predicates: IsEql" do
   context "with optional" do
     subject(:schema) do
       Dry::Schema.Params do
-        optional(:foo).value(:string) { is_eql?("23") }
+        optional(:foo).value(:string) { eql?("23") }
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe "Predicates: IsEql" do
       context "with value" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).value(:string, is_eql?: "23")
+            required(:foo).value(:string, eql?: "23")
           end
         end
 
@@ -126,7 +126,7 @@ RSpec.describe "Predicates: IsEql" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).filled(:string, is_eql?: "23")
+            required(:foo).filled(:string, eql?: "23")
           end
         end
 
@@ -166,7 +166,7 @@ RSpec.describe "Predicates: IsEql" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            required(:foo).maybe(:string, is_eql?: "23")
+            required(:foo).maybe(:string, eql?: "23")
           end
         end
 
@@ -208,7 +208,7 @@ RSpec.describe "Predicates: IsEql" do
       context "with value" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).value(:string, is_eql?: "23")
+            optional(:foo).value(:string, eql?: "23")
           end
         end
 
@@ -248,7 +248,7 @@ RSpec.describe "Predicates: IsEql" do
       context "with filled" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).filled(:string, is_eql?: "23")
+            optional(:foo).filled(:string, eql?: "23")
           end
         end
 
@@ -288,7 +288,7 @@ RSpec.describe "Predicates: IsEql" do
       context "with maybe" do
         subject(:schema) do
           Dry::Schema.Params do
-            optional(:foo).maybe(:string, is_eql?: "23")
+            optional(:foo).maybe(:string, eql?: "23")
           end
         end
 

--- a/spec/integration/schema/predicates/eql_spec.rb
+++ b/spec/integration/schema/predicates/eql_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-RSpec.describe "Predicates: Interface" do
+RSpec.describe "Predicates: Eql" do
   context "with required" do
     subject(:schema) do
-      Dry::Schema.define { required(:foo) { interface?(:bar) } }
+      Dry::Schema.define do
+        required(:foo) { eql?(23) }
+      end
     end
 
     context "with valid input" do
-      let(:input) { {foo: double(bar: 23)} }
+      let(:input) { {foo: 23} }
 
       it "is successful" do
         expect(result).to be_successful
@@ -18,7 +20,7 @@ RSpec.describe "Predicates: Interface" do
       let(:input) { {} }
 
       it "is not successful" do
-        expect(result).to be_failing ["is missing", "must respond to bar"]
+        expect(result).to be_failing ["is missing", "must be equal to 23"]
       end
     end
 
@@ -26,7 +28,7 @@ RSpec.describe "Predicates: Interface" do
       let(:input) { {foo: nil} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must respond to bar"]
+        expect(result).to be_failing ["must be equal to 23"]
       end
     end
 
@@ -34,26 +36,20 @@ RSpec.describe "Predicates: Interface" do
       let(:input) { {foo: ""} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must respond to bar"]
-      end
-    end
-
-    context "with invalid input" do
-      let(:input) { {foo: double(baz: 23)} }
-
-      it "is not successful" do
-        expect(result).to be_failing ["must respond to bar"]
+        expect(result).to be_failing ["must be equal to 23"]
       end
     end
   end
 
   context "with optional" do
     subject(:schema) do
-      Dry::Schema.define { optional(:foo) { interface?(:bar) } }
+      Dry::Schema.define do
+        optional(:foo) { eql?(23) }
+      end
     end
 
     context "with valid input" do
-      let(:input) { {foo: double(bar: 23)} }
+      let(:input) { {foo: 23} }
 
       it "is successful" do
         expect(result).to be_successful
@@ -72,7 +68,7 @@ RSpec.describe "Predicates: Interface" do
       let(:input) { {foo: nil} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must respond to bar"]
+        expect(result).to be_failing ["must be equal to 23"]
       end
     end
 
@@ -80,15 +76,7 @@ RSpec.describe "Predicates: Interface" do
       let(:input) { {foo: ""} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must respond to bar"]
-      end
-    end
-
-    context "with invalid input" do
-      let(:input) { {foo: double(baz: 23)} }
-
-      it "is not successful" do
-        expect(result).to be_failing ["must respond to bar"]
+        expect(result).to be_failing ["must be equal to 23"]
       end
     end
   end
@@ -97,11 +85,13 @@ RSpec.describe "Predicates: Interface" do
     context "with required" do
       context "with value" do
         subject(:schema) do
-          Dry::Schema.define { required(:foo).value(interface?: :bar) }
+          Dry::Schema.define do
+            required(:foo).value(eql?: 23)
+          end
         end
 
         context "with valid input" do
-          let(:input) { {foo: double(bar: 23)} }
+          let(:input) { {foo: 23} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -112,7 +102,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {} }
 
           it "is not successful" do
-            expect(result).to be_failing ["is missing", "must respond to bar"]
+            expect(result).to be_failing ["is missing", "must be equal to 23"]
           end
         end
 
@@ -120,7 +110,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be equal to 23"]
           end
         end
 
@@ -128,26 +118,20 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
-          end
-        end
-
-        context "with invalid input" do
-          let(:input) { {foo: double(baz: 23)} }
-
-          it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be equal to 23"]
           end
         end
       end
 
       context "with filled" do
         subject(:schema) do
-          Dry::Schema.define { required(:foo).filled(interface?: :bar) }
+          Dry::Schema.define do
+            required(:foo).filled(eql?: 23)
+          end
         end
 
         context "with valid input" do
-          let(:input) { {foo: double(bar: 23)} }
+          let(:input) { {foo: 23} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -158,7 +142,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {} }
 
           it "is not successful" do
-            expect(result).to be_failing ["is missing", "must respond to bar"]
+            expect(result).to be_failing ["is missing", "must be equal to 23"]
           end
         end
 
@@ -166,7 +150,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must respond to bar"]
+            expect(result).to be_failing ["must be filled", "must be equal to 23"]
           end
         end
 
@@ -174,26 +158,20 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must respond to bar"]
-          end
-        end
-
-        context "with invalid input" do
-          let(:input) { {foo: double(baz: 23)} }
-
-          it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be filled", "must be equal to 23"]
           end
         end
       end
 
       context "with maybe" do
         subject(:schema) do
-          Dry::Schema.define { required(:foo).maybe(interface?: :bar) }
+          Dry::Schema.define do
+            required(:foo).maybe(eql?: 23)
+          end
         end
 
         context "with valid input" do
-          let(:input) { {foo: double(bar: 23)} }
+          let(:input) { {foo: 23} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -204,7 +182,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {} }
 
           it "is not successful" do
-            expect(result).to be_failing ["is missing", "must respond to bar"]
+            expect(result).to be_failing ["is missing", "must be equal to 23"]
           end
         end
 
@@ -220,15 +198,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
-          end
-        end
-
-        context "with invalid input" do
-          let(:input) { {foo: double(baz: 23)} }
-
-          it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be equal to 23"]
           end
         end
       end
@@ -237,11 +207,13 @@ RSpec.describe "Predicates: Interface" do
     context "with optional" do
       context "with value" do
         subject(:schema) do
-          Dry::Schema.define { optional(:foo).value(interface?: :bar) }
+          Dry::Schema.define do
+            optional(:foo).value(eql?: 23)
+          end
         end
 
         context "with valid input" do
-          let(:input) { {foo: double(bar: 23)} }
+          let(:input) { {foo: 23} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -260,7 +232,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be equal to 23"]
           end
         end
 
@@ -268,26 +240,20 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
-          end
-        end
-
-        context "with invalid input" do
-          let(:input) { {foo: double(baz: 23)} }
-
-          it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be equal to 23"]
           end
         end
       end
 
       context "with filled" do
         subject(:schema) do
-          Dry::Schema.define { optional(:foo).filled(interface?: :bar) }
+          Dry::Schema.define do
+            optional(:foo).filled(eql?: 23)
+          end
         end
 
         context "with valid input" do
-          let(:input) { {foo: double(bar: 23)} }
+          let(:input) { {foo: 23} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -306,7 +272,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must respond to bar"]
+            expect(result).to be_failing ["must be filled", "must be equal to 23"]
           end
         end
 
@@ -314,26 +280,20 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must respond to bar"]
-          end
-        end
-
-        context "with invalid input" do
-          let(:input) { {foo: double(baz: 23)} }
-
-          it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be filled", "must be equal to 23"]
           end
         end
       end
 
       context "with maybe" do
         subject(:schema) do
-          Dry::Schema.define { optional(:foo).maybe(interface?: :bar) }
+          Dry::Schema.define do
+            optional(:foo).maybe(eql?: 23)
+          end
         end
 
         context "with valid input" do
-          let(:input) { {foo: double(bar: 23)} }
+          let(:input) { {foo: 23} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -360,15 +320,7 @@ RSpec.describe "Predicates: Interface" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
-          end
-        end
-
-        context "with invalid input" do
-          let(:input) { {foo: double(baz: 23)} }
-
-          it "is not successful" do
-            expect(result).to be_failing ["must respond to bar"]
+            expect(result).to be_failing ["must be equal to 23"]
           end
         end
       end

--- a/spec/integration/schema/predicates/respond_to_spec.rb
+++ b/spec/integration/schema/predicates/respond_to_spec.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe "Predicates: Eql" do
+RSpec.describe "Predicates: Interface" do
   context "with required" do
     subject(:schema) do
-      Dry::Schema.define do
-        required(:foo) { is_eql?(23) }
-      end
+      Dry::Schema.define { required(:foo) { respond_to?(:bar) } }
     end
 
     context "with valid input" do
-      let(:input) { {foo: 23} }
+      let(:input) { {foo: double(bar: 23)} }
 
       it "is successful" do
         expect(result).to be_successful
@@ -20,7 +18,7 @@ RSpec.describe "Predicates: Eql" do
       let(:input) { {} }
 
       it "is not successful" do
-        expect(result).to be_failing ["is missing", "must be equal to 23"]
+        expect(result).to be_failing ["is missing", "must respond to bar"]
       end
     end
 
@@ -28,7 +26,7 @@ RSpec.describe "Predicates: Eql" do
       let(:input) { {foo: nil} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must be equal to 23"]
+        expect(result).to be_failing ["must respond to bar"]
       end
     end
 
@@ -36,20 +34,26 @@ RSpec.describe "Predicates: Eql" do
       let(:input) { {foo: ""} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must be equal to 23"]
+        expect(result).to be_failing ["must respond to bar"]
+      end
+    end
+
+    context "with invalid input" do
+      let(:input) { {foo: double(baz: 23)} }
+
+      it "is not successful" do
+        expect(result).to be_failing ["must respond to bar"]
       end
     end
   end
 
   context "with optional" do
     subject(:schema) do
-      Dry::Schema.define do
-        optional(:foo) { is_eql?(23) }
-      end
+      Dry::Schema.define { optional(:foo) { respond_to?(:bar) } }
     end
 
     context "with valid input" do
-      let(:input) { {foo: 23} }
+      let(:input) { {foo: double(bar: 23)} }
 
       it "is successful" do
         expect(result).to be_successful
@@ -68,7 +72,7 @@ RSpec.describe "Predicates: Eql" do
       let(:input) { {foo: nil} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must be equal to 23"]
+        expect(result).to be_failing ["must respond to bar"]
       end
     end
 
@@ -76,7 +80,15 @@ RSpec.describe "Predicates: Eql" do
       let(:input) { {foo: ""} }
 
       it "is not successful" do
-        expect(result).to be_failing ["must be equal to 23"]
+        expect(result).to be_failing ["must respond to bar"]
+      end
+    end
+
+    context "with invalid input" do
+      let(:input) { {foo: double(baz: 23)} }
+
+      it "is not successful" do
+        expect(result).to be_failing ["must respond to bar"]
       end
     end
   end
@@ -85,13 +97,11 @@ RSpec.describe "Predicates: Eql" do
     context "with required" do
       context "with value" do
         subject(:schema) do
-          Dry::Schema.define do
-            required(:foo).value(is_eql?: 23)
-          end
+          Dry::Schema.define { required(:foo).value(respond_to?: :bar) }
         end
 
         context "with valid input" do
-          let(:input) { {foo: 23} }
+          let(:input) { {foo: double(bar: 23)} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -102,7 +112,7 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {} }
 
           it "is not successful" do
-            expect(result).to be_failing ["is missing", "must be equal to 23"]
+            expect(result).to be_failing ["is missing", "must respond to bar"]
           end
         end
 
@@ -110,7 +120,7 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be equal to 23"]
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
 
@@ -118,20 +128,26 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be equal to 23"]
+            expect(result).to be_failing ["must respond to bar"]
+          end
+        end
+
+        context "with invalid input" do
+          let(:input) { {foo: double(baz: 23)} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
       end
 
       context "with filled" do
         subject(:schema) do
-          Dry::Schema.define do
-            required(:foo).filled(is_eql?: 23)
-          end
+          Dry::Schema.define { required(:foo).filled(respond_to?: :bar) }
         end
 
         context "with valid input" do
-          let(:input) { {foo: 23} }
+          let(:input) { {foo: double(bar: 23)} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -142,7 +158,7 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {} }
 
           it "is not successful" do
-            expect(result).to be_failing ["is missing", "must be equal to 23"]
+            expect(result).to be_failing ["is missing", "must respond to bar"]
           end
         end
 
@@ -150,7 +166,7 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must be equal to 23"]
+            expect(result).to be_failing ["must be filled", "must respond to bar"]
           end
         end
 
@@ -158,20 +174,26 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must be equal to 23"]
+            expect(result).to be_failing ["must be filled", "must respond to bar"]
+          end
+        end
+
+        context "with invalid input" do
+          let(:input) { {foo: double(baz: 23)} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
       end
 
       context "with maybe" do
         subject(:schema) do
-          Dry::Schema.define do
-            required(:foo).maybe(is_eql?: 23)
-          end
+          Dry::Schema.define { required(:foo).maybe(respond_to?: :bar) }
         end
 
         context "with valid input" do
-          let(:input) { {foo: 23} }
+          let(:input) { {foo: double(bar: 23)} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -182,7 +204,7 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {} }
 
           it "is not successful" do
-            expect(result).to be_failing ["is missing", "must be equal to 23"]
+            expect(result).to be_failing ["is missing", "must respond to bar"]
           end
         end
 
@@ -198,7 +220,15 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be equal to 23"]
+            expect(result).to be_failing ["must respond to bar"]
+          end
+        end
+
+        context "with invalid input" do
+          let(:input) { {foo: double(baz: 23)} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
       end
@@ -207,13 +237,11 @@ RSpec.describe "Predicates: Eql" do
     context "with optional" do
       context "with value" do
         subject(:schema) do
-          Dry::Schema.define do
-            optional(:foo).value(is_eql?: 23)
-          end
+          Dry::Schema.define { optional(:foo).value(respond_to?: :bar) }
         end
 
         context "with valid input" do
-          let(:input) { {foo: 23} }
+          let(:input) { {foo: double(bar: 23)} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -232,7 +260,7 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be equal to 23"]
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
 
@@ -240,20 +268,26 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be equal to 23"]
+            expect(result).to be_failing ["must respond to bar"]
+          end
+        end
+
+        context "with invalid input" do
+          let(:input) { {foo: double(baz: 23)} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
       end
 
       context "with filled" do
         subject(:schema) do
-          Dry::Schema.define do
-            optional(:foo).filled(is_eql?: 23)
-          end
+          Dry::Schema.define { optional(:foo).filled(respond_to?: :bar) }
         end
 
         context "with valid input" do
-          let(:input) { {foo: 23} }
+          let(:input) { {foo: double(bar: 23)} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -272,7 +306,7 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: nil} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must be equal to 23"]
+            expect(result).to be_failing ["must be filled", "must respond to bar"]
           end
         end
 
@@ -280,20 +314,26 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be filled", "must be equal to 23"]
+            expect(result).to be_failing ["must be filled", "must respond to bar"]
+          end
+        end
+
+        context "with invalid input" do
+          let(:input) { {foo: double(baz: 23)} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
       end
 
       context "with maybe" do
         subject(:schema) do
-          Dry::Schema.define do
-            optional(:foo).maybe(is_eql?: 23)
-          end
+          Dry::Schema.define { optional(:foo).maybe(respond_to?: :bar) }
         end
 
         context "with valid input" do
-          let(:input) { {foo: 23} }
+          let(:input) { {foo: double(bar: 23)} }
 
           it "is successful" do
             expect(result).to be_successful
@@ -320,7 +360,15 @@ RSpec.describe "Predicates: Eql" do
           let(:input) { {foo: ""} }
 
           it "is not successful" do
-            expect(result).to be_failing ["must be equal to 23"]
+            expect(result).to be_failing ["must respond to bar"]
+          end
+        end
+
+        context "with invalid input" do
+          let(:input) { {foo: double(baz: 23)} }
+
+          it "is not successful" do
+            expect(result).to be_failing ["must respond to bar"]
           end
         end
       end

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe Dry::Schema, ".define" do
 
     context "sum type" do
       let(:type) do
-        Types::Params::Integer.constrained(gteq: 18) | Types::String.constrained(is_eql: "old enough")
+        Types::Params::Integer.constrained(gteq: 18) | Types::String.constrained(eql: "old enough")
       end
 
       subject(:schema) do
@@ -209,7 +209,7 @@ RSpec.describe Dry::Schema, ".define" do
     context "constrained sum type" do
       let(:type) do
         int = Types::Integer
-        (int.constrained([:odd]) | int.constrained(is_eql: 0)).constrained(gteq: 18)
+        (int.constrained([:odd]) | int.constrained(eql: 0)).constrained(gteq: 18)
       end
 
       subject(:schema) do

--- a/spec/integration/type_inheritance_spec.rb
+++ b/spec/integration/type_inheritance_spec.rb
@@ -50,25 +50,25 @@ RSpec.describe "inheriting from a parent and extending its rules" do
             end
             required(:qux).hash do
               required(:hello).hash do
-                required(:wow).value(:string, is_eql?: "a")
-                required(:such).value(:string, is_eql?: "cool")
+                required(:wow).value(:string, eql?: "a")
+                required(:such).value(:string, eql?: "cool")
                 required(:amaze).value(array[:string], size?: 1)
               end
               required(:my).hash do
-                required(:wow).value(:string, is_eql?: "b")
-                required(:such).value(:string, is_eql?: "cool")
+                required(:wow).value(:string, eql?: "b")
+                required(:such).value(:string, eql?: "cool")
                 required(:amaze).value(array[:string], size?: 1)
               end
               required(:friend).hash do
-                required(:wow).filled(:string, is_eql?: "c")
-                required(:such).filled(:string, is_eql?: "cool")
+                required(:wow).filled(:string, eql?: "c")
+                required(:such).filled(:string, eql?: "cool")
                 required(:amaze).value(array[:string], size?: 1)
               end
             end
           end
           required(:last).filled.hash do
-            required(:not).value(:array, is_eql?: ["rad"])
-            required(:least).value(:string, is_eql?: "done")
+            required(:not).value(:array, eql?: ["rad"])
+            required(:least).value(:string, eql?: "done")
           end
         end
       end

--- a/spec/unit/dry/schema/trace_spec.rb
+++ b/spec/unit/dry/schema/trace_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe Dry::Schema::Trace do
     end
 
     it "stores evaluated predicates with args" do
-      trace.evaluate(is_eql?: "foo")
+      trace.evaluate(eql?: "foo")
 
-      expect(trace.captures).to include(trace.is_eql?("foo"))
+      expect(trace.captures).to include(trace.eql?("foo"))
     end
   end
 
   describe "#method_missing" do
     it "creates predicate objects" do
-      predicate = trace.is_eql?("foo")
+      predicate = trace.eql?("foo")
 
-      expect(predicate.name).to be(:is_eql?)
+      expect(predicate.name).to be(:eql?)
       expect(predicate.args).to eql(["foo"])
     end
 


### PR DESCRIPTION
This makes sure that `eql?` and `respond_to?` with changed arity in dry-logic will work as expected, so that we don't have to go through deprecation and renaming of these predicates.

For context - it turned out that some tools that inspect all runtime objects rely on `eql?` or `respond_to?`, which means that `Dry::Logic::Predicates` module which has its own implementation of these methods *broke* such tools. To fix it, we've made the predicates compatible with the default `Object#eql?` and `Object#respond_to?` behavior.