### PR TITLE
Fix skipped ruby2_keywords flag warnings

### DIFF
--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -122,7 +122,6 @@ module Dry
             macro.call(...)
           end
         end
-        ruby2_keywords :schema if respond_to?(:ruby2_keywords, true)
 
         # Specify a nested hash with enforced `hash?` type-check
         #
@@ -137,7 +136,6 @@ module Dry
             macro.call(...)
           end
         end
-        ruby2_keywords :hash if respond_to?(:ruby2_keywords, true)
 
         # Specify predicates that should be applied to each element of an array
         #
@@ -161,7 +159,6 @@ module Dry
             macro.value(...)
           end
         end
-        ruby2_keywords :each if respond_to?(:ruby2_keywords, true)
 
         # Like `each` but sets `array?` type-check
         #
@@ -181,7 +178,6 @@ module Dry
             macro.value(...)
           end
         end
-        ruby2_keywords :array if respond_to?(:ruby2_keywords, true)
 
         # Set type spec
         #

--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -26,7 +26,6 @@ module Dry
           (filter_schema_dsl[name] || filter_schema_dsl.optional(name)).value(...)
           self
         end
-        ruby2_keywords(:filter) if respond_to?(:ruby2_keywords, true)
 
         # Coerce macro to a rule
         #


### PR DESCRIPTION
```
gems/dry-schema-1.11.3/lib/dry/schema/macros/dsl.rb:125: warning: Skipping set of ruby2_keywords flag for schema (method accepts keywords or method does not accept argument splat)
gems/dry-schema-1.11.3/lib/dry/schema/macros/dsl.rb:140: warning: Skipping set of ruby2_keywords flag for hash (method accepts keywords or method does not accept argument splat)
gems/dry-schema-1.11.3/lib/dry/schema/macros/dsl.rb:164: warning: Skipping set of ruby2_keywords flag for each (method accepts keywords or method does not accept argument splat)
gems/dry-schema-1.11.3/lib/dry/schema/macros/dsl.rb:184: warning: Skipping set of ruby2_keywords flag for array (method accepts keywords or method does not accept argument splat)
gems/dry-schema-1.11.3/lib/dry/schema/macros/key.rb:29: warning: Skipping set of ruby2_keywords flag for filter (method accepts keywords or method does not accept argument splat)
```

When using `...` you don't need to call `ruby2_keywords`.

From what I figured, these signatures were changed by rubocop recently.