### PR TITLE
update README with instructions on sum types

### DIFF
--- a/docsite/source/basics/macros.html.md
+++ b/docsite/source/basics/macros.html.md
@@ -19,6 +19,15 @@ Dry::Schema.Params do
 end
 ```
 
+Predicates passed as an array will be `OR`-ed automatically:
+
+```ruby
+Dry::Schema.Params do
+  # expands to `required(:id) { str? | int? }`
+  required(:id).value([:string, :integer])
+end
+```
+
 ### filled
 
 Use it when a value is expected to be filled. "filled" means that the value is non-nil and, in the case of a `String`, `Hash`, or `Array` value, that the value is not `.empty?`.


### PR DESCRIPTION
I had to look into specs to discover that this behavior was supported:

https://github.com/dry-rb/dry-schema/blob/main/spec/integration/params/macros/value_spec.rb#L31

I feel this is a very useful pattern, and that making it more discoverable will be more user-friendly.