### PR TITLE
Add support for JSON Schema "const"

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -37,6 +37,7 @@ module Dry
           true?: {},
           false?: {},
           included_in?: {enum: ->(v, _) { v.to_a }},
+          eql?: {const: IDENTITY},
           filled?: EMPTY_HASH,
           uri?: {format: "uri"},
           uuid_v1?: {

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -305,6 +305,30 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
     end
   end
 
+  context "when using const" do
+    include_examples "metaschema validation"
+
+    subject(:schema) do
+      Dry::Schema.JSON do
+        required(:version).value(:integer, eql?: 1)
+      end
+    end
+
+    it "returns the correct json schema" do
+      expect(schema.json_schema).to eql(
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        type: "object",
+        properties: {
+          version: {
+            type: "integer",
+            const: 1
+          }
+        },
+        required: %w[version]
+      )
+    end
+  end
+
   describe "inferring types" do
     {
       array: {type: "array"},


### PR DESCRIPTION
Fixes #513 

According [to the specs][1], you don't need to include the `type` key, however it's not invalid and including it makes implementing this much easier.

[1]: https://json-schema.org/understanding-json-schema/reference/const