### PR TITLE
Propagate dry-types meta and defaults into json_schema output; add .documentation macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- `json_schema` extension now propagates `:json_schema` metadata from `dry-types` `.meta(json_schema: {...})` into JSON Schema property output (@bogdan)
+- `json_schema` extension now auto-populates `default` in JSON Schema output from dry-types default values (@bogdan)
+- Added `.documentation(title:, description:, examples:, example:, deprecated:)` macro method for attaching JSON Schema annotation metadata inline when using the `json_schema` extension (@bogdan)
+
 ### Changed
 
 ### Deprecated

--- a/lib/dry/schema/extensions/json_schema.rb
+++ b/lib/dry/schema/extensions/json_schema.rb
@@ -17,13 +17,39 @@ module Dry
         #
         # @api public
         def json_schema(loose: false)
-          compiler = SchemaCompiler.new(root: true, loose: loose)
+          compiler = SchemaCompiler.new(root: true, loose: loose, type_schema: type_schema)
           compiler.call(to_ast)
           compiler.to_hash
+        end
+      end
+
+      module MacroMethods
+        # Attach JSON Schema documentation metadata to this key
+        #
+        # @example
+        #   required(:email).filled(:string).documentation(description: "User email", example: "a@b.com")
+        #
+        # @return [self]
+        #
+        # @api public
+        def documentation(title: nil, description: nil, examples: nil, example: nil, deprecated: false)
+          if schema_dsl.types[name].is_a?(Dry::Types::AnyClass)
+            raise ::Dry::Schema::InvalidSchemaError,
+              ".documentation must be called after a type is set (e.g. after .filled or .value)"
+          end
+          attrs = {
+            title: title, description: description,
+            examples: examples, example: example,
+            deprecated: deprecated || nil
+          }.compact
+          current = schema_dsl.types[name].meta[:json_schema] || {}
+          schema_dsl.types[name] = schema_dsl.types[name].meta(json_schema: current.merge(attrs))
+          self
         end
       end
     end
 
     Processor.include(JSONSchema::SchemaMethods)
+    Macros::Core.include(JSONSchema::MacroMethods)
   end
 end

--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -186,7 +186,7 @@ module Dry
               type_meta = key_type.meta[:json_schema]
               keys[name].merge!(type_meta) if type_meta
               default = extract_default(key_type)
-              keys[name][:default] = default unless default.equal?(Dry::Core::Constants::Undefined)
+              keys[name][:default] = default unless default.equal?(Undefined)
             rescue KeyError
               # key not found in type_schema, skip
             end
@@ -317,11 +317,44 @@ module Dry
         def extract_default(type)
           t = type
           while t
-            return t.value if t.is_a?(Dry::Types::Default)
+            return to_json_default(t.value) if t.is_a?(Dry::Types::Default)
 
             t = t.respond_to?(:type) ? t.type : nil
           end
-          Dry::Core::Constants::Undefined
+          Undefined
+        end
+
+        def to_json_default(value)
+          case value
+          when ::String, ::Integer, ::Float, ::TrueClass, ::FalseClass, ::NilClass
+            value
+          when ::Symbol
+            value.to_s
+          when ::BigDecimal
+            value.to_f
+          when ::Date, ::Time
+            value.iso8601
+          when ::Array
+            items = value.map { |v| to_json_default(v) }
+            return Undefined if items.any? { |v| v.equal?(Undefined) }
+
+            items
+          when ::Hash
+            result = {}
+            value.each do |k, v|
+              converted_key = to_json_default(k)
+              converted_val = to_json_default(v)
+              if converted_key.equal?(Undefined) ||
+                  converted_val.equal?(Undefined)
+                return Undefined
+              end
+
+              result[converted_key] = converted_val
+            end
+            result
+          else
+            Undefined
+          end
         end
 
         def child_type_schema(key, member)

--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -184,7 +184,12 @@ module Dry
             begin
               key_type = @type_schema.key(name)
               type_meta = key_type.meta[:json_schema]
