### PR TITLE
Fix JSON schema generation for Dry::Struct wrapped in constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ## [Unreleased]
 
+### Fixed
+
+- JSON schema generation now properly handles Dry::Struct wrapped in constructors (fixes #495) (@baweaver)
 
 ## [1.14.1] - 2025-03-03
 

--- a/lib/dry/schema/extensions/struct.rb
+++ b/lib/dry/schema/extensions/struct.rb
@@ -27,7 +27,8 @@ module Dry
                                    "a struct class (#{name.inspect} => #{args[0]})"
             end
 
-            schema = struct_compiler.(args[0])
+            struct_class = extract_struct_class(args[0])
+            schema = struct_compiler.(struct_class)
 
             super(schema, *args.drop(1))
             type(schema_dsl.types[name].constructor(schema))
@@ -39,7 +40,18 @@ module Dry
         private
 
         def struct?(type)
-          type.is_a?(::Class) && type <= ::Dry::Struct
+          (type.is_a?(::Class) && type <= ::Dry::Struct) ||
+            (type.is_a?(::Dry::Types::Constructor) && type.primitive <= ::Dry::Struct)
+        end
+
+        def extract_struct_class(type)
+          if type.is_a?(::Class) && type <= ::Dry::Struct
+            type
+          elsif type.is_a?(::Dry::Types::Constructor) && type.primitive <= ::Dry::Struct
+            type.primitive
+          else
+            type
+          end
         end
       })
     end

--- a/spec/integration/extensions/json_schema/struct_constructor_spec.rb
+++ b/spec/integration/extensions/json_schema/struct_constructor_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "dry-struct"
+require "dry/schema/extensions/struct"
+
+RSpec.describe "JSON Schema with struct constructors" do
+  before do
+    Dry::Schema.load_extensions(:json_schema)
+  end
+
+  let(:address_struct) do
+    Class.new(Dry::Struct) do
+      attribute :street, Types::Strict::String.optional.default(nil)
+      attribute :city, Types::Strict::String
+    end
+  end
+
+  context "with direct struct" do
+    let(:schema) do
+      struct = address_struct
+      Dry::Schema.Params do
+        required(:address).value(struct)
+      end
+    end
+
+    it "generates JSON schema with struct properties" do
+      json_schema = schema.json_schema
+
+      expect(json_schema[:properties][:address]).to include(
+        type: "object",
+        properties: {
+          street: { anyOf: [{ type: "null" }, { type: "string" }] },
+          city: { type: "string" }
+        },
+        required: ["street", "city"]
+      )
+    end
+  end
+
+  context "with struct constructor" do
+    let(:schema) do
+      struct = address_struct
+      Dry::Schema.Params do
+        required(:address).value(struct.constructor(&:itself))
+      end
+    end
+
+    it "generates JSON schema with struct properties" do
+      json_schema = schema.json_schema
+
+      expect(json_schema[:properties][:address]).to include(
+        type: "object",
+        properties: {
+          street: { anyOf: [{ type: "null" }, { type: "string" }] },
+          city: { type: "string" }
+        },
+        required: ["street", "city"]
+      )
+    end
+  end
+
+  context "comparing direct struct vs constructor" do
+    let(:direct_schema) do
+      struct = address_struct
+      Dry::Schema.Params do
+        required(:address).value(struct)
+      end
+    end
+
+    let(:constructor_schema) do
+      struct = address_struct
+      Dry::Schema.Params do
+        required(:address).value(struct.constructor(&:itself))
+      end
+    end
+
+    it "generates identical JSON schemas" do
+      expect(direct_schema.json_schema).to eq(constructor_schema.json_schema)
+    end
+  end
+end


### PR DESCRIPTION
## Fix JSON schema generation for Dry::Struct wrapped in constructors

Fixes #495

### Problem

When generating JSON schema for a schema containing a `Dry::Struct` wrapped in a constructor (e.g., 
 `Address.constructor(&:itself)`), all struct properties were omitted from the generated schema, returning only 
 `{type: "object"}` instead of the full schema with properties.

### Root Cause

The struct? method in the struct extension only recognized direct struct classes (Class instances that inherit 
 from `Dry::Struct`), but not struct constructors (`Dry::Types::Constructor` instances wrapping structs).

### Solution

• Extended `struct?` method to also recognize `Dry::Types::Constructor` instances that wrap struct classes
• Added `extract_struct_class` method to extract the underlying struct class from both direct structs and 
 constructors
• Modified the macro processing to use the extracted struct class for schema compilation

### Changes

• `lib/dry/schema/extensions/struct.rb`: Enhanced struct detection and extraction logic
• `spec/integration/extensions/json_schema/struct_constructor_spec.rb`: Comprehensive test coverage
• `CHANGELOG.md`: Document the fix

### Before/After

```ruby
# Before: Missing struct properties
Dry::Schema.Params do 
  required(:address).value(Address.constructor(&:itself)) 
end.json_schema
# => {:properties=>{:address=>{:type=>"object"}}} # No properties

# After: Full struct schema included  
Dry::Schema.Params do 
  required(:address).value(Address.constructor(&:itself)) 
end.json_schema
# => {:properties=>{:address=>{:type=>"object", :properties=>{:street=>{...}}}}} # Properties included
```

### Testing

• Tests direct struct usage (still works)
• Tests struct constructor usage (now works)
• Verifies both generate schemas with proper struct properties