### PR TITLE
Implement `eql?` predicate to json-schema `const` keyword conversion

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -46,6 +46,7 @@ module Dry
           uuid_v5?: {
             pattern: "^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$"
           },
+          eql?: {const: IDENTITY},
           gt?: {exclusiveMinimum: IDENTITY},
           gteq?: {minimum: IDENTITY},
           lt?: {exclusiveMaximum: IDENTITY},
@@ -162,9 +163,15 @@ module Dry
         def visit_predicate(node, opts = EMPTY_HASH)
           name, rest = node
 
-          if name.equal?(:key?)
+          case name
+          when :key?
             prop_name = rest[0][1]
             keys[prop_name] = {}
+          when :eql?
+            target = keys[opts[:key]]
+            type_opts = fetch_type_opts_for_predicate(:eql?, rest, target)
+
+            merge_opts!(target, type_opts)
           else
             target = keys[opts[:key]]
             type_opts = fetch_type_opts_for_predicate(name, rest, target)

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -230,6 +230,54 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
     end
   end
 
+  context "when using eql? predicate" do
+    include_examples "metaschema validation"
+
+    subject(:schema) do
+      Dry::Schema.JSON do
+        required(:id).value(:integer, :filled?, eql?: 42)
+        required(:category).value(:string, eql?: "fruits")
+        required(:sub_categories).value(array[:string], eql?: %w[citrus berry])
+        required(:quantities).value(:hash, eql?: {citrus: 2, berry: 1})
+      end
+    end
+
+    it "returns the correct json schema" do
+      expect(schema.json_schema).to eql(
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        type: "object",
+        properties: {
+          id: {
+            type: "integer",
+            not: {
+              type: "null"
+            },
+            const: 42
+          },
+          category: {
+            type: "string",
+            const: "fruits"
+          },
+          sub_categories: {
+            type: "array",
+            const: %w[citrus berry],
+            items: {
+              type: "string"
+            }
+          },
+          quantities: {
+            type: "object",
+            const: {
+              berry: 1,
+              citrus: 2
+            }
+          }
+        },
+        required: %w[id category sub_categories quantities]
+      )
+    end
+  end
+
   describe "inferring types" do
     {
       array: {type: "array"},


### PR DESCRIPTION
Hi!  This change would allow us to convert the `eql?` predicate to the `const` json-schema keyword which was available since the draft-06 of the spec.

References:
- https://json-schema.org/draft/2020-12/json-schema-validation.html#name-const
- https://json-schema.org/draft-06/json-schema-release-notes.html#additions-and-backwards-compatible-changes 

Thank you! 🙇