### PR TITLE
Fix: Allow use of symbol for configuration `top_namespace`

### DIFF
--- a/lib/dry/schema/config.rb
+++ b/lib/dry/schema/config.rb
@@ -46,7 +46,7 @@ module Dry
         setting :backend, default: :yaml
         setting :namespace
         setting :load_paths, default: ::Set[DEFAULT_MESSAGES_PATH], constructor: :dup.to_proc
-        setting :top_namespace, default: DEFAULT_MESSAGES_ROOT
+        setting :top_namespace, default: DEFAULT_MESSAGES_ROOT, constructor: :to_s.to_proc
         setting :default_locale
       end
 

--- a/spec/integration/messages/namespaced_spec.rb
+++ b/spec/integration/messages/namespaced_spec.rb
@@ -89,5 +89,12 @@ RSpec.describe "Namespaced messages" do
 
       expect(result.errors(full: true)[:post_body]).to eql(["(dry_validation) Post body must be filled"])
     end
+
+    it "allows symbol for top namespace" do
+      schema = Dry::Schema.Params do
+        config.messages.top_namespace = :dry_validation
+      end
+      expect(schema.config.messages.top_namespace).to eql "dry_validation"
+    end
   end
 end


### PR DESCRIPTION
Using a `top_namespace` in configuration that is a symbol fails with further processing where a string is expected. Relying on a conversion in settings constructor prevents an unexpected error.

> What error is happening?

Given a symbol is used for `top_namespace`, it results in the following error:

```
Namespaced messages with top namespace allows symbol for top namespace
     Failure/Error: data.transform_keys { _1.gsub(DEFAULT_MESSAGES_ROOT, config.top_namespace) }

     TypeError:
       no implicit conversion of Symbol into String
```


> [!NOTE]
> Ref: [Related issue 734 in dry-validation](https://github.com/dry-rb/dry-validation/issues/734)