-              keys[name].merge!(type_meta) if type_meta
+              if type_meta
+                sanitized = type_meta.dup
+                sanitized[:example] = serialize_json_value(sanitized[:example]) if sanitized.key?(:example)
+                sanitized[:examples] = sanitized[:examples]&.map { |v| serialize_json_value(v) } if sanitized.key?(:examples)
+                keys[name].merge!(sanitized)
+              end
               default = extract_default(key_type)
               keys[name][:default] = default unless default.equal?(Undefined)
             rescue KeyError
@@ -317,14 +322,14 @@ module Dry
         def extract_default(type)
           t = type
           while t
-            return to_json_default(t.value) if t.is_a?(Dry::Types::Default)
+            return serialize_json_value(t.value) if t.is_a?(Dry::Types::Default)
 
             t = t.respond_to?(:type) ? t.type : nil
           end
           Undefined
         end
 
-        def to_json_default(value)
+        def serialize_json_value(value)
           case value
           when ::String, ::Integer, ::Float, ::TrueClass, ::FalseClass, ::NilClass
             value
@@ -335,15 +340,15 @@ module Dry
           when ::Date, ::Time
             value.iso8601
           when ::Array
-            items = value.map { |v| to_json_default(v) }
+            items = value.map { |v| serialize_json_value(v) }
             return Undefined if items.any? { |v| v.equal?(Undefined) }
 
             items
           when ::Hash
             result = {}
             value.each do |k, v|
-              converted_key = to_json_default(k)
-              converted_val = to_json_default(v)
+              converted_key = serialize_json_value(k)
+              converted_val = serialize_json_value(v)
               if converted_key.equal?(Undefined) ||
                   converted_val.equal?(Undefined)
                 return Undefined

--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -76,11 +76,12 @@ module Dry
         attr_reader :keys, :required
 
         # @api private
-        def initialize(root: false, loose: false)
+        def initialize(root: false, loose: false, type_schema: nil)
           @keys = EMPTY_HASH.dup
           @required = Set.new
           @root = root
           @loose = loose
+          @type_schema = type_schema
         end
 
         # @api private
@@ -106,7 +107,12 @@ module Dry
 
         # @api private
         def visit_set(node, opts = EMPTY_HASH)
-          target = (key = opts[:key]) ? self.class.new(loose: loose?) : self
+          if (key = opts[:key])
+            nested_ts = child_type_schema(key, opts[:member])
+            target = self.class.new(loose: loose?, type_schema: nested_ts)
+          else
+            target = self
+          end
 
           node.map { |child| target.visit(child, opts.except(:member)) }
 
@@ -173,6 +179,18 @@ module Dry
           end
 
           visit(rest, opts.merge(key: name))
+
+          if @type_schema
+            begin
+              key_type = @type_schema.key(name)
+              type_meta = key_type.meta[:json_schema]
+              keys[name].merge!(type_meta) if type_meta
+              default = extract_default(key_type)
+              keys[name][:default] = default unless default.equal?(Dry::Core::Constants::Undefined)
+            rescue KeyError
+              # key not found in type_schema, skip
+            end
+          end
         end
 
         # @api private
@@ -294,6 +312,29 @@ module Dry
         # @api private
         def loose?
           @loose
+        end
+
+        def extract_default(type)
+          t = type
+          while t
+            return t.value if t.is_a?(Dry::Types::Default)
+
+            t = t.respond_to?(:type) ? t.type : nil
+          end
+          Dry::Core::Constants::Undefined
+        end
+
+        def child_type_schema(key, member)
+          return unless @type_schema.respond_to?(:key)
+
+          key_type = @type_schema.key(key).type
+          return key_type unless member
+
+          # For arrays: unwrap Lax -> Array::Member -> member (the element hash schema)
+          inner = key_type.respond_to?(:type) ? key_type.type : key_type
+          inner.respond_to?(:member) ? inner.member : nil
+        rescue KeyError
+          nil
         end
 
         def raise_unknown_conversion_error!(type, name)

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -532,4 +532,164 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
       end
     end
   end
