### PR TITLE
Fix info extension for maybe macro

### DIFF
--- a/lib/dry/schema/extensions/info/schema_compiler.rb
+++ b/lib/dry/schema/extensions/info/schema_compiler.rb
@@ -71,7 +71,7 @@ module Dry
         # @api private
         def visit_implication(node, opts = EMPTY_HASH)
           node.each do |el|
-            visit(el, opts.merge(required: false))
+            visit(el, opts.merge(required: false, nullable: false))
           end
         end
 
@@ -83,7 +83,14 @@ module Dry
         # @api private
         def visit_key(node, opts = EMPTY_HASH)
           name, rest = node
-          visit(rest, opts.merge(key: name, required: true))
+          visit(rest, opts.merge(key: name, required: true, nullable: false))
+        end
+
+        # @api private
+        def visit_not(_node, opts = EMPTY_HASH)
+          key = opts[:key]
+
+          keys[key][:nullable] = true
         end
 
         # @api private
@@ -93,7 +100,10 @@ module Dry
           key = opts[:key]
 
           if name.equal?(:key?)
-            keys[rest[0][1]] = {required: opts.fetch(:required, true)}
+            required = opts.fetch(:required, true)
+            nullable = opts.fetch(:nullable, false)
+
+            keys[rest[0][1]] = {required: required, nullable: nullable}
           else
             type = PREDICATE_TO_TYPE[name]
             assign_type(key, type) if type

--- a/spec/extensions/info/schema_spec.rb
+++ b/spec/extensions/info/schema_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dry::Schema::JSON, "#info" do
   subject(:schema) do
     Dry::Schema.JSON do
       required(:email).filled(:string)
-      optional(:age).filled(:integer)
+      optional(:age).maybe(:integer)
 
       required(:roles).array(:hash) do
         required(:name).filled(:string)
@@ -17,9 +17,9 @@ RSpec.describe Dry::Schema::JSON, "#info" do
 
       optional(:address).hash do
         required(:street).filled(:string)
-        required(:zipcode).filled(:string)
+        optional(:zipcode).filled(:string)
         required(:city).filled(:string)
-        optional(:phone).filled(:string)
+        optional(:phone).maybe(:string)
       end
     end
   end
@@ -28,23 +28,28 @@ RSpec.describe Dry::Schema::JSON, "#info" do
     {
       keys: {
         email: {
+          nullable: false,
           required: true,
           type: "string"
         },
         age: {
+          nullable: true,
           required: false,
           type: "integer"
         },
         roles: {
+          nullable: false,
           required: true,
           type: "array",
           member: {
             keys: {
               name: {
+                nullable: false,
                 required: true,
                 type: "string"
               },
               desc: {
+                nullable: false,
                 required: false,
                 type: "string"
               }
@@ -52,22 +57,27 @@ RSpec.describe Dry::Schema::JSON, "#info" do
           }
         },
         address: {
+          nullable: false,
           required: false,
           type: "hash",
           keys: {
             street: {
+              nullable: false,
               required: true,
               type: "string"
             },
             zipcode: {
-              required: true,
+              nullable: false,
+              required: false,
               type: "string"
             },
             city: {
+              nullable: false,
               required: true,
               type: "string"
             },
             phone: {
+              nullable: true,
               required: false,
               type: "string"
             }
@@ -95,20 +105,24 @@ RSpec.describe Dry::Schema::JSON, "#info" do
       {
         keys: {
           opt1: {
+            nullable: false,
             required: true,
             type: "array"
           },
           opt2: {
+            nullable: false,
             required: true,
             type: "array",
             member: "string"
           },
           opt3: {
+            nullable: false,
             required: true,
             type: "array",
             member: "integer"
           },
           opt4: {
+            nullable: false,
             required: true,
             type: "array",
             member: "bool"
@@ -136,7 +150,7 @@ RSpec.describe Dry::Schema::JSON, "#info" do
     }.each do |type_spec, type_name|
       it "infers '#{type_name}' from '#{type_spec}'" do
         expect(Dry::Schema.define { required(:key).value(type_spec) }.info).to eql(
-          keys: {key: {required: true, type: type_name}}
+          keys: {key: {nullable: false, required: true, type: type_name}}
         )
       end
     end


### PR DESCRIPTION
Fixes info extension for maybe macro, it introduces `nullable` flag to represent whether a key is nullable or not.

```ruby
    schema = Dry::Schema.JSON do
      required(:email).filled(:string)
      optional(:age).maybe(:integer)
    end
```
**BEFORE**
```
irb(main):030> schema.info
/usr/local/bundle/ruby/3.2.0/gems/dry-schema-1.13.3/lib/dry/schema/extensions/info/schema_compiler.rb:46:in `public_send': undefined method `visit_not' for #<Dry::Schema::Info::SchemaCompiler:0x00007fc01e0ce780 @keys={:email=>{:required=>true, :type=>"string"}, :age=>{:required=>false}}> (NoMethodError)

          public_send(:"visit_#{meth}", rest, opts)
          ^^^^^^^^^^^
Did you mean?  visit_and
               visit_set
               visit_key
```
**AFTER**
```
irb(main):156> schema.info
=> {:keys=>{:email=>{:required=>true, :nullable=>false, :type=>"string"}, :age=>{:required=>false, :nullable=>true, :type=>"integer"}}}
```