### PR TITLE
Fix type of objects nested under arrays. Fixes #400

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -90,7 +90,7 @@ module Dry
         def visit_set(node, opts = EMPTY_HASH)
           target = (key = opts[:key]) ? self.class.new(loose: loose?) : self
 
-          node.map { |child| target.visit(child, opts) }
+          node.map { |child| target.visit(child, opts.except(:member)) }
 
           return unless key
 

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
 
         required(:roles).array(:hash) do
           required(:name).value(:string, min_size?: 12, max_size?: 36)
+
+          required(:metadata).hash do
+            required(:assigned_at).value(:time)
+          end
         end
 
         optional(:address).hash do
@@ -59,9 +63,19 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
                   type: "string",
                   minLength: 12,
                   maxLength: 36
+                },
+                metadata: {
+                  type: "object",
+                  properties: {
+                    assigned_at: {
+                      format: "time",
+                      type: "string",
+                    },
+                  },
+                  required: %w[assigned_at]
                 }
               },
-              required: ["name"]
+              required: %w[name metadata]
             }
           },
           address: {


### PR DESCRIPTION
Fix for https://github.com/dry-rb/dry-schema/issues/400

Objects nested under arrays are not neccesailry arrays themselves - the `:member` option shouldn't be passed down the AST.