+
+  context "when a type has json_schema meta" do
+    let(:schema) do
+      Dry::Schema.JSON do
+        required(:email).filled(
+          Dry::Types["string"].meta(json_schema: {description: "Email address", example: "a@b.com"})
+        )
+        optional(:age).filled(
+          Dry::Types["integer"].meta(json_schema: {description: "Age in years"})
+        )
+        required(:name).filled(:string)
+      end
+    end
+
+    include_examples "metaschema validation"
+
+    it "merges json_schema meta into property output" do
+      result = schema.json_schema
+      expect(result[:properties][:email]).to include(description: "Email address", example: "a@b.com")
+      expect(result[:properties][:age]).to include(description: "Age in years")
+      expect(result[:properties][:name]).to eq({type: "string", minLength: 1})
+    end
+
+    context "with nested hash" do
+      let(:schema) do
+        Dry::Schema.JSON do
+          required(:address).hash do
+            required(:street).filled(
+              Dry::Types["string"].meta(json_schema: {description: "Street name"})
+            )
+          end
+        end
+      end
+
+      include_examples "metaschema validation"
+
+      it "merges json_schema meta into nested property output" do
+        result = schema.json_schema
+        expect(result[:properties][:address][:properties][:street]).to include(description: "Street name")
+      end
+    end
+
+    context "with array of hashes" do
+      let(:schema) do
+        Dry::Schema.JSON do
+          required(:roles).array(:hash) do
+            required(:name).filled(
+              Dry::Types["string"].meta(json_schema: {description: "Role name"})
+            )
+          end
+        end
+      end
+
+      include_examples "metaschema validation"
+
+      it "merges json_schema meta into array member property output" do
+        result = schema.json_schema
+        expect(result[:properties][:roles][:items][:properties][:name]).to include(description: "Role name")
+      end
+    end
+  end
+
+  context "when a type has a dry-types default value" do
+    it "auto-populates default in the json schema output" do
+      schema = Dry::Schema.JSON do
+        required(:role).value(Dry::Types["string"].default("user".freeze))
+        required(:count).value(Dry::Types["integer"].default(0))
+        required(:name).filled(:string)
+      end
+
+      result = schema.json_schema
+      expect(result[:properties][:role]).to include(default: "user")
+      expect(result[:properties][:count]).to include(default: 0)
+      expect(result[:properties][:name]).not_to have_key(:default)
+    end
+  end
+
+  context "when using .documentation chaining" do
+    let(:schema) do
+      Dry::Schema.JSON do
+        required(:email).filled(:string).documentation(description: "User email", example: "a@b.com")
+        optional(:age).filled(:integer).documentation(description: "Age in years")
+        required(:name).filled(:string)
+      end
+    end
+
+    include_examples "metaschema validation"
+
+    it "merges documentation attrs into property output" do
+      result = schema.json_schema
+      expect(result[:properties][:email]).to include(description: "User email", example: "a@b.com")
+      expect(result[:properties][:age]).to include(description: "Age in years")
+      expect(result[:properties][:name]).to eq({type: "string", minLength: 1})
+    end
+
+    it "works with value (not filled)" do
+      schema = Dry::Schema.JSON do
+        required(:code).value(:string).documentation(description: "Access code")
+      end
+      expect(schema.json_schema[:properties][:code]).to include(description: "Access code")
+    end
+
+    it "works inside nested hash" do
+      schema = Dry::Schema.JSON do
+        required(:address).hash do
+          required(:street).filled(:string).documentation(description: "Street name")
+        end
+      end
+      expect(schema.json_schema[:properties][:address][:properties][:street]).to include(description: "Street name")
+    end
+
+    it "works on a hash key itself" do
+      schema = Dry::Schema.JSON do
+        required(:address).hash do
+          required(:street).filled(:string)
+        end.documentation(description: "Mailing address")
+      end
+      expect(schema.json_schema[:properties][:address]).to include(type: "object", description: "Mailing address")
+    end
+
+    it "raises if called before a type is set" do
+      expect {
+        Dry::Schema.JSON { required(:email).documentation(description: "bad").filled(:string) }
+      }.to raise_error(Dry::Schema::InvalidSchemaError, /after a type is set/)
+    end
+
+    it "rejects :default (use dry-schema native default instead)" do
+      expect {
+        Dry::Schema.JSON do
+          required(:foo).filled(:string).documentation(default: "bar")
+        end
+      }.to raise_error(ArgumentError, /unknown keyword.*default/)
+    end
+
+    it "passes all supported keys through to the output" do
+      doc = {
+        title: "Foo",
+        description: "A foo",
+        examples: ["bar"],
+        example: "bar",
+        deprecated: true,
+      }
+      schema = Dry::Schema.JSON do
+        required(:foo).filled(:string).documentation(**doc)
+      end
+      expect(schema.json_schema[:properties][:foo]).to include(
+        type: "string",
+        minLength: 1,
+        **doc,
+      )
+    end
+
+    it "omits deprecated when false" do
+      props = Dry::Schema.JSON do
+        required(:foo).filled(:string).documentation(deprecated: false)
+      end.json_schema[:properties][:foo]
+
+      expect(props).not_to have_key(:deprecated)
+    end
+  end
 end

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -754,5 +754,19 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
 
       expect(props).not_to have_key(:deprecated)
     end
