### PR TITLE
FIX support for nested arrays with `config.validate_keys = true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 - Support for intersection types (created with `&` operator) in schema definitions (fixes #494) (@baweaver)
 - JSON schema generation now correctly uses `minItems`/`maxItems` for array size predicates instead of `minLength`/`maxLength` (fixes #481) (@baweaver)
 - Show correct index in errors when validating unexpected keys in arrays (via #510) (@katafrakt)
-
+- Fix support for nested arrays when validating unexpected keys (via #508) (@misdoro)
 
 ## [1.14.1] - 2025-03-03
 

--- a/docsite/source/nested-data.html.md
+++ b/docsite/source/nested-data.html.md
@@ -163,3 +163,25 @@ end
 schema.call(tags: nil).success? # true
 schema.call(tags: [{ name: 'Alice' }, { name: 'Bob' }]).success? # true
 ```
+
+### Nested Array of Arrays
+
+To define a matrix-like structure (an array of arrays), nest `value(:array)` macros:
+
+```ruby
+schema = Dry::Schema.Params do
+  config.validate_keys = true
+  required(:matrix).value(:array).each do
+    value(:array).each do
+      value(:integer, gteq?: 0)
+    end
+  end
+end
+
+errors = schema.call(matrix: [[1, 2, 3], [4, -5, 6]]).errors
+
+puts errors.to_h.inspect
+
+# => {:matrix=>{1=>{1=>["must be greater than or equal to 0"]}}}
+```
+


### PR DESCRIPTION
Before this change, it was impossible to validate schema for nested arrays of strings or hashes in params, when `config.validate_keys = true` was set. 

**Before:**
```ruby
schema = Dry::Schema.Params do
  config.validate_keys = true
  required(:matrix).value(:array, size?: 2).each do
    value(:array, size?: 3).each do
      value(:string, size?: 1)
    end
  end
end

errors = schema.call(matrix: [["a", "b", "c"], ["d", "ee", "f"]]).errors

puts errors.to_h.inspect
```
would fail validation saying:
```ruby
{matrix: {0 => {a: ["is not allowed"], b: ["is not allowed"], c: ["is not allowed"]}, 1 => {d: ["is not allowed"], ee: ["is not allowed"], f: ["is not allowed"]}}}
```

**After**

a correct validation error for the string length is reported
```ruby
{:matrix=>{1=>{1=>["length must be 1"]}}}
```