### PR TITLE
Fix bug with JSON Schema output for arrays with union items

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -133,13 +133,19 @@ module Dry
 
         # @api private
         def visit_or(node, opts = EMPTY_HASH)
+          any_of = []
           node.each do |child|
             c = self.class.new(loose: loose?)
             c.keys.update(subschema: {})
-            c.visit(child, opts.merge(key: :subschema))
-
-            any_of = (keys[opts[:key]][:anyOf] ||= [])
+            c.visit(child, opts.except(:member).merge(key: :subschema))
             any_of << c.keys[:subschema]
+          end
+
+          target = keys[opts[:key]]
+          if target[:type]&.include?("array")
+            target[:items] = {anyOf: any_of}
+          else
+            target[:anyOf] = any_of
           end
         end
 


### PR DESCRIPTION
Fixes #515 

When an array item contains schema combinations (via something like unions) the JSON Schema output is incorrect, producing the equivalent to

    Array.of(Schema1) | Array.of(Schema2)

rather than the correct

    Array.of(Schema1 | Schema2)

I'm not entirely sure if this is the best way to fix it, as I'm fairly unfamiliar with the codebase, but it seems a simple enough change and keeps the tests passing. Happy to be shown the correct way!