+
+    it "serializes example: Date to iso8601 string" do
+      schema = Dry::Schema.JSON do
+        required(:foo).filled(:date).documentation(example: ::Date.new(2024, 1, 15))
+      end
+      expect(schema.json_schema[:properties][:foo][:example]).to eq("2024-01-15")
+    end
+
+    it "serializes examples: [Date] elements to iso8601 strings" do
+      schema = Dry::Schema.JSON do
+        required(:foo).filled(:date).documentation(examples: [::Date.new(2024, 1, 1), ::Date.new(2024, 6, 30)])
+      end
+      expect(schema.json_schema[:properties][:foo][:examples]).to eq(["2024-01-01", "2024-06-30"])
+    end
   end
 end

--- a/spec/extensions/json_schema/schema_spec.rb
+++ b/spec/extensions/json_schema/schema_spec.rb
@@ -595,7 +595,7 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
   end
 
   context "when a type has a dry-types default value" do
-    it "auto-populates default in the json schema output" do
+    it "serializes primitive defaults" do
       schema = Dry::Schema.JSON do
         required(:role).value(Dry::Types["string"].default("user".freeze))
         required(:count).value(Dry::Types["integer"].default(0))
@@ -606,6 +606,69 @@ RSpec.describe Dry::Schema::JSON, "#json_schema" do
       expect(result[:properties][:role]).to include(default: "user")
       expect(result[:properties][:count]).to include(default: 0)
       expect(result[:properties][:name]).not_to have_key(:default)
+    end
+
+    it "serializes Date default as ISO 8601 string" do
+      schema = Dry::Schema.JSON do
+        required(:on).value(Dry::Types["date"].default(Date.new(2026, 6, 28).freeze))
+      end
+      expect(schema.json_schema[:properties][:on]).to include(default: "2026-06-28")
+    end
+
+    it "serializes Time default as ISO 8601 string" do
+      schema = Dry::Schema.JSON do
+        required(:at).value(Dry::Types["time"].default(Time.utc(2026, 6, 28, 10, 0, 0).freeze))
+      end
+      expect(schema.json_schema[:properties][:at]).to include(default: "2026-06-28T10:00:00Z")
+    end
+
+    it "serializes Array default recursively" do
+      schema = Dry::Schema.JSON do
+        required(:tags).value(Dry::Types["array"].default(["ruby", "rails"].freeze))
+      end
+      expect(schema.json_schema[:properties][:tags]).to include(default: ["ruby", "rails"])
+    end
+
+    it "serializes Hash default with string keys" do
+      schema = Dry::Schema.JSON do
+        required(:meta).value(Dry::Types["hash"].default({"env" => "prod"}.freeze))
+      end
+      expect(schema.json_schema[:properties][:meta]).to include(default: {"env" => "prod"})
+    end
+
+    it "serializes Symbol default as string" do
+      schema = Dry::Schema.JSON do
+        required(:tags).value(Dry::Types["array"].default([:foo, :bar].freeze))
+      end
+      expect(schema.json_schema[:properties][:tags]).to include(default: ["foo", "bar"])
+    end
+
+    it "serializes BigDecimal default as float" do
+      schema = Dry::Schema.JSON do
+        required(:amount).value(Dry::Types["decimal"].default(BigDecimal("1000")))
+      end
+      expect(schema.json_schema[:properties][:amount]).to include(default: 1000.0)
+    end
+
+    it "omits default when a hash value is not JSON-serializable" do
+      schema = Dry::Schema.JSON do
+        required(:thing).value(Dry::Types["any"].default(Object.new.freeze))
+      end
+      expect(schema.json_schema[:properties][:thing]).not_to have_key(:default)
+    end
+
+    it "converts symbol hash keys to strings" do
+      schema = Dry::Schema.JSON do
+        required(:meta).value(Dry::Types["hash"].default({env: "prod", count: 1}.freeze))
+      end
+      expect(schema.json_schema[:properties][:meta]).to include(default: {"env" => "prod", "count" => 1})
+    end
+
+    it "omits default when a hash key is not JSON-serializable" do
+      schema = Dry::Schema.JSON do
+        required(:meta).value(Dry::Types["hash"].default({Object.new => "bad"}.freeze))
+      end
+      expect(schema.json_schema[:properties][:meta]).not_to have_key(:default)
     end
   end
 


