### PR TITLE
Improve support for Sets in `included_in?` and `excluded_from?` predicates

### DIFF
--- a/lib/dry/schema/message_compiler.rb
+++ b/lib/dry/schema/message_compiler.rb
@@ -209,7 +209,7 @@ module Dry
       def message_tokens(args)
         tokens = args.each_with_object({}) do |arg, hash|
           case arg[1]
-          when Array
+          when Array, Set
             hash[arg[0]] = arg[1].join(LIST_SEPARATOR)
           when Range
             hash["#{arg[0]}_left".to_sym] = arg[1].first

--- a/spec/integration/schema/predicates/excluded_from/set_spec.rb
+++ b/spec/integration/schema/predicates/excluded_from/set_spec.rb
@@ -1,0 +1,459 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Excluded From" do
+  context "Set" do
+    context "with required" do
+      subject(:schema) do
+        Dry::Schema.define do
+          required(:foo) { excluded_from?(Set[1, 3, 5]) }
+        end
+      end
+
+      context "with valid input" do
+        let(:input) { {foo: 2} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["is missing", "must not be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with nil input" do
+        let(:input) { {foo: nil} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with blank input" do
+        let(:input) { {foo: ""} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with invalid type" do
+        let(:input) { {foo: {a: 1}} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with invalid input" do
+        let(:input) { {foo: 5} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+        end
+      end
+    end
+
+    context "with optional" do
+      subject(:schema) do
+        Dry::Schema.define do
+          optional(:foo) { excluded_from?(Set[1, 3, 5]) }
+        end
+      end
+
+      context "with valid input" do
+        let(:input) { {foo: 2} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with missing input" do
+        let(:input) { {} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with nil input" do
+        let(:input) { {foo: nil} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with blank input" do
+        let(:input) { {foo: ""} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with invalid type" do
+        let(:input) { {foo: {a: 1}} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with invalid input" do
+        let(:input) { {foo: 5} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+        end
+      end
+    end
+
+    context "as macro" do
+      context "with required" do
+        context "with value" do
+          subject(:schema) do
+            Dry::Schema.define do
+              required(:foo).value(excluded_from?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 2} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["is missing", "must not be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 5} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with filled" do
+          subject(:schema) do
+            Dry::Schema.define do
+              required(:foo).filled(excluded_from?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 2} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["is missing", "must not be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must not be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must not be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 5} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with maybe" do
+          subject(:schema) do
+            Dry::Schema.define do
+              required(:foo).maybe(excluded_from?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 2} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["is missing", "must not be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 5} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+            end
+          end
+        end
+      end
+
+      context "with optional" do
+        context "with value" do
+          subject(:schema) do
+            Dry::Schema.define do
+              optional(:foo).value(excluded_from?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 2} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 5} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with filled" do
+          subject(:schema) do
+            Dry::Schema.define do
+              optional(:foo).filled(excluded_from?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 2} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must not be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must not be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 5} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with maybe" do
+          subject(:schema) do
+            Dry::Schema.define do
+              optional(:foo).maybe(excluded_from?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 2} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 5} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must not be one of: 1, 3, 5"]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/schema/predicates/included_in/set_spec.rb
+++ b/spec/integration/schema/predicates/included_in/set_spec.rb
@@ -1,0 +1,459 @@
+# frozen_string_literal: true
+
+RSpec.context "Predicates: Included In" do
+  context "Set" do
+    context "with required" do
+      subject(:schema) do
+        Dry::Schema.define do
+          required(:foo) { included_in?(Set[1, 3, 5]) }
+        end
+      end
+
+      context "with valid input" do
+        let(:input) { {foo: 3} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["is missing", "must be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with nil input" do
+        let(:input) { {foo: nil} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with blank input" do
+        let(:input) { {foo: ""} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with invalid type" do
+        let(:input) { {foo: {a: 1}} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with invalid input" do
+        let(:input) { {foo: 4} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+    end
+
+    context "with optional" do
+      subject(:schema) do
+        Dry::Schema.define do
+          optional(:foo) { included_in?(Set[1, 3, 5]) }
+        end
+      end
+
+      context "with valid input" do
+        let(:input) { {foo: 3} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with missing input" do
+        let(:input) { {} }
+
+        it "is successful" do
+          expect(result).to be_successful
+        end
+      end
+
+      context "with nil input" do
+        let(:input) { {foo: nil} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with blank input" do
+        let(:input) { {foo: ""} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with invalid type" do
+        let(:input) { {foo: {a: 1}} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+
+      context "with invalid input" do
+        let(:input) { {foo: 4} }
+
+        it "is not successful" do
+          expect(result).to be_failing ["must be one of: 1, 3, 5"]
+        end
+      end
+    end
+
+    context "as macro" do
+      context "with required" do
+        context "with value" do
+          subject(:schema) do
+            Dry::Schema.define do
+              required(:foo).value(included_in?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 3} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["is missing", "must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 4} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with filled" do
+          subject(:schema) do
+            Dry::Schema.define do
+              required(:foo).filled(included_in?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 3} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["is missing", "must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 4} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with maybe" do
+          subject(:schema) do
+            Dry::Schema.define do
+              required(:foo).maybe(included_in?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 3} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["is missing", "must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 4} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+        end
+      end
+
+      context "with optional" do
+        context "with value" do
+          subject(:schema) do
+            Dry::Schema.define do
+              optional(:foo).value(included_in?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 3} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 4} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with filled" do
+          subject(:schema) do
+            Dry::Schema.define do
+              optional(:foo).filled(included_in?: [1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 3} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be filled", "must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 4} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+        end
+
+        context "with maybe" do
+          subject(:schema) do
+            Dry::Schema.define do
+              optional(:foo).maybe(included_in?: Set[1, 3, 5])
+            end
+          end
+
+          context "with valid input" do
+            let(:input) { {foo: 3} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with nil input" do
+            let(:input) { {foo: nil} }
+
+            it "is successful" do
+              expect(result).to be_successful
+            end
+          end
+
+          context "with blank input" do
+            let(:input) { {foo: ""} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid type" do
+            let(:input) { {foo: {a: 1}} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+
+          context "with invalid input" do
+            let(:input) { {foo: 4} }
+
+            it "is not successful" do
+              expect(result).to be_failing ["must be one of: 1, 3, 5"]
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request enhances support for using [Set](https://docs.ruby-lang.org/en/master/Set.html) with the `included_in?` and `excluded_from?` predicates:

* Update compiled error messages for sets. With this change, messages like `"must be one of: 1, 3, 5"` are produced instead of `"must be one of: #<Set: {1, 3, 5}>"`. This makes the error clearer, especially when exposed to end users.
* Add tests to demonstrate that Set is supported, as it responds to `#include?`.

Using sets is arguably more natural and efficient for membership checks, so explicitly supporting it makes sense.