### PR TITLE
Fix json-schema type of maybe array

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -97,7 +97,7 @@ module Dry
           target_info = opts[:member] ? {items: target.to_h} : target.to_h
           type = opts[:member] ? "array" : "object"
 
-          keys.update(key => {**keys[key], type: type, **target_info})
+          merge_opts!(keys[key], {type: type, **target_info})
         end
 
         # @api private
@@ -210,7 +210,7 @@ module Dry
           orig_type = orig_opts[:type]
 
           if orig_type && new_type && orig_type != new_type
-            new_opts[:type] = [orig_type, new_type]
+            new_opts[:type] = [orig_type, new_type].flatten.uniq
           end
 
           orig_opts.merge!(new_opts)

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -108,6 +108,68 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
     end
   end
 
+  context "when using maybe array types" do
+    include_examples "metaschema validation"
+
+    subject(:schema) do
+      Dry::Schema.JSON do
+        required(:list).maybe(:array).each(:str?)
+      end
+    end
+
+    it "returns the correct json schema" do
+      expect(schema.json_schema).to eql(
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        type: "object",
+        properties: {
+          list: {
+            type: %w[null array],
+            items: {
+              type: "string"
+            }
+          }
+        },
+        required: %w[list]
+      )
+    end
+  end
+
+  context "when using maybe array types with nested properties" do
+    include_examples "metaschema validation"
+
+    subject(:schema) do
+      Dry::Schema.JSON do
+        required(:list).maybe(:array).each do
+          hash do
+            required(:name).value(:string)
+          end
+        end
+      end
+    end
+
+    it "returns the correct json schema" do
+      expect(schema.json_schema).to eql(
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        type: "object",
+        properties: {
+          list: {
+            type: %w[null array],
+            items: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string"
+                }
+              },
+              required: %w[name]
+            }
+          }
+        },
+        required: %w[list]
+      )
+    end
+  end
+
   describe "filled macro" do
     context "when there is no type" do
       include_examples "metaschema validation"


### PR DESCRIPTION
Make sure to not override an existing `type: ["null", "array"]` with `type: "array"` if it's already filled by `visit_predicate` before `visit_set`.

For example for the test schema https://github.com/dry-rb/dry-schema/blob/3065a8b97d89befce9379e6f5655783957123744/spec/extensions/json_schema/schema_spec.rb#L142-L146

the result of the fix is:

```diff
{
   "$schema": "http://json-schema.org/draft-06/schema#",
   "type": "object",
   "properties": {
     "list": {
-      "type": "array",
+      "type": [
+        "null",
+        "array"
+      ],
       "items": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           }
         },
         "required": [
           "name"
         ]
       }
     }
   },
   "required": [
     "list"
   ]
 }
```