### PR DESCRIPTION
## Background

This PR addresses two recurring forum requests:
- [dry-schema key annotations](https://discourse.dry-rb.org/t/dry-schema-key-annotations/1544)
- [Getting dry-types metadata into dry-schema's JSON Schema output](https://discourse.dry-rb.org/t/getting-dry-types-metadata-into-dry-schemas-json-schema-output/1439)

## Summary

The `json_schema` extension currently has no way to attach descriptive metadata (description, title, examples, etc.) to individual fields without defining a separate named `dry-types` constant with `.meta(json_schema: {...})`. This PR makes that metadata first-class in two ways.

### 1. Propagate `dry-types` `.meta(json_schema: {...})` into JSON Schema output

When a type has `:json_schema` metadata attached via dry-types `.meta(...)`, it is now merged into the corresponding property in the JSON Schema output:

```ruby
Email = Dry::Types["string"].meta(json_schema: { description: "User email" })

schema = Dry::Schema.JSON do
  required(:email).filled(Email)
end

schema.json_schema
# => { ..., properties: { email: { type: "string", minLength: 1, description: "User email" } } }
```

This works for flat keys, nested hashes, and array-of-hash members. The `SchemaCompiler` receives the processor's `type_schema` and propagates it into child compilers for nested schemas.

### 2. Auto-populate `default` from dry-types default values

If a type has a runtime default set via dry-types, it is automatically reflected as `default` in the JSON Schema output by walking the type chain for a `Dry::Types::Default` node. This keeps the JSON Schema annotation in sync with the actual runtime behaviour without any extra effort from the user.

```ruby
required(:role).value(Dry::Types["string"].default("user".freeze))
# => { type: "string", default: "user" }
```

### 3. New `.documentation(...)` macro method

A `.documentation` method is added to `Macros::Core` by the `json_schema` extension, enabling inline annotation via method chaining without needing a named type constant:

```ruby
Dry::Schema.JSON do
  required(:email).filled(:string).documentation(description: "User email", example: "a@b.com")
  optional(:age).filled(:integer).documentation(description: "Age in years", deprecated: true)
  required(:address).hash { required(:street).filled(:string) }.documentation(title: "Address")
end
```

Accepted keys are the JSON Schema annotation keywords: `title`, `description`, `examples`, `example`, `deprecated`. The `deprecated` key defaults to `false` and is omitted from the output unless `true`. Passing `default:` raises `ArgumentError` — use dry-schema's native default instead, which is picked up automatically (see above). Calling `.documentation` before `.filled`/`.value` raises `Dry::Schema::InvalidSchemaError`.

## Test plan

- All existing `json_schema` extension specs pass unchanged
- New specs cover: meta propagation for flat/nested/array schemas, auto-populated defaults, all `.documentation` keys and their output, wrong-order guard, `deprecated` true/false behaviour, and hash key annotation