### PR TITLE
Switch to json_schemer from json-schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem "dry-monads"
   gem "dry-struct"
   gem "i18n", require: false
-  gem "json-schema"
+  gem "json_schemer"
   gem "ostruct"
   gem "super_diff"
   gem "transproc"

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "json-schema"
+require "json_schemer"
 
 RSpec.describe Dry::Schema::JSON, "#json_schema" do
   before do
@@ -10,10 +10,9 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
   shared_examples "metaschema validation" do
     describe "validating against the metaschema" do
       it "produces a valid json schema document for draft6" do
-        metaschema = JSON::Validator.validator_for_name("draft6").metaschema
         input = schema.respond_to?(:json_schema) ? schema.json_schema : schema
 
-        JSON::Validator.validate!(metaschema, input)
+        expect(JSONSchemer.validate_schema(input).to_a).to be_empty
       end
     end
   end


### PR DESCRIPTION
json-schema is unmaintained and only supports up to draft-06 of JSON Schema. That is three versions older than the latest specification. json_schemer is supported and supports all versions of JSON Schema, including 2020-12, which is the latest one.

This change swaps one dependency for another in order to support newer versions.