### PR TITLE
Support pluralization in I18n messages backend

### DIFF
--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -234,6 +234,42 @@ RSpec.describe Dry::Schema::Messages::I18n do
           expect(meta).to eq({code: 123})
         end
       end
+
+      context "with plural message" do
+        before do
+          store_errors(
+            apples: {
+              one: "single apple",
+              other: "%{count} apples"
+            }
+          )
+        end
+
+        it "uses correct variant" do
+          template, meta = messages[:apples, path: :path, count: 3]
+
+          expect(template.()).to eql("3 apples")
+          expect(meta).to eql({})
+        end
+
+        context "without count" do
+          it "returns meta" do
+            template, meta = messages[:apples, path: :path]
+
+            expect(template.()).to eql({
+                                         one: "single apple",
+                                         other: "%{count} apples"
+                                       })
+
+            expect(template.(count: 1)).to eql("single apple")
+
+            expect(meta).to eql({
+                                  one: "single apple",
+                                  other: "%{count} apples"
+                                })
+          end
+        end
+      end
     end
 
     context "with dynamic locale" do


### PR DESCRIPTION
It turned out that pluralization in i81n backend does not work, because `:count` is stripped out from provided options. 

```yaml
  en:
    foo:
      one: %{count} foo
      other: %{count} foos
```
```ruby
  I18n.t(:foo, count: 1) #=> 1 foo
  I18n.t(:foo, count: 1) #=> 2 foos
```

I suggest to pass all options down to `I18n.t` method. Already tested this in production with dry-validation.

Not sure that the `meta` in case of pluralization should be returned when no `:count` provided, because `meta` and `template` are the same in that case. Is it ok? 

```ruby
template, meta = messages[:apples, path: :path]

expect(meta).to eql({
  one: "single apple",
  other: "%{count} apples"
})

expect(template.()).to eql({
  one: "single apple",
  other: "%{count} apples"
})
```