### PR TITLE
Add support for intersection types in schema definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ## [Unreleased]
 
+### Fixed
+
+- Support for intersection types (created with `&` operator) in schema definitions (fixes #494) (@baweaver)
 
 ## [1.14.1] - 2025-03-03
 

--- a/lib/dry/schema/macros/dsl.rb
+++ b/lib/dry/schema/macros/dsl.rb
@@ -234,6 +234,10 @@ module Dry
               type_rule = [type_spec.left, type_spec.right].map { |ts|
                 new(klass: Core, chain: false).value(ts)
               }.reduce(:|)
+            elsif type_spec.is_a?(Dry::Types::Intersection) && set_type
+              type_rule = [type_spec.left, type_spec.right].map { |ts|
+                new(klass: Core, chain: false).value(ts)
+              }.reduce(:&)
             else
               type_predicates = predicate_inferrer[resolved_type]
 

--- a/lib/dry/schema/predicate_inferrer.rb
+++ b/lib/dry/schema/predicate_inferrer.rb
@@ -4,7 +4,16 @@ module Dry
   module Schema
     # @api private
     class PredicateInferrer < ::Dry::Types::PredicateInferrer
-      Compiler = ::Class.new(superclass::Compiler)
+      Compiler = ::Class.new(superclass::Compiler) do
+        # @api private
+        def visit_intersection(node)
+          left_node, right_node, = node
+          left = visit(left_node)
+          right = visit(right_node)
+
+          [left, right].flatten.compact
+        end
+      end
 
       def initialize(registry = PredicateRegistry.new)
         super

--- a/lib/dry/schema/primitive_inferrer.rb
+++ b/lib/dry/schema/primitive_inferrer.rb
@@ -4,7 +4,13 @@ module Dry
   module Schema
     # @api private
     class PrimitiveInferrer < ::Dry::Types::PrimitiveInferrer
-      Compiler = ::Class.new(superclass::Compiler)
+      Compiler = ::Class.new(superclass::Compiler) do
+        # @api private
+        def visit_intersection(node)
+          left, right = node
+          [visit(left), visit(right)].flatten(1)
+        end
+      end
 
       def initialize
         super

--- a/spec/integration/schema/intersection_types_spec.rb
+++ b/spec/integration/schema/intersection_types_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe "Intersection types" do
+  context "with hash schemas" do
+    let(:schema) do
+      Dry::Schema.Params do
+        required(:body).value(
+          Types::Hash.schema(a: Types::String) & 
+          (Types::Hash.schema(b: Types::String) | Types::Hash.schema(c: Types::String))
+        )
+      end
+    end
+
+    it "validates intersection of hash schemas successfully" do
+      result = schema.call(body: {a: "test", b: "value"})
+      
+      expect(result).to be_success
+      expect(result.to_h).to eq(body: {a: "test", b: "value"})
+    end
+
+    it "validates intersection with alternative branch" do
+      result = schema.call(body: {a: "test", c: "value"})
+      
+      expect(result).to be_success
+      expect(result.to_h).to eq(body: {a: "test", c: "value"})
+    end
+
+    it "fails when intersection requirements not met" do
+      result = schema.call(body: {b: "value"})
+      
+      expect(result).to be_failure
+      expect(result.errors.to_h).to eq(body: {a: ["is missing"]})
+    end
+  end
+
+  context "with simple type intersection" do
+    let(:schema) do
+      Dry::Schema.Params do
+        required(:value).value(Types::String & Types::Params::String)
+      end
+    end
+
+    it "validates simple intersection types" do
+      result = schema.call(value: "test")
+      
+      expect(result).to be_success
+      expect(result.to_h).to eq(value: "test")
+    end
+  end
+
+  context "with DSL predicates and intersection" do
+    let(:schema) do
+      Dry::Schema.Params do
+        required(:name).value(Types::String & Types::Params::String) { filled? & min_size?(2) }
+      end
+    end
+
+    it "combines type intersection with predicate rules" do
+      result = schema.call(name: "John")
+      
+      expect(result).to be_success
+      expect(result.to_h).to eq(name: "John")
+    end
+
+    it "fails when predicate rules not met" do
+      result = schema.call(name: "J")
+      
+      expect(result).to be_failure
+      expect(result.errors.to_h).to eq(name: ["size cannot be less than 2"])
+    end
+  end
+end


### PR DESCRIPTION
## Add support for intersection types in schema definitions

Fixes #494

### Problem

Dry-schema was failing when using intersection types (created with & operator) in schema definitions, throwing  `NoMethodError: undefined method 'visit_intersection'`.

### Root Cause

The `PredicateInferrer::Compiler` and `PrimitiveInferrer::Compiler` classes didn't have methods to handle 
intersection type AST nodes, and the DSL wasn't processing intersection types like it does for sum types.

Chances are that parts of this change should move upstream to `Dry::Types`.

### Solution

• Added `visit_intersection` methods to both compiler classes to handle intersection type inference
• Extended `extract_type_spec` to process intersection types with AND logic (similar to how sum types use OR 
logic)
• Intersection types now properly validate that ALL constituent types must pass

### Changes

• `lib/dry/schema/predicate_inferrer.rb`: Add `visit_intersection` method
• `lib/dry/schema/primitive_inferrer.rb`: Add `visit_intersection` method  
• `lib/dry/schema/macros/dsl.rb`: Handle intersection types in `extract_type_spec`
• `spec/integration/schema/intersection_types_spec.rb`: Comprehensive test coverage
• `CHANGELOG.md`: Document the fix

### Testing

• Validates the exact example from the issue works correctly
• Tests intersection with sum types (complex algebraic data types)
• Tests DSL integration with predicate rules
• Tests proper validation logic (AND semantics)

### Example Usage

```ruby
# Now works without errors
intersection_type =
  Types::Hash.schema(a: Types::String) & 
  (Types::Hash.schema(b: Types::String) | Types::Hash.schema(c: Types::String))

schema = Dry::Schema.Params do
  required(:body).value(intersection_type)
end

schema.call(body: {a: "test", b: "value"}) # passes
schema.call(body: {b: "value"})            # fails - missing 'a'
```