### PR TITLE
Do not eager load i18n message backend

### DIFF
--- a/lib/dry/schema.rb
+++ b/lib/dry/schema.rb
@@ -32,6 +32,7 @@ module Dry
           "#{root}/dry/schema/{constants,errors,version,extensions}.rb",
           "#{root}/dry/schema/extensions"
         )
+        loader.do_not_eager_load("#{root}/dry/schema/messages/i18n.rb")
         loader.inflector.inflect("dsl" => "DSL")
       end
     end


### PR DESCRIPTION
This backend has a dependency on the i18n library which may not be available in all environments.